### PR TITLE
Optimized sorting on CPU path for LOD and culling

### DIFF
--- a/regen/gl-types/queries/elapsed-time.h
+++ b/regen/gl-types/queries/elapsed-time.h
@@ -22,7 +22,12 @@ namespace regen {
 	 */
 	class ElapsedTimeDebugger {
 	public:
-		ElapsedTimeDebugger(std::string_view sessionName, uint32_t numFrames);
+		enum Mode {
+			CPU_ONLY,
+			CPU_AND_GPU
+		};
+
+		ElapsedTimeDebugger(std::string_view sessionName, uint32_t numFrames, Mode mode = CPU_AND_GPU);
 
 		~ElapsedTimeDebugger();
 
@@ -35,6 +40,7 @@ namespace regen {
 	protected:
 		const std::string sessionName_;
 		const uint32_t numFrames_;
+		const Mode mode_;
 		ref_ptr<TimeElapsedQuery> query_;
 		std::chrono::time_point<std::chrono::system_clock> cpuLastTime_;
 		// CPU time in milliseconds

--- a/regen/shapes/bounding-shape.cpp
+++ b/regen/shapes/bounding-shape.cpp
@@ -136,7 +136,7 @@ bool BoundingShape::hasIntersectionWith(const BoundingShape &other) const {
 				case BoundingShapeType::BOX:
 					return ((const BoundingSphere &) *this).hasIntersectionWithShape((const BoundingBox &) other);
 				case BoundingShapeType::FRUSTUM:
-					return ((const Frustum &) other).hasIntersectionWithFrustum((const BoundingSphere &) *this);
+					return ((const Frustum &) other).hasIntersectionWithSphere((const BoundingSphere &) *this);
 			}
 
 		case BoundingShapeType::BOX:
@@ -146,15 +146,15 @@ bool BoundingShape::hasIntersectionWith(const BoundingShape &other) const {
 				case BoundingShapeType::BOX:
 					return ((const BoundingBox &) *this).hasIntersectionWithBox((const BoundingBox &) other);
 				case BoundingShapeType::FRUSTUM:
-					return ((const Frustum &) other).hasIntersectionWithFrustum((const BoundingBox &) *this);
+					return ((const Frustum &) other).hasIntersectionWithBox((const BoundingBox &) *this);
 			}
 
 		case BoundingShapeType::FRUSTUM:
 			switch (other.shapeType()) {
 				case BoundingShapeType::SPHERE:
-					return ((const Frustum *) this)->hasIntersectionWithFrustum((const BoundingSphere &) other);
+					return ((const Frustum *) this)->hasIntersectionWithSphere((const BoundingSphere &) other);
 				case BoundingShapeType::BOX:
-					return ((const Frustum *) this)->hasIntersectionWithFrustum((const BoundingBox &) other);
+					return ((const Frustum *) this)->hasIntersectionWithBox((const BoundingBox &) other);
 				case BoundingShapeType::FRUSTUM:
 					return ((const Frustum *) this)->hasIntersectionWithFrustum((const Frustum &) other);
 			}

--- a/regen/shapes/frustum.cpp
+++ b/regen/shapes/frustum.cpp
@@ -226,16 +226,16 @@ bool Frustum::hasIntersectionWithBox(const Vec3f &center, const Vec3f *point) co
 	return hasIntersection_OBB_(planes, center, point);
 }
 
-bool Frustum::hasIntersectionWithFrustum(const BoundingSphere &sphere) const {
-	return hasIntersectionWithSphere(sphere.translation(), sphere.radius());
-}
-
-bool Frustum::hasIntersectionWithFrustum(const BoundingBox &box) const {
+bool Frustum::hasIntersectionWithBox(const BoundingBox &box) const {
 	if (box.isAABB()) {
 		return hasIntersection_AABB_(planes, box);
 	} else {
 		return hasIntersection_OBB_(planes, box);
 	}
+}
+
+bool Frustum::hasIntersectionWithSphere(const BoundingSphere &sphere) const {
+	return hasIntersectionWithSphere(sphere.translation(), sphere.radius());
 }
 
 bool Frustum::hasIntersectionWithFrustum(const Frustum &other) const {

--- a/regen/shapes/frustum.h
+++ b/regen/shapes/frustum.h
@@ -66,14 +66,14 @@ namespace regen {
 		bool hasIntersectionWithBox(const Vec3f &center, const Vec3f *points) const;
 
 		/**
-		 * @return true if the sphere intersects with this frustum.
-		 */
-		bool hasIntersectionWithFrustum(const BoundingSphere &sphere) const;
-
-		/**
 		 * @return true if the box intersects with this frustum.
 		 */
-		bool hasIntersectionWithFrustum(const BoundingBox &box) const;
+		bool hasIntersectionWithBox(const BoundingBox &box) const;
+
+		/**
+		 * @return true if the sphere intersects with this frustum.
+		 */
+		bool hasIntersectionWithSphere(const BoundingSphere &sphere) const;
 
 		/**
 		 * @return true if the frustum intersects with this frustum.

--- a/regen/shapes/indexed-shape.cpp
+++ b/regen/shapes/indexed-shape.cpp
@@ -16,17 +16,10 @@ IndexedShape::IndexedShape(
 	}
 
 	const uint32_t L = camera_->numLayer();
-	const uint32_t K = numLODs_;
-	const uint32_t I = shape->numInstances();
-	const uint32_t B = L * K;
+	const uint32_t B = L * numLODs_;
 	tmp_binCounts_.resize(B, 0);
 	tmp_binBase_.resize(B, 0);
 	tmp_layerVisibility_.resize(L, false);
-	tmp_layerShapes_.reserve(L * I);
-	tmp_layerInstances_.reserve(L * I);
-	tmp_sortKeys_32_.reserve(L * I);
-	tmp_sortKeys_64_.reserve(L * I);
-
 	visible_.resize(L, true);
 }
 

--- a/regen/shapes/indexed-shape.cpp
+++ b/regen/shapes/indexed-shape.cpp
@@ -24,8 +24,8 @@ IndexedShape::IndexedShape(
 	tmp_layerVisibility_.resize(L, false);
 	tmp_layerShapes_.reserve(L * I);
 	tmp_layerInstances_.reserve(L * I);
-	tmp_layerIndices_.reserve(L * I);
-	tmp_layerDistances_.reserve(L * I);
+	tmp_sortKeys_32_.reserve(L * I);
+	tmp_sortKeys_64_.reserve(L * I);
 
 	visible_.resize(L, true);
 }

--- a/regen/shapes/indexed-shape.h
+++ b/regen/shapes/indexed-shape.h
@@ -132,13 +132,11 @@ namespace regen {
 		// per (lod, layer) data flattened as lod * numLayers + layer
 		std::vector<uint32_t> tmp_binCounts_;   // size = numLODs * numLayers
 		std::vector<uint32_t> tmp_binBase_;     // size = numLODs * numLayers
-
-		// These vectors are filled up during traversal and sorted
-		// according to the instance distance to the camera.
-		std::vector<uint32_t> tmp_layerShapes_; // size = numLayers * numInstances
-		std::vector<uint32_t> tmp_layerInstances_; // size = numLayers * numInstances
-		std::vector<uint64_t> tmp_sortKeys_64_; // size = numLayers * numInstances
-		std::vector<uint32_t> tmp_sortKeys_32_; // size = numLayers * num
+		uint32_t tmp_totalCount_ = 0;
+		// The index of this shape in the camera's shape list.
+		// Here we limit to max 65536 shapes per camera for sorting key packing,
+		// however instances are not counted as individual shapes.
+		uint16_t shapeIdx_ = 0;
 
 		struct MappedData {
 			explicit MappedData(

--- a/regen/shapes/indexed-shape.h
+++ b/regen/shapes/indexed-shape.h
@@ -137,8 +137,8 @@ namespace regen {
 		// according to the instance distance to the camera.
 		std::vector<uint32_t> tmp_layerShapes_; // size = numLayers * numInstances
 		std::vector<uint32_t> tmp_layerInstances_; // size = numLayers * numInstances
-		std::vector<uint32_t> tmp_layerIndices_; // size = numLayers * numInstances
-		std::vector<float> tmp_layerDistances_; // size = numLayers * numInstances
+		std::vector<uint64_t> tmp_sortKeys_64_; // size = numLayers * numInstances
+		std::vector<uint32_t> tmp_sortKeys_32_; // size = numLayers * num
 
 		struct MappedData {
 			explicit MappedData(

--- a/regen/shapes/lod-state.cpp
+++ b/regen/shapes/lod-state.cpp
@@ -511,7 +511,7 @@ void LODState::createComputeShader() {
 	}
 
 	{ // radix sort
-		radixSort_ = ref_ptr<RadixSort>::alloc(cullShape_->numInstances(), camera_->numLayer());
+		radixSort_ = ref_ptr<RadixSort_GPU>::alloc(cullShape_->numInstances(), camera_->numLayer());
 		radixSort_->setUseCompaction(useCompaction_);
 		radixSort_->setOutputBuffer(instanceBuffer_, false);
 		radixSort_->setRadixBits(RADIX_BITS_PER_PASS);

--- a/regen/shapes/lod-state.h
+++ b/regen/shapes/lod-state.h
@@ -108,7 +108,7 @@ namespace regen {
 		// GPU LOD update
 		ref_ptr<ComputePass> cullPass_;
 		ref_ptr<ComputePass> copyIndirect_;
-		ref_ptr<RadixSort> radixSort_;
+		ref_ptr<RadixSort_GPU> radixSort_;
 		// buffer for indirect draw calls, one per mesh part
 		// (parts have different index buffers, so we cannot use a single buffer for all parts)
 		std::vector<ref_ptr<SSBO>> indirectDrawBuffers_;

--- a/regen/shapes/quad-tree.cpp
+++ b/regen/shapes/quad-tree.cpp
@@ -7,7 +7,7 @@
 #include "regen/math/simd.h"
 
 //#define QUAD_TREE_DEBUG_TESTS
-#define QUAD_TREE_DEBUG_TIME
+//#define QUAD_TREE_DEBUG_TIME
 #define QUAD_TREE_EVER_GROWING
 #define QUAD_TREE_SQUARED
 //#define QUAD_TREE_DISABLE_SIMD

--- a/regen/shapes/spatial-index.cpp
+++ b/regen/shapes/spatial-index.cpp
@@ -190,7 +190,7 @@ static inline uint32_t getLODLevel(
 }
 
 inline uint16_t floatToHalf(float distance, SortMode sortMode) {
-	uint32_t x = *reinterpret_cast<uint32_t *>(&distance);
+	uint32_t x = std::bit_cast<uint32_t>(distance);
 	uint16_t q = ((x>>16)&0x8000) |                     // sign bit
 		   ((((x&0x7f800000)-0x38000000)>>13)&0x7c00) | // exponent bits
 		   	((x>>13)&0x03ff);                           // mantissa bits

--- a/regen/shapes/spatial-index.cpp
+++ b/regen/shapes/spatial-index.cpp
@@ -190,7 +190,7 @@ static inline uint32_t getLODLevel(
 }
 
 inline uint16_t floatToHalf(float distance, SortMode sortMode) {
-	uint32_t x = *((uint32_t*)&distance);
+	uint32_t x = *reinterpret_cast<uint32_t *>(&distance);
 	uint16_t q = ((x>>16)&0x8000) |                     // sign bit
 		   ((((x&0x7f800000)-0x38000000)>>13)&0x7c00) | // exponent bits
 		   	((x>>13)&0x03ff);                           // mantissa bits

--- a/regen/shapes/spatial-index.h
+++ b/regen/shapes/spatial-index.h
@@ -162,6 +162,15 @@ namespace regen {
 			std::unordered_map<std::string_view, ref_ptr<IndexedShape>> nameToShape_;
 			// flattened list of shapes for faster access
 			std::vector<IndexedShape*> indexShapes_;
+			// These vectors are filled up during traversal and sorted
+			// according to the instance distance to the camera.
+			std::vector<uint32_t> tmp_layerInstances_; // size = sum_{shape} numLayers * numInstances_{shape}
+			std::vector<uint32_t> tmp_layerShapes_; // size = sum_{shape} numLayers * numInstances_{shape}
+			std::vector<uint64_t> tmp_sortKeys_; // size = sum_{shape} numLayers * numInstances_{shape}
+			// total number of keys = sum_{shape} numLayers * numInstances_{shape}
+			uint32_t numKeys = 0;
+			// mark camera as dirty when shapes are added/removed
+			bool isDirty = false;
 			// how to sort instances by distance to camera
 			SortMode sortMode = SortMode::FRONT_TO_BACK;
 			Vec4i lodShift = Vec4i(0);
@@ -194,13 +203,14 @@ namespace regen {
 		// used internally when handling intersections
 		struct TraversalData {
 			SpatialIndex *index;
+			IndexCamera *indexCamera;
 			const Vec3f *camPos;
 			uint32_t layerIdx;
 		};
 
 		static void handleIntersection(const BoundingShape &b_shape, void *userData);
 
-		static void updateLOD_Major(IndexCamera &indexCamera, IndexedShape *indexShape);
+		static void updateLOD_Major(IndexCamera &indexCamera, IndexedShape *indexShape, uint32_t shapeBase);
 	};
 } // namespace
 

--- a/regen/shapes/spatial-index.h
+++ b/regen/shapes/spatial-index.h
@@ -6,6 +6,7 @@
 #include <regen/shapes/indexed-shape.h>
 #include <regen/camera/camera.h>
 #include "regen/utility/debug-interface.h"
+#include "regen/utility/radix-sort-cpu.h"
 #include <regen/scene/loading-context.h>
 
 namespace regen {
@@ -15,6 +16,8 @@ namespace regen {
 	class SpatialIndex : public Resource {
 	public:
 		static constexpr const char *TYPE_NAME = "SpatialIndex";
+		// Threshold for using standard sort (small arrays) vs radix sort (large arrays)
+		static constexpr uint32_t SMALL_ARRAY_SIZE = 256;
 
 		SpatialIndex();
 
@@ -173,6 +176,8 @@ namespace regen {
 			bool isDirty = false;
 			// how to sort instances by distance to camera
 			SortMode sortMode = SortMode::FRONT_TO_BACK;
+			// radix sort for sorting the instances
+			RadixSort_CPU_seq<uint32_t, uint64_t, 8> radixSort;
 			Vec4i lodShift = Vec4i(0);
 		};
 		std::unordered_map<std::string_view, ref_ptr<std::vector<ref_ptr<BoundingShape>>>> nameToShape_;

--- a/regen/simulation/boids-gpu.cpp
+++ b/regen/simulation/boids-gpu.cpp
@@ -160,7 +160,7 @@ void BoidsGPU::createResource() {
 	}
 	#endif
 	{
-		auto radixSort = ref_ptr<RadixSort>::alloc(numBoids_);
+		auto radixSort = ref_ptr<RadixSort_GPU>::alloc(numBoids_);
 		// note: with compaction enabled, there will be an additional "numVisibleKeys" field in the Key buffer,
 		//       that needs to be filled externally (one value per layer).
 		radixSort->setUseCompaction(false);
@@ -175,8 +175,8 @@ void BoidsGPU::createResource() {
 	{
 		auto updateState = ref_ptr<State>::alloc();
 		updateState->setInput(gridUBO_);
-		updateState->setInput(((RadixSort*)radixSort_.get())->keyBuffer());
-		updateState->setInput(((RadixSort*)radixSort_.get())->valueBuffer());
+		updateState->setInput(((RadixSort_GPU*)radixSort_.get())->keyBuffer());
+		updateState->setInput(((RadixSort_GPU*)radixSort_.get())->valueBuffer());
 		updateState->setInput(gridOffsetBuffer_);
 		updateState->setInput(u_numCells_);
 		gridResetPass_ = ref_ptr<ComputePass>::alloc("regen.animation.boid.grid.reset");
@@ -195,8 +195,8 @@ void BoidsGPU::createResource() {
 	{
 		auto updateState = ref_ptr<State>::alloc();
 		updateState->setInput(gridUBO_);
-		updateState->setInput(((RadixSort*)radixSort_.get())->keyBuffer());
-		updateState->setInput(((RadixSort*)radixSort_.get())->valueBuffer());
+		updateState->setInput(((RadixSort_GPU*)radixSort_.get())->keyBuffer());
+		updateState->setInput(((RadixSort_GPU*)radixSort_.get())->valueBuffer());
 		updateState->setInput(gridOffsetBuffer_);
 		#ifdef BOID_USE_SORTED_DATA
 		updateState->setInput(velBuffer_);
@@ -242,7 +242,7 @@ void BoidsGPU::createResource() {
 	simulationState_->setInput(gridUBO_);
 	simulationState_->setInput(velBuffer_);
 	simulationState_->setInput(gridOffsetBuffer_);
-	simulationState_->setInput(((RadixSort*)radixSort_.get())->valueBuffer());
+	simulationState_->setInput(((RadixSort_GPU*)radixSort_.get())->valueBuffer());
 	if (tf_.get()) {
 		simulationState_->setInput(tfBuffer_);
 	}
@@ -406,11 +406,11 @@ void BoidsGPU::debugVelocity(RenderState *rs) {
 void BoidsGPU::debugGridSorting(RenderState *rs) {
 	// read the key buffer
 	std::vector<uint32_t> sortKeys(numBoids_);
-	uint32_t bufferID = ((RadixSort*)radixSort_.get())->keyBuffer()->drawBufferRef()->bufferID();
+	uint32_t bufferID = ((RadixSort_GPU*)radixSort_.get())->keyBuffer()->drawBufferRef()->bufferID();
 	auto sortKeysData = (uint32_t *) glMapNamedBufferRange(
 			bufferID,
-			((RadixSort*)radixSort_.get())->keyBuffer()->drawBufferRef()->address(),
-			((RadixSort*)radixSort_.get())->keyBuffer()->drawBufferRef()->allocatedSize(),
+			((RadixSort_GPU*)radixSort_.get())->keyBuffer()->drawBufferRef()->address(),
+			((RadixSort_GPU*)radixSort_.get())->keyBuffer()->drawBufferRef()->allocatedSize(),
 			GL_MAP_READ_BIT);
 	if (sortKeysData) {
 		std::set<uint32_t> usedCells;
@@ -423,11 +423,11 @@ void BoidsGPU::debugGridSorting(RenderState *rs) {
 	}
 
 	// second map the index buffer and test if the indices are sorted correctly
-	bufferID = ((RadixSort*)radixSort_.get())->valueBuffer()->drawBufferRef()->bufferID();
+	bufferID = ((RadixSort_GPU*)radixSort_.get())->valueBuffer()->drawBufferRef()->bufferID();
 	auto sortedIndexData = (uint32_t *) glMapNamedBufferRange(
 			bufferID,
-			((RadixSort*)radixSort_.get())->valueBuffer()->drawBufferRef()->address(),
-			((RadixSort*)radixSort_.get())->valueBuffer()->drawBufferRef()->allocatedSize(),
+			((RadixSort_GPU*)radixSort_.get())->valueBuffer()->drawBufferRef()->address(),
+			((RadixSort_GPU*)radixSort_.get())->valueBuffer()->drawBufferRef()->allocatedSize(),
 			GL_MAP_READ_BIT);
 	if (sortedIndexData) {
 		uint32_t lastCell = 0;

--- a/regen/states/radix-sort.h
+++ b/regen/states/radix-sort.h
@@ -1,5 +1,5 @@
-#ifndef REGEN_RADIX_SORT_H
-#define REGEN_RADIX_SORT_H
+#ifndef REGEN_RADIX_SORT_GPU_H
+#define REGEN_RADIX_SORT_GPU_H
 
 #include <regen/states/state.h>
 #include "compute-pass.h"
@@ -11,15 +11,15 @@ namespace regen {
 	 * as unsigned integers (for floats use a bit representation).
 	 * The output will be an index buffer (the value array) with the keys sorted in ascending order.
 	 */
-	class RadixSort : public State {
+	class RadixSort_GPU : public State {
 	public:
 		/**
 		 * @brief Constructor for RadixSort
 		 * @param numKeys
 		 */
-		explicit RadixSort(uint32_t numKeys, uint32_t numLayers = 1);
+		explicit RadixSort_GPU(uint32_t numKeys, uint32_t numLayers = 1);
 
-		~RadixSort() override = default;
+		~RadixSort_GPU() override = default;
 
 		/**
 		 * Set whether visible instances are compacted before sorting.
@@ -117,4 +117,4 @@ namespace regen {
 	};
 } // namespace
 
-#endif /* REGEN_RADIX_SORT_H */
+#endif /* REGEN_RADIX_SORT_GPU_H */

--- a/regen/utility/radix-sort-cpu.h
+++ b/regen/utility/radix-sort-cpu.h
@@ -1,0 +1,89 @@
+#ifndef REGEN_RADIX_SORT_CPU_H
+#define REGEN_RADIX_SORT_CPU_H
+
+#include <vector>
+#include <cstdint>
+#include <cstring>
+
+namespace regen {
+	/**
+	 * @brief CPU-based Radix Sort implementation
+	 * This is a sequential implementation of the Radix Sort algorithm, running
+	 * in a single thread on the CPU. However, this is still significantly faster
+	 * compared to standard sorting algorithms like std::sort when sorting large.
+	 * @tparam IndexType The index type
+	 * @tparam KeyType The key type
+	 * @tparam BITS_PER_PASS The number of bits per pass
+	 */
+	template <typename IndexType, typename KeyType, int BITS_PER_PASS>
+	struct RadixSort_CPU_seq {
+		// e.g. 256 if BITS_PER_PASS=8
+		static constexpr int BUCKETS = 1 << BITS_PER_PASS;
+		// e.g. 8 passes if KEY_BITS=64 and BITS_PER_PASS=8
+		static constexpr int PASSES = (sizeof(KeyType)*8) / BITS_PER_PASS;
+		// whether the sorting starts with the temporary buffer
+		static constexpr bool START_WITH_TMP = ((PASSES % 2) == 1);
+
+		std::vector<IndexType> tmp_indices_;
+		std::vector<uint32_t> histogram_;
+
+		RadixSort_CPU_seq() : histogram_(BUCKETS) {}
+
+		/**
+		 * @brief Resize the internal buffers
+		 * @param numKeys The number of keys
+		 */
+		void resize(size_t numKeys) {
+			tmp_indices_.reserve(numKeys);
+		}
+
+		/**
+		 * @brief Sort the indices based on the keys
+		 * @param indices The indices to sort
+		 * @param keys The keys to sort by
+		 */
+		void sort(std::vector<IndexType> &indices, const std::vector<KeyType> &keys) {
+			const uint32_t numKeys = indices.size();
+			const KeyType *src_keys = keys.data();
+			tmp_indices_.resize(numKeys);
+
+			IndexType *src, *dst;
+			if constexpr (START_WITH_TMP) {
+				src = tmp_indices_.data();
+				dst = indices.data();
+			} else {
+				src = indices.data();
+				dst = tmp_indices_.data();
+			}
+
+			for (int pass = 0; pass < PASSES; ++pass) {
+				const int shift = pass * BITS_PER_PASS;
+				std::ranges::fill(histogram_, 0);
+
+				// Histogram: Count how many keys fall into each bucket
+				for (uint32_t i = 0; i < numKeys; ++i) {
+					++histogram_[(src_keys[src[i]] >> shift) & (BUCKETS - 1)];
+				}
+
+				// Prefix sum: Compute the starting index for each bucket
+				size_t sum = 0;
+				for (int i = 0; i < BUCKETS; ++i) {
+					const uint32_t tmp = histogram_[i];
+					histogram_[i] = sum;
+					sum += tmp;
+				}
+
+				// Scatter: Place each key in its corresponding bucket
+				for (uint32_t i = 0u; i < numKeys; ++i) {
+					const auto digit = (src_keys[src[i]] >> shift) & (BUCKETS - 1);
+					dst[histogram_[digit]++] = src[i];
+				}
+
+				// Swap buffers
+				std::swap(src, dst);
+			}
+		}
+	};
+} // regen
+
+#endif //REGEN_RADIX_SORT_CPU_H


### PR DESCRIPTION
- Use larger contiguous arrays (per camera)
- Pack multiple keys into 64 bit
- Use radix sort over the large arrays