### PR TITLE
Revised bone tree traversal

### DIFF
--- a/CMakeModules/FindBoost.cmake
+++ b/CMakeModules/FindBoost.cmake
@@ -218,7 +218,6 @@ macro(_Boost_ADJUST_LIB_VARS basename)
         # then just use the release libraries
         set(Boost_${basename}_LIBRARY ${Boost_${basename}_LIBRARY_RELEASE} )
       endif()
-      # FIXME: This probably should be set for both cases
       set(Boost_${basename}_LIBRARIES optimized ${Boost_${basename}_LIBRARY_RELEASE} debug ${Boost_${basename}_LIBRARY_DEBUG})
     endif()
 

--- a/CMakeModules/FindOpenAL.cmake
+++ b/CMakeModules/FindOpenAL.cmake
@@ -1,7 +1,10 @@
 include(Utility)
 
-# FIXME: on mac it's include/OpenAL/*.h
-find_include_path(OPENAL NAMES AL/al.h)
+if (APPLE)
+    find_include_path(OPENAL NAMES OpenAL/al.h)
+else()
+    find_include_path(OPENAL NAMES AL/al.h)
+endif()
 
 find_library_path(OPENAL NAMES libopenal.a OpenAL al openal soft_oal OpenAL32)
 

--- a/applications/glut/glut-application.cpp
+++ b/applications/glut/glut-application.cpp
@@ -70,7 +70,7 @@ void GLUTApplication::specialKeyDownStatic(int key, int x, int y)
 
 GLUTApplication::GLUTApplication(
     int &argc, char** argv,
-    GLuint width, GLuint height)
+    uint32_t width, uint32_t height)
 : Application(argc,argv),
   windowTitle_("OpenGL Engine"),
   glutHeight_(width),
@@ -96,15 +96,15 @@ void GLUTApplication::set_windowTitle(const string &windowTitle)
 {
   windowTitle_ = windowTitle;
 }
-void GLUTApplication::set_height(GLuint height)
+void GLUTApplication::set_height(uint32_t height)
 {
   glutHeight_ = height;
 }
-void GLUTApplication::set_width(GLuint width)
+void GLUTApplication::set_width(uint32_t width)
 {
   glutWidth_ = width;
 }
-void GLUTApplication::set_displayMode(GLuint displayMode)
+void GLUTApplication::set_displayMode(uint32_t displayMode)
 {
   displayMode_ = displayMode;
 }

--- a/applications/glut/glut-application.h
+++ b/applications/glut/glut-application.h
@@ -25,12 +25,12 @@ public:
   GLUTApplication(
       const ref_ptr<RootNode> &tree,
       int &argc, char** argv,
-      GLuint width=800, GLuint height=600);
+      uint32_t width=800, uint32_t height=600);
 
   void set_windowTitle(const std::string &windowTitle);
-  void set_height(GLuint height);
-  void set_width(GLuint width);
-  void set_displayMode(GLuint displayMode);
+  void set_height(uint32_t height);
+  void set_width(uint32_t width);
+  void set_displayMode(uint32_t displayMode);
 
   virtual void show();
   virtual int mainLoop();
@@ -40,9 +40,9 @@ protected:
   static GLUTApplication *singleton_;
 
   string windowTitle_;
-  GLuint glutHeight_;
-  GLuint glutWidth_;
-  GLuint displayMode_;
+  uint32_t glutHeight_;
+  uint32_t glutWidth_;
+  uint32_t displayMode_;
 
   GLboolean applicationRunning_;
 

--- a/applications/mesh-viewer/mesh-viewer-widget.cpp
+++ b/applications/mesh-viewer/mesh-viewer-widget.cpp
@@ -462,7 +462,6 @@ void MeshViewerWidget::gl_loadScene() {
 	sceneRoot_->state()->joinStates(ref_ptr<ToggleState>::alloc(RenderState::SAMPLE_ALPHA_TO_COVERAGE, true));
 
 	// enable light, and use it in direct shading
-	// TODO: better use deferred shading, and also allow to display the normals
 	auto shadingState = ref_ptr<DirectShading>::alloc();
 	shadingState->ambientLight()->setVertex(0, Vec3f(0.3f));
 

--- a/applications/mesh-viewer/mesh-viewer-widget.cpp
+++ b/applications/mesh-viewer/mesh-viewer-widget.cpp
@@ -328,20 +328,18 @@ void MeshViewerWidget::loadResources_GL() {
 }
 
 void MeshViewerWidget::loadAnimation(const ref_ptr<Mesh> &mesh, uint32_t index) {
-	std::list<ref_ptr<BoneNode> > meshBones;
+	std::vector<ref_ptr<BoneNode> > meshBones;
 	uint32_t numBoneWeights = asset_->numBoneWeights(mesh.get());
 
 	// Find bones influencing this mesh
 	auto nodeAnim = asset_->getNodeAnimation();
 	auto boneNodes = asset_->loadMeshBones(mesh.get(), nodeAnim.get());
 	meshBones.insert(meshBones.end(), boneNodes.begin(), boneNodes.end());
-	uint32_t numBones = boneNodes.size();
 	nodeAnim->startAnimation();
 
 	// Create Bones state that is responsible for uploading animation data to GL.
 	if (!meshBones.empty()) {
-		ref_ptr<Bones> bonesState = ref_ptr<Bones>::alloc(numBoneWeights, numBones);
-		bonesState->setBones(meshBones);
+		ref_ptr<Bones> bonesState = ref_ptr<Bones>::alloc(nodeAnim, meshBones, numBoneWeights);
 		bonesState->setAnimationName(REGEN_STRING("bones-mesh-viewer-" << index));
 		bonesState->startAnimation();
 		mesh->joinStates(bonesState);

--- a/applications/qt/ColorWidget.cpp
+++ b/applications/qt/ColorWidget.cpp
@@ -23,7 +23,7 @@ ColorWidget::ColorWidget(const RegenWidgetData &data, QWidget *parent)
 QColor ColorWidget::initializeColor() {
 	auto mapped = input_->mapClientDataRaw(BUFFER_GPU_READ);
 	const byte *value = mapped.r;
-	GLuint count = input_->valsPerElement();
+	uint32_t count = input_->valsPerElement();
 	QColor color;
 	if (input_->baseType() == GL_FLOAT) {
 		GLfloat r = ((GLfloat *) value)[0];
@@ -53,7 +53,7 @@ QColor ColorWidget::initializeColor() {
 
 void ColorWidget::updateColor(const QColor &color) {
 	// Update the shader input
-	GLuint count = input_->valsPerElement();
+	uint32_t count = input_->valsPerElement();
 	byte *changedData = new byte[input_->elementSize()];
 	if (input_->baseType() == GL_FLOAT) {
 		((GLfloat *) changedData)[0] = color.redF();
@@ -71,7 +71,7 @@ void ColorWidget::updateColor(const QColor &color) {
 
 void ColorWidget::pickColor() {
 	// Ensure the selected shader input is a color (3 or 4 components)
-	GLuint count = input_->valsPerElement();
+	uint32_t count = input_->valsPerElement();
 	if (count < 3 || count > 4) {
 		REGEN_WARN("pickColor() called but selected input is not a color.");
 		return;
@@ -114,7 +114,7 @@ void ColorWidget::pickColor() {
 
 void ColorWidget::alphaChanged() {
 	// Ensure the selected shader input is a color (4 components)
-	GLuint count = input_->valsPerElement();
+	uint32_t count = input_->valsPerElement();
 	if (count != 4) {
 		REGEN_WARN("alphaChanged() called but selected input is not a color with alpha.");
 		return;
@@ -172,6 +172,6 @@ void ColorWidget::rgbChanged() {
 
 void ColorWidget::scaleChanged() {
 	// Ensure the selected shader input is a color (3 or 4 components)
-	//GLuint count = input_->valsPerElement();
+	//uint32_t count = input_->valsPerElement();
 	//auto sliderValue = ui_.scaleValue->value();
 }

--- a/applications/qt/VectorWidget.cpp
+++ b/applications/qt/VectorWidget.cpp
@@ -2,7 +2,7 @@
 
 using namespace regen;
 
-static GLfloat readInputValue(const ref_ptr<ShaderInput> &input, const byte *value, GLuint i) {
+static GLfloat readInputValue(const ref_ptr<ShaderInput> &input, const byte *value, uint32_t i) {
 	switch (input->baseType()) {
 		case GL_FLOAT: {
 			return ((GLfloat *) value)[i];
@@ -11,7 +11,7 @@ static GLfloat readInputValue(const ref_ptr<ShaderInput> &input, const byte *val
 			return static_cast<GLfloat>((((GLint *) value)[i]));
 		}
 		case GL_UNSIGNED_INT: {
-			return static_cast<GLfloat>((((GLuint *) value)[i]));
+			return static_cast<GLfloat>((((uint32_t *) value)[i]));
 		}
 		default:
 			REGEN_WARN("Unknown data type " << input->baseType());
@@ -22,8 +22,8 @@ static GLfloat readInputValue(const ref_ptr<ShaderInput> &input, const byte *val
 
 VectorWidget::VectorWidget(const RegenWidgetData &data, QWidget *parent)
 		: RegenWidget(data, parent) {
-	GLuint count = input_->valsPerElement();
-	GLuint i;
+	uint32_t count = input_->valsPerElement();
+	uint32_t i;
 	if (count > 4) {
 		throw std::runtime_error("More than 4 components unsupported.");
 	}
@@ -107,9 +107,9 @@ byte *createData(
 		const ref_ptr<ShaderInput> &in,
 		QSlider **valueWidgets,
 		QLineEdit **valueTexts,
-		GLuint count) {
+		uint32_t count) {
 	T *typedData = new T[count];
-	for (GLuint i = 0u; i < count; ++i) {
+	for (uint32_t i = 0u; i < count; ++i) {
 		QSlider *widget = valueWidgets[i];
 		std::stringstream ss;
 		ss << static_cast<float>(widget->value()) / 1000.0f;
@@ -128,7 +128,7 @@ void VectorWidget::valueUpdated() {
 	QLineEdit *valueTexts[4] =
 			{ui_.xValueText, ui_.yValueText, ui_.zValueText, ui_.wValueText};
 
-	GLuint count = input_->valsPerElement();
+	uint32_t count = input_->valsPerElement();
 	if (count > 4) {
 		REGEN_WARN("More then 4 components unsupported.");
 		return;
@@ -143,7 +143,7 @@ void VectorWidget::valueUpdated() {
 			changedData = createData<GLint>(input_, valueWidgets, valueTexts, count);
 			break;
 		case GL_UNSIGNED_INT:
-			changedData = createData<GLuint>(input_, valueWidgets, valueTexts, count);
+			changedData = createData<uint32_t>(input_, valueWidgets, valueTexts, count);
 			break;
 		default:
 			REGEN_WARN("Unknown data type " << input_->baseType());
@@ -154,7 +154,7 @@ void VectorWidget::valueUpdated() {
 	delete[] changedData;
 
 	// set value of external sliders
-	for (GLuint i = 0; i < count; ++i) {
+	for (uint32_t i = 0; i < count; ++i) {
 		for (auto *slider: externalSlider_[i]) {
 			slider->setValue(valueWidgets[i]->value());
 		}

--- a/applications/qt/qt-application.cpp
+++ b/applications/qt/qt-application.cpp
@@ -29,7 +29,7 @@ static int appArgCount = 1;
 QtApplication::QtApplication(
 		const int &argc, const char **argv,
 		const QSurfaceFormat &glFormat,
-		GLuint width, GLuint height,
+		uint32_t width, uint32_t height,
 		QWidget *parent)
 		: Scene(argc, argv), isMainloopRunning_(GL_FALSE), exitCode_(0) {
 	QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);

--- a/applications/qt/shader-input-widget.cpp
+++ b/applications/qt/shader-input-widget.cpp
@@ -37,7 +37,7 @@ ShaderInputWidget::~ShaderInputWidget() {
 }
 
 void ShaderInputWidget::updateInitialValue(ShaderInput *x) {
-	GLuint stamp = x->stampOfReadData();
+	uint32_t stamp = x->stampOfReadData();
 	if (stamp != valueStamp_[x] &&
 		stamp != initialValueStamp_[x]) {
 		// last time value was not changed from widget
@@ -136,7 +136,7 @@ bool ShaderInputWidget::handleNode(
 	}
 
 	QTreeWidgetItem *x = parent;
-	GLuint level = 0u;
+	uint32_t level = 0u;
 	while (x != nullptr) {
 		level += 1u;
 		x = x->parent();

--- a/applications/qt/shader-input-widget.h
+++ b/applications/qt/shader-input-widget.h
@@ -37,8 +37,8 @@ namespace regen {
 		GLboolean ignoreValueChanges_;
 
 		std::map<ShaderInput *, byte *> initialValue_;
-		std::map<ShaderInput *, GLuint> initialValueStamp_;
-		std::map<ShaderInput *, GLuint> valueStamp_;
+		std::map<ShaderInput *, uint32_t> initialValueStamp_;
+		std::map<ShaderInput *, uint32_t> valueStamp_;
 
 		ref_ptr<StateNode> rootNode_;
 		std::map<QTreeWidgetItem *, ref_ptr<StateNode>> nodes_;

--- a/applications/scene-display/examples/canyon.xml
+++ b/applications/scene-display/examples/canyon.xml
@@ -436,7 +436,6 @@
     <!--**************************-->
 
     <!-- NOTE: trunk uses mesh index 0, twigs use index 1 -->
-    <!-- TODO: idea use lower level LOD for trees surrounded by other trees. -->
     <mesh id="tree-mesh" type="proctree"
           lods="3,2,1"
           lod-thresholds="10.0, 50.0, 100.0"

--- a/applications/scene-display/examples/character.xml
+++ b/applications/scene-display/examples/character.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <node>
-    <constant name="num-fire-flies" value="20"/>
     <constant name="far-plane" value="100.0"/>
     <constant name="close-range" value="40.0"/>
     <constant name="mid-range" value="100.0"/>
@@ -140,38 +139,6 @@
            diffuse="0.8,0.9,0.835"
            ambient="0.6,0.6,0.6"
            update-frequency="NEVER"/>
-    <light id="fire-flies-light0"
-           num-instances="{{num-fire-flies}}"
-           type="POINT"
-           radius="0.5,1.4"
-           ambient="0.0,0.0,0.0">
-        <set target="lightPosition" value="4.0,12.0,-4.0">
-            <set mode="circle" blend-mode="ADD" radius="5.0" variance="0.1"
-                 dir-x="1.0, 0.0, 0.0" dir-z="0.0, 0.0, 1.0"/>
-        </set>
-        <set target="lightDiffuse">
-            <set mode="fade" blend-mode="SRC" start="0.47, 0.45, 0.15" stop="0.47, 0.18. 0.08"/>
-        </set>
-        <animation type="boids"
-                   sim-mode="CPU"
-                   max-speed="4.0"
-                   visual-range="1.0"
-                   look-ahead="1.0"
-                   repulsion="8.0"
-                   coherence-weight="10.0"
-                   alignment-weight="10.0"
-                   avoidance-weight="10.0"
-                   avoidance-distance="0.5"
-                   separation-weight="10.0"
-                   bounds-min="2.0, 0.0, -14.0"
-                   bounds-max="14.0, 4.0, -2.0">
-            <home-point value="8.0, 4.0, -8.0"/>
-            <object type="danger" value="8.0, 10.0, -8.0" />
-            <object type="attractor" value="8.0, 8.0, -8.0" />
-            <object type="danger" value="8.0, 6.0, -8.0" />
-            <object type="attractor" value="8.0, 4.0, -8.0" />
-        </animation>
-    </light>
     <asset id="dwarf-asset"
            type="asset"
            file="res/models/psionic/dwarf/x/dwarf.x"
@@ -821,11 +788,6 @@
                                shadow-camera="room-light-camera0"/>
                     </light-pass>
                 </node>
-                <node>
-                    <light-pass type="POINT" ambient="0" shader="regen.shading.deferred.point.cube">
-                        <light id="fire-flies-light0"/>
-                    </light-pass>
-                </node>
             </node>
         </node>
     </node>
@@ -853,21 +815,6 @@
         <input name="modelOffset" state="room-light0" component="lightPosition"/>
         -->
         <shape id="light-bulb-shape" index="1" cull="1" type="sphere" radius="0.5" mesh-id="light-bulb-point" />
-    </mesh>
-    <mesh id="fire-flies0" type="point" update-frequency="NEVER" num-vertices="1" num-instances="{{num-fire-flies}}">
-        <material diffuse="0.0, 0.0, 0.0" ambient="0.0, 0.0, 0.0" specular="0.0, 0.0, 0.0" shininess="256.0" update-frequency="NEVER"/>
-        <define key="in_modelOffset" value="in_lightPosition_FireFly" />
-        <define key="in_matEmission" value="in_lightDiffuse_FireFly" />
-        <define key="HAS_modelOffset" value="TRUE" />
-        <define key="HAS_matEmission" value="TRUE" />
-        <input name="LightOfFireFly" state="fire-flies-light0" component="Light" member-suffix="_FireFly"/>
-        <!-- TODO: Add to spatial index.
-                - will need to find a way to make light position available in LOD state (see above)
-                - best would probably be in this case to use bounding sphere around all fire-flies
-                  and use that for spatial index. -->
-        <!--
-        <shape id="fire-flies-shape0" index="1" cull="1" type="sphere" radius="0.1" mesh-id="fire-flies0" />
-        -->
     </mesh>
 
     <node id="Static-Ground-Items">
@@ -899,10 +846,6 @@
             <texture id="ground-color" map-to="color" blend-mode="SRC" wrapping="REPEAT"/>
             <material specular="0, 0, 0" ambient="0.05, 0.0, 0.0" update-frequency="NEVER"/>
             <mesh id="ground-mesh" primitive="triangles" shader="regen.models.mesh"/>
-        </node>
-        <node id="Fire-Flies">
-            <input name="sphereRadius" type="float" value="0.1"/>
-            <mesh id="fire-flies0" shader="regen.models.sprite-sphere"/>
         </node>
 
         <node id="Light-Bulbs">

--- a/applications/scene-display/examples/character.xml
+++ b/applications/scene-display/examples/character.xml
@@ -300,9 +300,6 @@
         <shape id="tree-shape" index="1" cull="1" type="aabb" mesh-id="tree-mesh" transform-id="tree-tf">
             <has-part mesh-id="tree-mesh" mesh-index="1"/>
         </shape>
-        <!-- FIXME: there is some hack around here, look at bullet shape it is not at correct height.
-                 probably because base of the mesh is at 0.0,0.0,0.0, and not its center.
-                 plus there is a scaling here too. -->
         <shape id="tree-mesh-physics" physics="1" shape="box" mass="0.0" size="0.6, 6.0, 0.6"
                mesh-id="tree-mesh" transform-id="tree-tf"/>
     </mesh>
@@ -807,8 +804,6 @@
         <input type="vec3" name="lightAmbient" value="0.3,0.3,0.3"/>
         <resource id="sky"/>
 
-        <!-- TODO: seems light-passes must be seperated into different nodes everywhere! I guess because states on
-             same level are joined when building a shader? -->
         <node id="Light-Shading">
             <node>
                 <light-pass type="DIRECTIONAL" ambient="1" shader="regen.shading.deferred.directional">
@@ -949,8 +944,7 @@
         <node import="Depth-of-Field">
             <fbo id="g-buffer" draw-buffers="1"/>
             <texture name="inputTexture" fbo="g-buffer" attachment="0"/>
-            <!-- TODO: shouldn't blurred scene be used? -->
-            <!-- <texture name="inputTexture" id="blurred-scene" /> -->
+            <texture name="blurTexture" id="blurred-scene"/>
             <input type="vec2" name="focalWidth" value="0.7,1.0" />
         </node>
         <view id="Depth of Field">
@@ -1004,7 +998,6 @@
 
     <node id="initialize">
         <node import="Collision-Initialize"/>
-        <!-- TODO: could render static shadow maps here. -->
     </node>
 
     <node id="root">

--- a/applications/scene-display/examples/gpu-boids.xml
+++ b/applications/scene-display/examples/gpu-boids.xml
@@ -232,7 +232,6 @@
              swizzle-g="RED" swizzle-b="RED"/>
 
     <!-- water surface mesh used for depth rendering and post-processing effects -->
-    <!-- FIXME: this does not work well when camera is facing downwards, effectively looking behind its position in xz plane. -->
     <mesh id="water-mesh" type="rectangle" lod="0" center="1"
           use-normal="0" use-texco="0" use-tangent="0"
           rotation="0.0,0.0,3.1415"

--- a/applications/scene-display/examples/meadow.xml
+++ b/applications/scene-display/examples/meadow.xml
@@ -651,6 +651,7 @@
         <node import="Depth-of-Field">
             <fbo id="g-buffer" draw-buffers="1"/>
             <texture name="inputTexture" fbo="g-buffer" attachment="0"/>
+            <texture name="blurTexture" id="blurred-scene"/>
             <input type="vec2" name="focalWidth" value="0.7,1.0" />
         </node>
         <view id="Depth of Field">

--- a/applications/scene-display/examples/npc-behavior.xml
+++ b/applications/scene-display/examples/npc-behavior.xml
@@ -1638,10 +1638,11 @@
             <fbo id="g-buffer" draw-buffers="0"/>
         </node>
 
-        <node import="G-Buffer-Blur0"/> <!-- TODO: remove? -->
+        <node import="G-Buffer-Blur0"/>
         <node import="Depth-of-Field">
             <fbo id="g-buffer" draw-buffers="1"/>
             <texture name="inputTexture" fbo="g-buffer" attachment="0"/>
+            <texture name="blurTexture" id="blurred-scene"/>
             <input type="vec2" name="focalWidth" value="0.2,0.5"/>
         </node>
         <view id="DoF">

--- a/applications/scene-display/examples/terrain.xml
+++ b/applications/scene-display/examples/terrain.xml
@@ -230,7 +230,8 @@
              swizzle-g="RED" swizzle-b="RED"/>
 
     <!-- water surface mesh used for depth rendering and post-processing effects -->
-    <!-- FIXME: this does not work well when camera is facing downwards, effectively looking behind its position in xz plane. -->
+    <!-- FIXME: This does not work well when camera is facing downwards,
+                effectively looking behind its position in xz plane. Also the case in other scenes. -->
     <mesh id="water-mesh" type="rectangle" lod="0" center="1"
           use-normal="0" use-texco="0" use-tangent="0"
           rotation="0.0,0.0,3.1415"

--- a/applications/scene-display/fps-widget.h
+++ b/applications/scene-display/fps-widget.h
@@ -36,7 +36,7 @@ public:
 
 private:
 	ref_ptr<TextureMappedText> widget_{};
-	GLuint frameCounter_{};
+	uint32_t frameCounter_{};
 	GLint fps_{};
 	GLdouble sumDtMiliseconds_;
 };

--- a/applications/scene-display/scene-display-widget.cpp
+++ b/applications/scene-display/scene-display-widget.cpp
@@ -679,11 +679,6 @@ void SceneDisplayWidget::handleControllerConfiguration(
 				anchors_.emplace_back(anchor);
 			}
 		}
-
-		// make sure camera transforms are updated in first few frames
-		// TODO: HACK really needed?
-		userController_->animate(0.0);
-		userController_->glAnimate(RenderState::get(), 0.0);
 		userController_->startAnimation();
 	}
 	else if (controllerType == "animal") {

--- a/applications/scene-display/scene-display-widget.h
+++ b/applications/scene-display/scene-display-widget.h
@@ -99,7 +99,7 @@ protected:
 
 	ref_ptr<KeyFrameController> anchorAnim_;
 	std::vector<ref_ptr<CameraAnchor>> anchors_;
-	GLuint anchorIndex_;
+	uint32_t anchorIndex_;
 	GLdouble anchorEaseInOutIntensity_;
 	GLdouble anchorPauseTime_;
 	GLdouble anchorTimeScale_;

--- a/applications/video-player/video-player-widget.cpp
+++ b/applications/video-player/video-player-widget.cpp
@@ -39,8 +39,8 @@ extern "C" {
 using namespace std;
 
 static QString formatTime(GLfloat elapsedSeconds) {
-	GLuint seconds = (GLuint) elapsedSeconds;
-	GLuint minutes = seconds / 60;
+	uint32_t seconds = (uint32_t) elapsedSeconds;
+	uint32_t minutes = seconds / 60;
 	seconds = seconds % 60;
 	string label = REGEN_STRING(
 			(minutes < 10 ? "0" : "") << minutes <<

--- a/doc/doxygen.h
+++ b/doc/doxygen.h
@@ -190,7 +190,7 @@ class MyEventObject : public EventObject
 public:
   // This is the event identifier. We have to call EventObject::registerEvent
   // to set the value.
-  static GLuint MY_EVENT;
+  static uint32_t MY_EVENT;
   // Each time MY_EVENT is emitted a MyEvent instance is generated
   // and passed to connected handlers.
   class MyEvent : public EventData
@@ -214,7 +214,7 @@ public:
   }
 }
 // statically register the event
-GLuint MyEventObject::MY_EVENT = EventObject::registerEvent("my-event");
+uint32_t MyEventObject::MY_EVENT = EventObject::registerEvent("my-event");
 
 // EventHandler is the interface used to connect to events.
 class MyEventHandler : public EventHandler

--- a/regen/animation/animation.cpp
+++ b/regen/animation/animation.cpp
@@ -7,8 +7,8 @@
 
 using namespace regen;
 
-GLuint Animation::ANIMATION_STARTED = EventObject::registerEvent("animationStarted");
-GLuint Animation::ANIMATION_STOPPED = EventObject::registerEvent("animationStopped");
+uint32_t Animation::ANIMATION_STARTED = EventObject::registerEvent("animationStarted");
+uint32_t Animation::ANIMATION_STOPPED = EventObject::registerEvent("animationStopped");
 
 Animation::Animation(bool isGPUAnimation, bool isCPUAnimation)
 		: EventObject(),
@@ -65,7 +65,7 @@ void Animation::lock_gl() { mutex_gl_.lock(); }
 
 void Animation::unlock_gl() { mutex_gl_.unlock(); }
 
-void Animation::wait(GLuint milliseconds) {
+void Animation::wait(uint32_t milliseconds) {
 	usleepRegen(1000 * milliseconds);
 }
 

--- a/regen/animation/animation.h
+++ b/regen/animation/animation.h
@@ -18,11 +18,11 @@ namespace regen {
 		/**
 		 * The animation state switched to active.
 		 */
-		static GLuint ANIMATION_STARTED;
+		static uint32_t ANIMATION_STARTED;
 		/**
 		 * The animation state switched to inactive.
 		 */
-		static GLuint ANIMATION_STOPPED;
+		static uint32_t ANIMATION_STOPPED;
 
 		/**
 		 * Create an animation.
@@ -126,7 +126,7 @@ namespace regen {
 		 * Waits for a while.
 		 * @param milliseconds number of ms to wait
 		 */
-		void wait(GLuint milliseconds);
+		void wait(uint32_t milliseconds);
 
 		/**
 		 * @return true if the animation implements glAnimate().

--- a/regen/animation/bone-tree.h
+++ b/regen/animation/bone-tree.h
@@ -40,7 +40,6 @@ namespace regen {
 		void addChild(const ref_ptr<BoneNode> &child) { children.push_back(child); }
 	};
 
-
 	struct ActiveBoneRange {
 		// -1 indicates that the range is inactive
 		int32_t trackIdx_ = -1;
@@ -65,6 +64,17 @@ namespace regen {
 	};
 
 	struct BoneTreeTraversal;
+	class BoneTree;
+
+	/**
+	 * \brief A slice of a bone tree for multi-threaded updates.
+	 */
+	struct BoneTreeSlice {
+		BoneTree* boneTree;
+		uint32_t startInstance;
+		uint32_t endInstance;
+		float dt_ms;
+	};
 
 	/**
 	 * \brief A skeletal animation.
@@ -328,6 +338,9 @@ namespace regen {
 		std::vector<InstanceData> instanceData_;
 		ref_ptr<BoneEvent> eventData_ = ref_ptr<BoneEvent>::alloc();
 
+		std::vector<BoneTreeSlice> instanceSlices_;
+		uint32_t sliceSize_;
+
 		// per-node data arrays
 		// Matrix that transforms from mesh space to bone space in bind pose.
 		std::vector<Mat4f> localTransform_;
@@ -349,6 +362,8 @@ namespace regen {
 		void updateLocalTransforms(BoneTreeTraversal &td, uint32_t instanceIdx, InstanceData &instance);
 
 		void updateGlobalTransforms(BoneTreeTraversal &td, uint32_t instanceIdx);
+
+		friend struct BoneSliceJob;
 	};
 } // namespace
 

--- a/regen/animation/bone-tree.h
+++ b/regen/animation/bone-tree.h
@@ -10,63 +10,61 @@
 #include <unordered_map>
 #include <vector>
 
-#include "regen/utility/stamped.h"
 #include "animation-channel.h"
 
 namespace regen {
 	/**
 	 * \brief A node in a skeleton with parent and children.
 	 */
-	class BoneNode {
-	public:
+	struct BoneNode {
 		// The node name.
 		std::string name;
+		// The index of the node in the BoneTree node array.
+		uint32_t nodeIdx = 0;
 		// The parent node.
 		ref_ptr<BoneNode> parent;
 		// The node children.
 		std::vector<ref_ptr<BoneNode>> children;
-		// Local transformation matrix.
-		Mat4f localTransform;
-		Mat4f globalTransform; // temporary storage
-		// Matrix that transforms from mesh space to bone space in bind pose.
-		Mat4f offsetMatrix;
-		// per-instance offsetMatrix * nodeTransform * inverseTransform
-		std::vector<Mat4f> boneTransformationMatrix;
-		// per-instance count of active animations affecting this node.
-		std::vector<uint32_t> numActive;
-		// The index of the node in the BoneTree node array.
-		uint32_t nodeIdx;
-		bool isBoneNode;
-		bool localDirty = true;
-		bool globalDirty = true;
-		float lastWeightSum = 0.0f;
 
 		/**
 		 * @param name the node name.
 		 * @param parent the parent node.
 		 */
-		BoneNode(const std::string &name, const ref_ptr<BoneNode> &parent);
+		BoneNode(const std::string &name, const ref_ptr<BoneNode> &parent)
+			: name(name), parent(parent) {}
 
 		/**
 		 * Add a node child.
 		 * @param child
 		 */
-		void addChild(const ref_ptr<BoneNode> &child);
-
-		/**
-		 * Recursively updates the internal node transformations from the given matrix array.
-		 * @param transforms transformation matrices.
-		 */
-		void updateTransforms(uint32_t instanceIdx, Mat4f *transforms);
-
-		/**
-		 * Concatenates all parent transforms to get the global transform for this node.
-		 */
-		void calculateGlobalTransform();
-
-	protected:
-		Stack<BoneNode *> traversalStack;
+		void addChild(const ref_ptr<BoneNode> &child) { children.push_back(child); }
 	};
+
+
+	struct ActiveBoneRange {
+		// -1 indicates that the range is inactive
+		int32_t trackIdx_ = -1;
+		// config for currently active anim
+		double startTick_ = 0.0;
+		double duration_ = 0.0;
+		Vec2d tickRange_ = Vec2d(0.0, 0.0);
+		// milliseconds from start of animation
+		double elapsedTime_ = 0.0;
+		// last update time in ticks
+		double lastTime_ = 0.0;
+		// the current time in ticks
+		double timeInTicks_ = 0.0;
+		// Overall weight for this animation range, weights of nodes
+		// are multiplied with this.
+		float weight_ = 1.0;
+		// Per node weights for blending.
+		float *nodeWeights_;
+		// Remember last frame of each channel for interpolation.
+		std::vector<Vec3ui> lastFramePosition_;
+		std::vector<Vec3ui> startFramePosition_;
+	};
+
+	struct BoneTreeTraversal;
 
 	/**
 	 * \brief A skeletal animation.
@@ -81,9 +79,13 @@ namespace regen {
 		using AnimationHandle = int32_t;
 
 		/**
-		 * @param rootNode animation tree.
+		 * Construct a bone tree.
+		 * The root node is the first node in the nodes array.
+		 * Make sure that in the array i < j for any node i being parent of node j.
+		 * @param nodes the array of bone nodes.
+		 * @param numInstances the number of instances.
 		 */
-		explicit BoneTree(const ref_ptr<BoneNode> &rootNode, uint32_t numInstances = 1);
+		explicit BoneTree(const std::vector<ref_ptr<BoneNode>> &nodes, uint32_t numInstances = 1);
 
 		/**
 		 * @return the root node.
@@ -94,6 +96,64 @@ namespace regen {
 		 * @return the number of nodes in the bone tree.
 		 */
 		uint32_t numNodes() const { return static_cast<uint32_t>(nodes_.size()); }
+
+		/**
+		 * @return the number of instances.
+		 */
+		uint32_t numInstances() const { return numInstances_; }
+
+		/**
+		 * @param instanceID the instance index.
+		 * @param nodeIdx the node index.
+		 * @return the bone matrix for the given node and instance.
+		 */
+		const Mat4f &boneMatrix(uint32_t instanceID, uint32_t nodeIdx) const {
+			const auto numNodes = static_cast<uint32_t>(nodes_.size());
+			return boneMatrix_[instanceID * numNodes + nodeIdx];
+		}
+
+		/**
+		 * Set the offset matrix for a given node.
+		 * @param nodeIdx the node index.
+		 * @param offset the offset matrix.
+		 */
+		void setOffsetMatrix(uint32_t nodeIdx, const Mat4f &offset) {
+			offsetMatrix_[nodeIdx] = offset;
+		}
+
+		/**
+		 * @param nodeIdx the node index.
+		 * @return the offset matrix for the given node.
+		 */
+		const Mat4f &offsetMatrix(uint32_t nodeIdx) const {
+			return offsetMatrix_[nodeIdx];
+		}
+
+		/**
+		 * Set the local transform for a given node.
+		 * @param nodeIdx the node index.
+		 * @param tf the local transform.
+		 */
+		void setLocalTransform(uint32_t nodeIdx, const Mat4f &tf) {
+			localTransform_[nodeIdx] = tf;
+		}
+
+		/**
+		 * Mark a node as bone node or not.
+		 * @param nodeIdx the node index.
+		 * @param isBone true if the node is a bone node.
+		 */
+		void setIsBoneNode(uint32_t nodeIdx, bool isBone) {
+			isBoneNode_[nodeIdx] = isBone;
+		}
+
+		/**
+		 * @param nodeIdx the node index.
+		 * @return true if the node is a bone node.
+		 */
+		bool isBoneNode(uint32_t nodeIdx) const {
+			return isBoneNode_[nodeIdx];
+		}
 
 		/**
 		 * Add an animation.
@@ -227,33 +287,14 @@ namespace regen {
 			uint32_t rangeIdx = 0;
 		};
 
-		struct ActiveRange {
-			// -1 indicates that the range is inactive
-			int32_t trackIdx_ = -1;
-			// config for currently active anim
-			double startTick_ = 0.0;
-			double duration_ = 0.0;
-			Vec2d tickRange_ = Vec2d(0.0, 0.0);
-			// milliseconds from start of animation
-			double elapsedTime_ = 0.0;
-			// last update time in ticks
-			double lastTime_ = 0.0;
-			// the current time in ticks
-			double timeInTicks_ = 0.0;
-			// Overall weight for this animation range, weights of nodes
-			// are multiplied with this.
-			float weight_ = 1.0;
-			// Per node weights for blending.
-			float *nodeWeights_;
-			// Remember last frame of each channel for interpolation.
-			std::vector<Vec3ui> lastFramePosition_;
-			std::vector<Vec3ui> startFramePosition_;
-			std::vector<Vec3f> lastInterpolation_;
-		};
 	protected:
+		std::vector<ref_ptr<BoneNode>> nodes_;
 		ref_ptr<BoneNode> rootNode_;
+		std::unordered_map<std::string, uint32_t> nameToNode_;
+
 		uint32_t numInstances_ = 1;
 		double timeFactor_ = 0.001;
+		bool hasScalingKeys_ = false;
 
 		/**
 		 * A track in the bone animation.
@@ -271,43 +312,43 @@ namespace regen {
 			ref_ptr<StaticAnimationData> staticData_;
 		};
 		std::vector<Track> animTracks_;
+		std::unordered_map<std::string, int32_t> trackNameToIndex_;
 
 		struct InstanceData {
 			// An array of active ranges, however the array only grows so we may have
 			// inactive ranges in between.
-			std::vector<ActiveRange> ranges_;
+			std::vector<ActiveBoneRange> ranges_;
 			// The number of active ranges, i.e. animations that are active in parallel.
 			// This is usually a very small number.
 			uint32_t numActiveRanges_ = 0;
+			// Indices into ranges_ that are currently active.
+			std::vector<int32_t> activeRanges_;
+			std::vector<uint32_t> handleToActiveRange_;
 		};
 		std::vector<InstanceData> instanceData_;
-		// per-instance + per-node local node transformation
-		std::vector<Mat4f> blendedTransforms_;
 		ref_ptr<BoneEvent> eventData_ = ref_ptr<BoneEvent>::alloc();
 
-		// tmp storage
-		Stamped<Vec3f> tmpPos_;
-		Stamped<Vec3f> tmpScale_;
-		Stamped<Quaternion> tmpRot_;
+		// per-node data arrays
+		// Matrix that transforms from mesh space to bone space in bind pose.
+		std::vector<Mat4f> localTransform_;
+		std::vector<Mat4f> offsetMatrix_;
+		std::vector<int32_t> nodeParent_;
+		std::vector<int8_t> isBoneNode_;
 
-		// tmp storage
-		Vec3f accPos_;
-		Vec3f accScale_;
-		Quaternion accRot_;
+		// per-instance data arrays in node-major layout, i.e. numInstances x numNodes
+		std::vector<uint32_t> numActive_;
+		std::vector<Mat4f> boneMatrix_;
+		std::vector<Mat4f> blendedTransforms_;
 
-		std::vector<BoneNode*> nodes_;
-		std::unordered_map<std::string, uint32_t> nameToNode_;
-		std::unordered_map<std::string, int32_t> trackNameToIndex_;
+		void setTickRange(ActiveBoneRange &ar, const Vec2d &forcedTickRange);
 
-		void setTickRange(ActiveRange &ar, const Vec2d &forcedTickRange);
+		template <bool HasScaleKeys>
+		void updateBoneTree(uint32_t firstInstance, uint32_t numInstances, double dt_ms);
 
-		Quaternion nodeRotation(ActiveRange &ar, const AnimationChannel &channel, bool &isDirty, uint32_t i);
+		template <bool HasScaleKeys>
+		void updateLocalTransforms(BoneTreeTraversal &td, uint32_t instanceIdx, InstanceData &instance);
 
-		Vec3f nodePosition(ActiveRange &ar, const AnimationChannel &channel, bool &isDirty, uint32_t i);
-
-		Vec3f nodeScaling(ActiveRange &ar, const AnimationChannel &channel, bool &isDirty, uint32_t i);
-
-		static ref_ptr<BoneNode> findNode(ref_ptr<BoneNode> &n, const std::string &name);
+		void updateGlobalTransforms(BoneTreeTraversal &td, uint32_t instanceIdx);
 	};
 } // namespace
 

--- a/regen/animation/bones.cpp
+++ b/regen/animation/bones.cpp
@@ -6,7 +6,7 @@ using namespace regen;
 
 #define USE_BONE_TBO
 
-Bones::Bones(GLuint numBoneWeights, GLuint numBones)
+Bones::Bones(uint32_t numBoneWeights, uint32_t numBones)
 		: State(),
 		  Animation(false, true) {
 	bufferSize_ = 0u;

--- a/regen/animation/bones.cpp
+++ b/regen/animation/bones.cpp
@@ -6,10 +6,17 @@ using namespace regen;
 
 #define USE_BONE_TBO
 
-Bones::Bones(uint32_t numBoneWeights, uint32_t numBones)
+Bones::Bones(const ref_ptr<BoneTree> &tree,
+			const std::vector<ref_ptr<BoneNode>> &boneNodes,
+			uint32_t numBoneWeights)
 		: State(),
-		  Animation(false, true) {
+		  Animation(false, true),
+		  boneTree_(tree),
+		  boneNodes_(boneNodes) {
+	const uint32_t numBones = static_cast<uint32_t>(boneNodes_.size());
+
 	bufferSize_ = 0u;
+	numInstances_ = boneTree_->numInstances();
 	setAnimationName("bones");
 
 	numBoneWeights_ = ref_ptr<ShaderInput1i>::alloc("numBoneWeights");
@@ -19,21 +26,11 @@ Bones::Bones(uint32_t numBoneWeights, uint32_t numBones)
 	// prepend '#define HAS_BONES' to loaded shaders
 	shaderDefine("HAS_BONES", "TRUE");
 	shaderDefine("NUM_BONES_PER_MESH", REGEN_STRING(numBones));
-}
-
-void Bones::setBones(const std::list<ref_ptr<BoneNode>> &bones) {
-	bones_ = bones;
-	shaderDefine("NUM_BONES", REGEN_STRING(bones_.size()));
-	if (bones.empty()) {
-		REGEN_WARN("bones array is empty.");
-		return;
-	} else {
-		numInstances_ = bones.front()->boneTransformationMatrix.size();
-	}
+	shaderDefine("NUM_BONES", REGEN_STRING(numBones));
 
 	// create and join bone matrix uniform
-	boneMatrices_ = ref_ptr<ShaderInputMat4>::alloc("boneMatrices", bones.size() * numInstances_);
-	boneMatrices_->set_forceArray(GL_TRUE);
+	boneMatrices_ = ref_ptr<ShaderInputMat4>::alloc("boneMatrices", numBones * numInstances_);
+	boneMatrices_->set_forceArray(true);
 	boneMatrices_->setUniformUntyped();
 	bufferSize_ = boneMatrices_->inputSize();
 
@@ -65,13 +62,10 @@ void Bones::animate(GLdouble dt) {
 	auto mapped = boneMatrices_->mapClientData<Mat4f>(BUFFER_GPU_WRITE);
 	auto *boneMatrixData_ = mapped.w.data();
 
-	unsigned int i = 0;
+	uint32_t matIdx = 0;
 	for (uint32_t instanceID=0u; instanceID < numInstances_; ++instanceID) {
-		for (auto &bone : bones_) {
-			// the bone matrix is actually calculated in the animation thread
-			// by NodeAnimation.
-			boneMatrixData_[i] = bone->boneTransformationMatrix[instanceID];
-			i += 1;
+		for (auto &boneNode : boneNodes_) {
+			boneMatrixData_[matIdx++] = boneTree_->boneMatrix(instanceID, boneNode->nodeIdx);
 		}
 	}
 }

--- a/regen/animation/bones.h
+++ b/regen/animation/bones.h
@@ -15,16 +15,9 @@ namespace regen {
 	 */
 	class Bones : public State, public Animation {
 	public:
-		/**
-		 * @param numBoneWeights maximum number of bone weights.
-		 * @param numBones number of bones per mesh.
-		 */
-		Bones(uint32_t numBoneWeights, uint32_t numBones);
-
-		/**
-		 * @param bones  the bone list
-		 */
-		void setBones(const std::list<ref_ptr<BoneNode>> &bones);
+		Bones(const ref_ptr<BoneTree> &tree,
+			const std::vector<ref_ptr<BoneNode>> &boneNodes,
+			uint32_t numBoneWeights);
 
 		/**
 		 * @return maximum number of weights influencing a single bone.
@@ -35,7 +28,9 @@ namespace regen {
 		void animate(GLdouble dt) override;
 
 	protected:
-		std::list<ref_ptr<BoneNode>> bones_;
+		ref_ptr<BoneTree> boneTree_;
+		std::vector<ref_ptr<BoneNode>> boneNodes_;
+
 		ref_ptr<ShaderInput1i> numBoneWeights_;
 		uint32_t numInstances_;
 		uint32_t bufferSize_;

--- a/regen/animation/bones.h
+++ b/regen/animation/bones.h
@@ -19,7 +19,7 @@ namespace regen {
 		 * @param numBoneWeights maximum number of bone weights.
 		 * @param numBones number of bones per mesh.
 		 */
-		Bones(GLuint numBoneWeights, GLuint numBones);
+		Bones(uint32_t numBoneWeights, uint32_t numBones);
 
 		/**
 		 * @param bones  the bone list

--- a/regen/animation/mesh-animation.cpp
+++ b/regen/animation/mesh-animation.cpp
@@ -216,7 +216,7 @@ void MeshAnimation::glAnimate(RenderState *rs, GLdouble dt) {
 	const auto &inputs = mesh_->inputs();
 
 	meshBufferOffset_ = (inputs.empty() ? 0 : (inputs.begin()->in_)->offset());
-	for (auto it = inputs.rbegin(); it != inputs.rend(); ++it) {
+	for (auto it = inputs.begin(); it != inputs.end(); ++it) {
 		const ref_ptr<ShaderInput> &in = it->in_;
 		if (!in->isVertexAttribute()) continue;
 		if (in->offset() < meshBufferOffset_) {

--- a/regen/animation/mesh-animation.cpp
+++ b/regen/animation/mesh-animation.cpp
@@ -20,7 +20,7 @@ void MeshAnimation::findFrameAfterTick(
 
 void MeshAnimation::findFrameBeforeTick(
 		GLdouble &tick,
-		GLuint &frame,
+		uint32_t &frame,
 		std::vector<KeyFrame> &keys) {
 	for (frame = keys.size() - 1; frame > 0;) {
 		if (tick >= keys[frame].startTick) {
@@ -57,7 +57,7 @@ MeshAnimation::MeshAnimation(
 
 	// find buffer size
 	bufferSize_ = 0u;
-	GLuint i = 0u;
+	uint32_t i = 0u;
 	for (auto it = mesh->inputs().begin(); it != mesh->inputs().end(); ++it) {
 		const ref_ptr<ShaderInput> &in = it->in_;
 		if (!in->isVertexAttribute()) continue;
@@ -169,7 +169,7 @@ void MeshAnimation::setTickRange(const Vec2d &forcedTickRange) {
 	if (tickRange_.x < 0.00001) {
 		startFramePosition_ = 0u;
 	} else {
-		GLuint framePos;
+		uint32_t framePos;
 		findFrameBeforeTick(tickRange_.x, framePos, frames_);
 		startFramePosition_ = framePos;
 	}
@@ -181,7 +181,7 @@ void MeshAnimation::setTickRange(const Vec2d &forcedTickRange) {
 	elapsedTime_ = 0.0;
 }
 
-void MeshAnimation::loadFrame(GLuint frameIndex, GLboolean isPongFrame) {
+void MeshAnimation::loadFrame(uint32_t frameIndex, GLboolean isPongFrame) {
 	MeshAnimation::KeyFrame &frame = frames_[frameIndex];
 
 	std::list<ref_ptr<ShaderInput> > atts;
@@ -440,7 +440,7 @@ void MeshAnimation::addSphereAttributes(
 	// find the centroid of the mesh
 	Vec3f minPos = posAtt->getVertex(0).r;
 	Vec3f maxPos = posAtt->getVertex(0).r;
-	for (GLuint i = 1; i < posAtt->numVertices(); ++i) {
+	for (uint32_t i = 1; i < posAtt->numVertices(); ++i) {
 		auto v = posAtt->getVertex(i);
 		if(minPos.x > v.r.x) minPos.x = v.r.x;
 		if(minPos.y > v.r.y) minPos.y = v.r.y;
@@ -456,7 +456,7 @@ void MeshAnimation::addSphereAttributes(
 	//       There might be artifacts caused by faces that are flipped.
 	//       Also make sure to use polygon offset to avoid shadow map fighting.
 	// TODO: it should be possible to do this with less artifacts by taking the faces into account.
-	for (GLuint i = 0; i < spherePos->numVertices(); ++i) {
+	for (uint32_t i = 0; i < spherePos->numVertices(); ++i) {
 		Vec3f v = posAtt->getVertex(i).r;
 		Vec3f direction = v - centroid;
 		Vec3f n;
@@ -623,7 +623,7 @@ void MeshAnimation::addBoxAttributes(
 			ShaderInput::copy(norAtt, GL_FALSE));
 
 	// set cube vertex data
-	for (GLuint i = 0; i < boxPos->numVertices(); ++i) {
+	for (uint32_t i = 0; i < boxPos->numVertices(); ++i) {
 		Vec3f v = posAtt->getVertex(i).r;
 		Vec3f n;
 		GLdouble l = v.length();

--- a/regen/animation/mesh-animation.h
+++ b/regen/animation/mesh-animation.h
@@ -137,10 +137,10 @@ namespace regen {
 		ref_ptr<State> meshAnimState_;
 
 		ref_ptr<Mesh> mesh_;
-		GLuint meshBufferOffset_;
+		uint32_t meshBufferOffset_;
 
 		GLint lastFrame_, nextFrame_;
-		GLuint bufferSize_;
+		uint32_t bufferSize_;
 
 		ref_ptr<VBO> feedbackBuffer_;
 		ref_ptr<BufferReference> feedbackRef_;
@@ -157,14 +157,14 @@ namespace regen {
 		GLdouble ticksPerSecond_;
 		GLdouble lastTime_;
 		Vec2d tickRange_;
-		GLuint lastFramePosition_;
-		GLuint startFramePosition_;
+		uint32_t lastFramePosition_;
+		uint32_t startFramePosition_;
 
-		GLuint mapOffset_, mapSize_;
+		uint32_t mapOffset_, mapSize_;
 
 		bool hasMeshInterleavedAttributes_;
 
-		void loadFrame(GLuint frameIndex, GLboolean isPongFrame);
+		void loadFrame(uint32_t frameIndex, GLboolean isPongFrame);
 
 		ref_ptr<ShaderInput> findLastAttribute(const std::string &name);
 
@@ -172,7 +172,7 @@ namespace regen {
 				GLdouble tick, GLint &frame, std::vector<KeyFrame> &keys);
 
 		static void findFrameBeforeTick(
-				GLdouble &tick, GLuint &frame, std::vector<KeyFrame> &keys);
+				GLdouble &tick, uint32_t &frame, std::vector<KeyFrame> &keys);
 	};
 } // namespace
 

--- a/regen/av/audio.cpp
+++ b/regen/av/audio.cpp
@@ -219,7 +219,7 @@ AudioSource::AudioBuffer::~AudioBuffer() {
 	alDeleteBuffers(1, &id_);
 }
 
-AudioSource::AudioSource(GLuint cachedBytesLimit)
+AudioSource::AudioSource(uint32_t cachedBytesLimit)
 		: AudioVideoStream(cachedBytesLimit),
 		  id_(0),
 		  alType_(AL_NONE),
@@ -235,7 +235,7 @@ AudioSource::AudioSource(GLuint cachedBytesLimit)
 	alGenSources(1, &id_);
 }
 
-AudioSource::AudioSource(AVStream *stream, GLint index, GLuint cachedBytesLimit)
+AudioSource::AudioSource(AVStream *stream, GLint index, uint32_t cachedBytesLimit)
 		: AudioVideoStream(cachedBytesLimit),
 		  id_(0),
 		  alType_(AL_NONE),

--- a/regen/av/audio.h
+++ b/regen/av/audio.h
@@ -110,14 +110,14 @@ namespace regen {
 		/**
 		 * @param chachedBytesLimit limit for pre-loading.
 		 */
-		explicit AudioSource(GLuint chachedBytesLimit);
+		explicit AudioSource(uint32_t chachedBytesLimit);
 
 		/**
 		 * @param stream a av stream handle.
 		 * @param index index in stream.
 		 * @param chachedBytesLimit limit for pre-loading.
 		 */
-		AudioSource(AVStream *stream, GLint index, GLuint chachedBytesLimit);
+		AudioSource(AVStream *stream, GLint index, uint32_t chachedBytesLimit);
 
 		~AudioSource() override;
 

--- a/regen/av/av-stream.cpp
+++ b/regen/av/av-stream.cpp
@@ -12,7 +12,7 @@
 
 using namespace regen;
 
-AudioVideoStream::AudioVideoStream(AVStream *stream, GLint index, GLuint cachedBytesLimit)
+AudioVideoStream::AudioVideoStream(AVStream *stream, GLint index, uint32_t cachedBytesLimit)
 		: stream_(nullptr),
 		  codecCtx_(nullptr),
 		  codec_(nullptr),
@@ -23,7 +23,7 @@ AudioVideoStream::AudioVideoStream(AVStream *stream, GLint index, GLuint cachedB
 	open(stream, index, GL_TRUE);
 }
 
-AudioVideoStream::AudioVideoStream(GLuint cachedBytesLimit)
+AudioVideoStream::AudioVideoStream(uint32_t cachedBytesLimit)
 		: stream_(nullptr),
 		  codecCtx_(nullptr),
 		  codec_(nullptr),
@@ -69,17 +69,17 @@ void AudioVideoStream::open(AVStream *stream, GLint index, GLboolean initial) {
 	isActive_ = GL_TRUE;
 }
 
-GLuint AudioVideoStream::numFrames() {
+uint32_t AudioVideoStream::numFrames() {
 	boost::lock_guard<boost::mutex> lock(decodingLock_);
 	return decodedFrames_.size();
 }
 
-void AudioVideoStream::pushFrame(AVFrame *frame, GLuint frameSize) {
+void AudioVideoStream::pushFrame(AVFrame *frame, uint32_t frameSize) {
 	{
 		boost::lock_guard<boost::mutex> lock(decodingLock_);
 		cachedBytes_ += frameSize;
 	}
-	GLuint cachedBytes, numCachedFrames;
+	uint32_t cachedBytes, numCachedFrames;
 	if (cachedBytesLimit_ > 0u) {
 		while (isActive_) {
 			cachedBytes = cachedBytes_;

--- a/regen/av/av-stream.h
+++ b/regen/av/av-stream.h
@@ -44,12 +44,12 @@ namespace regen {
 		 * @param index index in stream.
 		 * @param cachedBytesLimit limit for pre-loading.
 		 */
-		AudioVideoStream(AVStream *stream, GLint index, GLuint cachedBytesLimit);
+		AudioVideoStream(AVStream *stream, GLint index, uint32_t cachedBytesLimit);
 
 		/**
 		 * @param cachedBytesLimit limit for pre-loading.
 		 */
-		explicit AudioVideoStream(GLuint cachedBytesLimit);
+		explicit AudioVideoStream(uint32_t cachedBytesLimit);
 
 		virtual ~AudioVideoStream();
 
@@ -67,7 +67,7 @@ namespace regen {
 		 * Push a decoded frame onto queue of frames.
 		 * The frames may get processed in a seperate thread.
 		 */
-		void pushFrame(AVFrame *frame, GLuint frameSize);
+		void pushFrame(AVFrame *frame, uint32_t frameSize);
 
 		/**
 		 * Front element of the queue.
@@ -82,7 +82,7 @@ namespace regen {
 		/**
 		 * Number of frames in queue.
 		 */
-		GLuint numFrames();
+		uint32_t numFrames();
 
 		/**
 		 * The stream may block in decode() waiting to be able
@@ -113,8 +113,8 @@ namespace regen {
 		std::queue<AVFrame *> decodedFrames_;
 		std::queue<GLint> frameSizes_;
 
-		GLuint cachedBytes_;
-		GLuint cachedBytesLimit_;
+		uint32_t cachedBytes_;
+		uint32_t cachedBytesLimit_;
 		GLboolean isActive_;
 
 		void open(AVStream *stream, GLint index, GLboolean initial = GL_FALSE);

--- a/regen/av/demuxer.cpp
+++ b/regen/av/demuxer.cpp
@@ -102,7 +102,7 @@ void Demuxer::set_file(std::string_view file) {
 	// Find the first video/audio stream
 	videoStreamIndex_ = -1;
 	audioStreamIndex_ = -1;
-	for (GLuint i = 0u; i < formatCtx_->nb_streams; ++i) {
+	for (uint32_t i = 0u; i < formatCtx_->nb_streams; ++i) {
 		auto stream = formatCtx_->streams[i];
 		auto codec_type = stream->codecpar->codec_type;
 		if (videoStreamIndex_ == -1 && codec_type == AVMEDIA_TYPE_VIDEO) { videoStreamIndex_ = i; }

--- a/regen/av/video-recorder.cpp
+++ b/regen/av/video-recorder.cpp
@@ -21,8 +21,6 @@ namespace regen {
 			desiredFrameRate_ = 30.0f;
 		}
 
-		// TODO: rather do the animate() in VideoRecorder, but currently unsynchronized threads seem to
-		//       have problems running together with synchronized GL animation call, maybe it is about the signals.
 		void animate(GLdouble dt) override {
 			encoder_->encodeNextFrame();
 		}

--- a/regen/av/video-stream.cpp
+++ b/regen/av/video-stream.cpp
@@ -18,7 +18,7 @@ using namespace regen;
 
 #define GL_RGB_PIXEL_FORMAT AV_PIX_FMT_RGB24
 
-VideoStream::VideoStream(AVStream *stream, GLint index, GLuint cachedBytesLimit)
+VideoStream::VideoStream(AVStream *stream, GLint index, uint32_t cachedBytesLimit)
 		: AudioVideoStream(stream, index, cachedBytesLimit) {
 	stream_ = stream;
 	width_ = codecCtx_->width;

--- a/regen/av/video-stream.h
+++ b/regen/av/video-stream.h
@@ -22,7 +22,7 @@ namespace regen {
 		 * @param index the stream index.
 		 * @param cachedBytesLimit size limit for pre loading.
 		 */
-		VideoStream(AVStream *stream, GLint index, GLuint cachedBytesLimit);
+		VideoStream(AVStream *stream, GLint index, uint32_t cachedBytesLimit);
 
 		~VideoStream() override;
 

--- a/regen/av/video-texture.cpp
+++ b/regen/av/video-texture.cpp
@@ -137,7 +137,7 @@ void VideoTexture::animate(GLdouble animateDT) {
 	dt_ += animateDT;
 	if (interval_ > 0.0) { return; }
 
-	GLuint numFrames = vs_->numFrames();
+	uint32_t numFrames = vs_->numFrames();
 	GLboolean isIdle = (numFrames == 0);
 
 	if (isIdle) {

--- a/regen/behavior/animal-controller.cpp
+++ b/regen/behavior/animal-controller.cpp
@@ -95,7 +95,7 @@ std::vector<ref_ptr<AnimalController>> AnimalController::load(
 	ref_ptr<Mesh> mesh;
 	auto compositeMesh = scene->getResources()->getMesh(scene, node.getValue("mesh"));
 	if (compositeMesh.get() != nullptr && !compositeMesh->meshes().empty()) {
-		auto meshIndex = node.getValue<GLuint>("mesh-index", 0u);
+		auto meshIndex = node.getValue<uint32_t>("mesh-index", 0u);
 		if (meshIndex >= compositeMesh->meshes().size()) {
 			REGEN_WARN("Invalid mesh index for '" << node.getDescription() << "'.");
 			meshIndex = 0;

--- a/regen/behavior/user-controller.cpp
+++ b/regen/behavior/user-controller.cpp
@@ -77,7 +77,7 @@ ref_ptr<UserController> UserController::load(
 	ref_ptr<Mesh> mesh;
 	auto compositeMesh = scene->getResources()->getMesh(scene, node.getValue("mesh"));
 	if (compositeMesh.get() != nullptr && !compositeMesh->meshes().empty()) {
-		auto meshIndex = node.getValue<GLuint>("mesh-index", 0u);
+		auto meshIndex = node.getValue<uint32_t>("mesh-index", 0u);
 		if (meshIndex >= compositeMesh->meshes().size()) {
 			REGEN_WARN("Invalid mesh index for '" << node.getDescription() << "'.");
 			meshIndex = 0;

--- a/regen/behavior/world/world-model-debug.h
+++ b/regen/behavior/world/world-model-debug.h
@@ -37,8 +37,8 @@ namespace regen {
 		GLint lineLocation_;
 
 		ref_ptr<VAO> vao_;
-		GLuint vbo_{};
-		GLuint bufferSize_;
+		uint32_t vbo_{};
+		uint32_t bufferSize_;
 	};
 }
 

--- a/regen/buffer/buffer-allocator.cpp
+++ b/regen/buffer/buffer-allocator.cpp
@@ -3,9 +3,9 @@
 
 using namespace regen;
 
-GLuint BufferAllocator::createAllocator(GLuint poolIdx, GLuint size) {
+uint32_t BufferAllocator::createAllocator(uint32_t poolIdx, uint32_t size) {
 	// create a fresh GL buffer object.
-	GLuint ref;
+	uint32_t ref;
 	glCreateBuffers(1, &ref);
 	// allocate the storage for the buffer object.
 	const uint32_t flags = glStorageFlags((BufferStorageMode)(poolIdx % BUFFER_STORAGE_MODE_LAST));
@@ -13,11 +13,11 @@ GLuint BufferAllocator::createAllocator(GLuint poolIdx, GLuint size) {
 	return ref;
 }
 
-void BufferAllocator::deleteAllocator(GLuint /*poolIndex*/, GLuint ref) {
+void BufferAllocator::deleteAllocator(uint32_t /*poolIndex*/, uint32_t ref) {
 	glDeleteBuffers(1, &ref);
 }
 
-void* BufferAllocator::mapAllocator(GLuint poolIdx, GLuint size, GLuint ref) {
+void* BufferAllocator::mapAllocator(uint32_t poolIdx, uint32_t size, uint32_t ref) {
 	const uint32_t flags = glAccessFlags((BufferStorageMode)(poolIdx % BUFFER_STORAGE_MODE_LAST));
 	if (flags & GL_MAP_PERSISTENT_BIT) {
 		return glMapNamedBufferRange(ref, 0, size, flags);
@@ -26,13 +26,13 @@ void* BufferAllocator::mapAllocator(GLuint poolIdx, GLuint size, GLuint ref) {
 	}
 }
 
-void BufferAllocator::unmapAllocator(GLuint poolIdx, GLuint ref) {
+void BufferAllocator::unmapAllocator(uint32_t poolIdx, uint32_t ref) {
 	const uint32_t flags = glAccessFlags((BufferStorageMode)(poolIdx % BUFFER_STORAGE_MODE_LAST));
 	if (flags & GL_MAP_PERSISTENT_BIT) {
 		glUnmapNamedBuffer(ref);
 	}
 }
 
-void BufferAllocator::orphanAllocatorRange(GLuint ref, GLuint offset, GLuint size) {
+void BufferAllocator::orphanAllocatorRange(uint32_t ref, uint32_t offset, uint32_t size) {
 	glInvalidateBufferSubData(ref, offset, size);
 }

--- a/regen/buffer/buffer-allocator.h
+++ b/regen/buffer/buffer-allocator.h
@@ -12,7 +12,7 @@ namespace regen {
 		 * Generate buffer object name and
 		 * create and initialize the buffer object's data store to the named size.
 		 */
-		static GLuint createAllocator(GLuint poolIndex, GLuint size);
+		static uint32_t createAllocator(uint32_t poolIndex, uint32_t size);
 
 		/**
 		 * Map the buffer object to the CPU memory.
@@ -22,7 +22,7 @@ namespace regen {
 		 * @param ref the reference to the buffer object.
 		 * @return pointer to mapped memory, or nullptr if mapping is not possible.
 		 */
-		static void* mapAllocator(GLuint poolIndex, GLuint size, GLuint ref);
+		static void* mapAllocator(uint32_t poolIndex, uint32_t size, uint32_t ref);
 
 		/**
 		 * Unmap the buffer object from the CPU memory.
@@ -30,14 +30,14 @@ namespace regen {
 		 * @param poolIndex the index of the pool.
 		 * @param ref the reference to the buffer object.
 		 */
-		static void unmapAllocator(GLuint poolIndex, GLuint ref);
+		static void unmapAllocator(uint32_t poolIndex, uint32_t ref);
 
 		/**
 		 * Delete named buffer object.
 		 * After a buffer object is deleted, it has no contents,
 		 * and its name is free for reuse.
 		 */
-		static void deleteAllocator(GLuint poolIndex, GLuint ref);
+		static void deleteAllocator(uint32_t poolIndex, uint32_t ref);
 
 		/**
 		 * Invalidate a buffer range.
@@ -45,15 +45,15 @@ namespace regen {
 		 * @param offset the offset in the buffer object.
 		 * @param size the size of the data to invalidate.
 		 */
-		static void orphanAllocatorRange(GLuint ref, GLuint offset, GLuint size);
+		static void orphanAllocatorRange(uint32_t ref, uint32_t offset, uint32_t size);
 	};
 
 	/**
 	 * \brief A pool of VBO memory allocators.
 	 */
 	typedef AllocatorPool<
-			BufferAllocator, GLuint,   // actual allocator and reference type
-			BuddyAllocator, GLuint     // virtual allocator and reference type
+			BufferAllocator, uint32_t,   // actual allocator and reference type
+			BuddyAllocator, uint32_t     // virtual allocator and reference type
 	> BufferPool;
 } // namespace
 

--- a/regen/buffer/client-allocator.cpp
+++ b/regen/buffer/client-allocator.cpp
@@ -3,23 +3,23 @@
 
 using namespace regen;
 
-ClientBufferRef ClientBufferAllocator::createAllocator(GLuint /*poolIdx*/, GLuint size) {
+ClientBufferRef ClientBufferAllocator::createAllocator(uint32_t /*poolIdx*/, uint32_t size) {
 	return (byte*)std::malloc(size);
 }
 
-void ClientBufferAllocator::deleteAllocator(GLuint /*poolIndex*/, ClientBufferRef ref) {
+void ClientBufferAllocator::deleteAllocator(uint32_t /*poolIndex*/, ClientBufferRef ref) {
 	if (!ref) return;
 	std::free(ref);
 }
 
-void* ClientBufferAllocator::mapAllocator(GLuint /*poolIdx*/, GLuint /*size*/, ClientBufferRef ref) {
+void* ClientBufferAllocator::mapAllocator(uint32_t /*poolIdx*/, uint32_t /*size*/, ClientBufferRef ref) {
 	return ref;
 }
 
-void ClientBufferAllocator::unmapAllocator(GLuint /*poolIdx*/, ClientBufferRef /*ref*/) {
+void ClientBufferAllocator::unmapAllocator(uint32_t /*poolIdx*/, ClientBufferRef /*ref*/) {
 	// nothing to do here.
 }
 
-void ClientBufferAllocator::orphanAllocatorRange(ClientBufferRef /*ref*/, GLuint /*offset*/, GLuint /*size*/) {
+void ClientBufferAllocator::orphanAllocatorRange(ClientBufferRef /*ref*/, uint32_t /*offset*/, uint32_t /*size*/) {
 	// nothing to do here.
 }

--- a/regen/buffer/client-allocator.h
+++ b/regen/buffer/client-allocator.h
@@ -18,7 +18,7 @@ namespace regen {
 		 * Generate buffer object name and
 		 * create and initialize the buffer object's data store to the named size.
 		 */
-		static ClientBufferRef createAllocator(GLuint poolIndex, GLuint size);
+		static ClientBufferRef createAllocator(uint32_t poolIndex, uint32_t size);
 
 		/**
 		 * Map the buffer object to the CPU memory.
@@ -28,7 +28,7 @@ namespace regen {
 		 * @param ref the reference to the buffer object.
 		 * @return pointer to mapped memory, or nullptr if mapping is not possible.
 		 */
-		static void* mapAllocator(GLuint poolIndex, GLuint size, ClientBufferRef ref);
+		static void* mapAllocator(uint32_t poolIndex, uint32_t size, ClientBufferRef ref);
 
 		/**
 		 * Unmap the buffer object from the CPU memory.
@@ -36,14 +36,14 @@ namespace regen {
 		 * @param poolIndex the index of the pool.
 		 * @param ref the reference to the buffer object.
 		 */
-		static void unmapAllocator(GLuint poolIndex, ClientBufferRef ref);
+		static void unmapAllocator(uint32_t poolIndex, ClientBufferRef ref);
 
 		/**
 		 * Delete named buffer object.
 		 * After a buffer object is deleted, it has no contents,
 		 * and its name is free for reuse.
 		 */
-		static void deleteAllocator(GLuint poolIndex, ClientBufferRef ref);
+		static void deleteAllocator(uint32_t poolIndex, ClientBufferRef ref);
 
 		/**
 		 * Invalidate a buffer range.
@@ -51,7 +51,7 @@ namespace regen {
 		 * @param offset the offset in the buffer object.
 		 * @param size the size of the data to invalidate.
 		 */
-		static void orphanAllocatorRange(ClientBufferRef ref, GLuint offset, GLuint size);
+		static void orphanAllocatorRange(ClientBufferRef ref, uint32_t offset, uint32_t size);
 	};
 
 	/**
@@ -61,7 +61,7 @@ namespace regen {
 			ClientBufferAllocator,
 			ClientBufferRef,   // actual allocator and reference type
 			BuddyAllocator,
-			GLuint     // virtual allocator and reference type
+			uint32_t     // virtual allocator and reference type
 	> ClientBufferPool;
 } // namespace
 

--- a/regen/camera/camera.cpp
+++ b/regen/camera/camera.cpp
@@ -537,7 +537,7 @@ ref_ptr<Camera> createLightCamera(LoadingContext &ctx, scene::SceneInputNode &in
 		REGEN_WARN("Unable to find Light for '" << input.getDescription() << "'.");
 		return {};
 	}
-	auto numLayer = input.getValue<GLuint>("num-layer", 1u);
+	auto numLayer = input.getValue<uint32_t>("num-layer", 1u);
 	auto splitWeight = input.getValue<GLdouble>("split-weight", 0.9);
 	auto cameraType = input.getValue<std::string>("camera-type", "spot");
 	auto near = input.getValue<float>("near", 0.1f);
@@ -660,7 +660,7 @@ ref_ptr<Camera> Camera::createCamera(LoadingContext &ctx, scene::SceneInputNode 
 			}
 			const std::vector<ref_ptr<Mesh> > &vec = compositeMesh->meshes();
 			cam = ref_ptr<ReflectionCamera>::alloc(
-					userCamera, vec[0], input.getValue<GLuint>("vertex-index", 0u), hasBackFace);
+					userCamera, vec[0], input.getValue<uint32_t>("vertex-index", 0u), hasBackFace);
 		} else if (input.hasAttribute("reflector-normal")) {
 			auto normal = input.getValue<Vec3f>("reflector-normal", Vec3f(0.0f, 1.0f, 0.0f));
 			auto position = input.getValue<Vec3f>("reflector-point", Vec3f(0.0f, 0.0f, 0.0f));

--- a/regen/effects/bloom-pass.cpp
+++ b/regen/effects/bloom-pass.cpp
@@ -162,7 +162,7 @@ ref_ptr<BloomPass> BloomPass::load(LoadingContext &ctx, scene::SceneInputNode &i
 			REGEN_WARN("Unable to find FBO for " << input.getDescription() << ".");
 			return {};
 		}
-		auto attachment = input.getValue<GLuint>("attachment", 0);
+		auto attachment = input.getValue<uint32_t>("attachment", 0);
 		std::vector<ref_ptr<Texture> > textures = fbo->colorTextures();
 		if (attachment >= textures.size()) {
 			REGEN_WARN("FBO " << input.getValue("fbo") <<

--- a/regen/effects/bloom-texture.cpp
+++ b/regen/effects/bloom-texture.cpp
@@ -2,7 +2,7 @@
 
 using namespace regen;
 
-BloomTexture::BloomTexture(GLuint numMips) : TextureMips2D(numMips) {
+BloomTexture::BloomTexture(uint32_t numMips) : TextureMips2D(numMips) {
 	mips_.resize(numMips);
 	mips_[0].texture = this;
 	for (auto i = 0u; i < numMips; ++i) {
@@ -14,7 +14,7 @@ BloomTexture::BloomTexture(GLuint numMips) : TextureMips2D(numMips) {
 	}
 }
 
-void BloomTexture::resize(GLuint width, GLuint height) {
+void BloomTexture::resize(uint32_t width, uint32_t height) {
 	auto i_mipSize = Vec2ui(width, height);
 	auto f_mipSize = Vec2f(
 		static_cast<float>(i_mipSize.x),

--- a/regen/effects/bloom-texture.h
+++ b/regen/effects/bloom-texture.h
@@ -15,11 +15,11 @@ namespace regen {
 			Vec2f sizeInverse;
 		};
 
-		explicit BloomTexture(GLuint numMips = 5);
+		explicit BloomTexture(uint32_t numMips = 5);
 
 		auto &mips() { return mips_; }
 
-		void resize(GLuint width, GLuint height);
+		void resize(uint32_t width, uint32_t height);
 
 	protected:
 		std::vector<Mip> mips_;

--- a/regen/effects/filter.cpp
+++ b/regen/effects/filter.cpp
@@ -47,12 +47,12 @@ ref_ptr<Texture> Filter::createTexture() {
 void Filter::setInput(const ref_ptr<Texture> &input) {
 	set_input(input);
 
-	//GLuint inputSize = min(input_->width(), input_->height());
-	//GLuint bufferSize  = scaleFactor_*inputSize;
-	GLuint bufferW = scaleFactor_ * input_->width();
-	GLuint bufferH = scaleFactor_ * input_->height();
+	//uint32_t inputSize = min(input_->width(), input_->height());
+	//uint32_t bufferSize  = scaleFactor_*inputSize;
+	uint32_t bufferW = scaleFactor_ * input_->width();
+	uint32_t bufferH = scaleFactor_ * input_->height();
 
-	GLuint inputDepth = 1;
+	uint32_t inputDepth = 1;
 	if (dynamic_cast<Texture3D *>(input_.get())) {
 		inputDepth = (dynamic_cast<Texture3D *>(input_.get()))->depth();
 	}
@@ -165,7 +165,7 @@ ref_ptr<FilterSequence> FilterSequence::load(LoadingContext &ctx, scene::SceneIn
 			REGEN_WARN("Unable to find FBO for " << input.getDescription() << ".");
 			return {};
 		}
-		auto attachment = input.getValue<GLuint>("attachment", 0);
+		auto attachment = input.getValue<uint32_t>("attachment", 0);
 		std::vector<ref_ptr<Texture> > textures = fbo->colorTextures();
 		if (attachment >= textures.size()) {
 			REGEN_WARN("FBO " << input.getValue("fbo") <<
@@ -271,9 +271,9 @@ void FilterSequence::createShader(StateConfig &cfg) {
 }
 
 void FilterSequence::resize() {
-	//GLuint size = min(input_->width(), input_->height());
-	GLuint width = input_->width();
-	GLuint height = input_->height();
+	//uint32_t size = min(input_->width(), input_->height());
+	uint32_t width = input_->width();
+	uint32_t height = input_->height();
 	if (width == lastWidth_ && height == lastHeight_) return;
 	lastWidth_ = width;
 	lastHeight_ = height;

--- a/regen/effects/filter.cpp
+++ b/regen/effects/filter.cpp
@@ -116,19 +116,6 @@ FilterSequence::FilterSequence(const ref_ptr<Texture> &input, GLboolean bindInpu
 	internalFormat_ = GL_NONE;
 	pixelType_ = GL_NONE;
 
-	viewport_ = ref_ptr<ShaderInput2f>::alloc("viewport");
-	viewport_->setEditable(false);
-	viewport_->setUniformData(Vec2f(
-			(GLfloat) input->width(), (GLfloat) input->height()));
-
-	inverseViewport_ = ref_ptr<ShaderInput2f>::alloc("inverseViewport");
-	inverseViewport_->setEditable(false);
-	inverseViewport_->setUniformData(Vec2f(
-			1.0f / (GLfloat) input->width(), 1.0f / (GLfloat) input->height()));
-
-	setInput(viewport_);
-	setInput(inverseViewport_);
-
 	ref_ptr<ShaderInput2f> inverseViewport;
 
 	// use layered geometry shader for 3d textures
@@ -223,12 +210,12 @@ const ref_ptr<Texture> &FilterSequence::output() const {
 		// no filter added yet, return identity
 		return input_;
 	}
-	ref_ptr<Filter> lastFilter = *filterSequence_.rbegin();
-	GLenum last = lastFilter->outputAttachment();
+	const FilterData &lastFilter = *filterSequence_.rbegin();
+	GLenum last = lastFilter.filter->outputAttachment();
 	if (last == GL_COLOR_ATTACHMENT0) {
-		return lastFilter->output()->tex0_;
+		return lastFilter.filter->output()->tex0_;
 	} else {
-		return lastFilter->output()->tex1_;
+		return lastFilter.filter->output()->tex1_;
 	}
 }
 
@@ -241,32 +228,40 @@ void FilterSequence::addFilter(const ref_ptr<Filter> &f) {
 		// no filter was added before, create a new framebuffer
 		f->setInput(input_);
 	} else {
-		ref_ptr<Filter> lastFilter = *filterSequence_.rbegin();
+		const FilterData &lastFilter = *filterSequence_.rbegin();
 		// another filter was added before
 		if (math::isApprox(f->scaleFactor(), 1.0)) {
 			// filter does not apply scaling. We gonna ping pong render
 			// to the framebuffer provided by previous filter.
-			f->setInput(lastFilter->output(), lastFilter->outputAttachment());
+			f->setInput(
+				lastFilter.filter->output(),
+				lastFilter.filter->outputAttachment());
 		} else {
 			// create a new framebuffer for this filter
-			GLenum last = lastFilter->outputAttachment();
+			GLenum last = lastFilter.filter->outputAttachment();
 			if (last == GL_COLOR_ATTACHMENT0) {
-				f->setInput(lastFilter->output()->tex0_);
+				f->setInput(lastFilter.filter->output()->tex0_);
 			} else {
-				f->setInput(lastFilter->output()->tex1_);
+				f->setInput(lastFilter.filter->output()->tex1_);
 			}
 		}
 	}
 
-	filterSequence_.push_back(f);
+	auto &data = filterSequence_.emplace_back();
+	data.filter = f;
+	data.viewport = ref_ptr<ShaderInput2f>::alloc("viewport");
+	data.viewport->setUniformData(Vec2f::zero());
+	data.inverseViewport = ref_ptr<ShaderInput2f>::alloc("inverseViewport");
+	data.inverseViewport->setUniformData(Vec2f::zero());
 }
 
 void FilterSequence::createShader(StateConfig &cfg) {
 	for (auto &it: filterSequence_) {
-		auto *f = (Filter *) it.get();
 		StateConfigurer _cfg(cfg);
-		_cfg.addState(f);
-		f->createShader(_cfg.cfg());
+		_cfg.addState(it.filter.get());
+		_cfg.addInput(it.viewport->name(), it.viewport);
+		_cfg.addInput(it.inverseViewport->name(), it.inverseViewport);
+		it.filter->createShader(_cfg.cfg());
 	}
 }
 
@@ -280,7 +275,7 @@ void FilterSequence::resize() {
 
 	FBO *last = nullptr;
 	for (auto &it: filterSequence_) {
-		auto *f = (Filter *) it.get();
+		auto *f = it.filter.get();
 		FBO *fbo = f->output()->fbo_.get();
 
 		if (last != fbo) {
@@ -288,6 +283,11 @@ void FilterSequence::resize() {
 			height *= f->scaleFactor();
 			fbo->resize(width, height, fbo->depth());
 		}
+
+		it.viewport->setVertex(0,
+			fbo->viewport()->getVertex(0).r);
+		it.inverseViewport->setVertex(0,
+			fbo->inverseViewport()->getVertex(0).r);
 
 		last = fbo;
 	}
@@ -301,20 +301,18 @@ void FilterSequence::enable(RenderState *rs) {
 	resize();
 
 	if (clearFirstFilter_) {
-		Filter *firstFilter = (Filter *) (*filterSequence_.begin()).get();
+		Filter *firstFilter = (*filterSequence_.begin()).filter.get();
 		firstFilter->output()->fbo_->clearAllColorAttachments(clearColor_);
 	}
 	auto oldViewport = rs->viewport().current();
 	auto oldDrawFBO = rs->drawFrameBuffer().current();
 
 	for (auto &it: filterSequence_) {
-		auto *f = (Filter *) it.get();
+		auto *f = it.filter.get();
 
 		FBO *fbo = f->output()->fbo_.get();
 		rs->drawFrameBuffer().apply(fbo->id());
 		rs->viewport().apply(fbo->glViewport());
-		viewport_->setVertex(0, fbo->viewport()->getVertex(0).r);
-		inverseViewport_->setVertex(0, fbo->inverseViewport()->getVertex(0).r);
 
 		f->enable(rs);
 		f->disable(rs);

--- a/regen/effects/filter.h
+++ b/regen/effects/filter.h
@@ -161,10 +161,13 @@ namespace regen {
 		void enable(RenderState *state) override;
 
 	protected:
-		std::list<ref_ptr<Filter> > filterSequence_;
+		struct FilterData {
+			ref_ptr<Filter> filter;
+			ref_ptr<ShaderInput2f> viewport;
+			ref_ptr<ShaderInput2f> inverseViewport;
+		};
+		std::list<FilterData> filterSequence_;
 		ref_ptr<Texture> input_;
-		ref_ptr<ShaderInput2f> viewport_;
-		ref_ptr<ShaderInput2f> inverseViewport_;
 
 		bool clearFirstFilter_;
 		Vec4f clearColor_;

--- a/regen/gl-types/atomic-counter.cpp
+++ b/regen/gl-types/atomic-counter.cpp
@@ -26,10 +26,10 @@ BoundingBoxCounter::BoundingBoxCounter() :
 }
 
 Bounds<Vec3f> &BoundingBoxCounter::updateBounds() {
-	auto *ptr = (GLuint *) glMapNamedBufferRange(
+	auto *ptr = (uint32_t *) glMapNamedBufferRange(
 			ref_->bufferID(),
 			ref_->address(),
-			sizeof(GLuint) * 6,
+			sizeof(uint32_t) * 6,
 			GL_MAP_READ_BIT | GL_MAP_WRITE_BIT);
 
 	auto localData = &bounds_.min.x;

--- a/regen/gl-types/atomic-counter.h
+++ b/regen/gl-types/atomic-counter.h
@@ -34,7 +34,7 @@ namespace regen {
 		Bounds<Vec3f> &bounds() { return bounds_; }
 
 	protected:
-		GLuint initialData_[6];
+		uint32_t initialData_[6];
 		Bounds<Vec3f> bounds_;
 		ref_ptr<BufferReference> ref_;
 	};

--- a/regen/gl-types/draw-command.h
+++ b/regen/gl-types/draw-command.h
@@ -7,17 +7,17 @@ namespace regen {
 	/**
 	 * This is used to unify the following two structures:
 	 *     struct IndirectIndexedData {
-	 *        GLuint count;           // index count
-	 *        GLuint instanceCount;
-	 *        GLuint firstIndex;
+	 *        uint32_t count;           // index count
+	 *        uint32_t instanceCount;
+	 *        uint32_t firstIndex;
 	 *        GLint baseVertex;
-	 *        GLuint baseInstance;
+	 *        uint32_t baseInstance;
 	 *    };
 	 *    struct IndirectArrayData {
-	 *        GLuint count;           // vertex count
-	 *        GLuint instanceCount;
-	 *        GLuint firstVertex;
-	 *        GLuint baseInstance;
+	 *        uint32_t count;           // vertex count
+	 *        uint32_t instanceCount;
+	 *        uint32_t firstVertex;
+	 *        uint32_t baseInstance;
 	 *    };
 	 **/
 	struct DrawCommand {

--- a/regen/gl-types/gl-enum.cpp
+++ b/regen/gl-types/gl-enum.cpp
@@ -85,7 +85,7 @@ std::string glenum::glslStagePrefix(GLenum stage) {
 	}
 }
 
-GLenum glenum::dataType(GLenum pixelType, GLuint valsPerElement) {
+GLenum glenum::dataType(GLenum pixelType, uint32_t valsPerElement) {
 	// compose complex data type from base type and number of components
 	switch (pixelType) {
 		case GL_FLOAT:
@@ -171,7 +171,7 @@ GLenum glenum::dataType(GLenum pixelType, GLuint valsPerElement) {
 	return GL_RGBA32F;
 }
 
-std::string glenum::glslDataType(GLenum pixelType, GLuint valsPerElement) {
+std::string glenum::glslDataType(GLenum pixelType, uint32_t valsPerElement) {
 	switch (pixelType) {
 		case GL_BYTE:
 		case GL_UNSIGNED_BYTE:

--- a/regen/gl-types/gl-enum.h
+++ b/regen/gl-types/gl-enum.h
@@ -110,7 +110,7 @@ namespace regen {
 		 * @param val the type string.
 		 * @return 1, 2, 3 or 4.
 		 */
-		inline GLuint pixelComponents(GLenum format) {
+		inline uint32_t pixelComponents(GLenum format) {
 			switch (format) {
 				case GL_RED:
 				case GL_GREEN:
@@ -142,7 +142,7 @@ namespace regen {
 		 * @param numComponents Number of components per texel.
 		 * @return On of the GL_R,GL_RG,GL_RGB,GL_RGBA constants.
 		 */
-		inline GLenum textureFormat(GLuint numComponents) {
+		inline GLenum textureFormat(uint32_t numComponents) {
 			switch (numComponents) {
 				case 1:
 					return GL_RED;
@@ -188,13 +188,13 @@ namespace regen {
 		 * @param bytesPerComponent bytes per component.
 		 * @return On of the GL_R,GL_RG,GL_RGB,GL_RGBA constants.
 		 */
-		inline GLenum textureInternalFormat(GLenum pixelType, GLuint numComponents, GLuint bytesPerComponent) {
-			GLuint i = 1;
+		inline GLenum textureInternalFormat(GLenum pixelType, uint32_t numComponents, uint32_t bytesPerComponent) {
+			uint32_t i = 1;
 			if (bytesPerComponent <= 8) i = 0;
 			else if (bytesPerComponent <= 16) i = 1;
 			else if (bytesPerComponent <= 32) i = 2;
 
-			GLuint j = numComponents - 1;
+			uint32_t j = numComponents - 1;
 
 			if (pixelType == GL_FLOAT || pixelType == GL_DOUBLE || pixelType == GL_HALF_FLOAT) {
 				static GLenum values[3][4] = {
@@ -258,7 +258,7 @@ namespace regen {
 		/**
 		 * Maps [0,5] to cube map layer enum.
 		 */
-		inline GLenum cubeMapLayer(GLuint layer) {
+		inline GLenum cubeMapLayer(uint32_t layer) {
 			const GLenum cubeMapLayer[] = {
 					GL_TEXTURE_CUBE_MAP_POSITIVE_Z,
 					GL_TEXTURE_CUBE_MAP_NEGATIVE_Z,
@@ -293,14 +293,14 @@ namespace regen {
 		/**
 		 * Maps pixel type and values per element to the GLSL data type.
 		 */
-		std::string glslDataType(GLenum pixelType, GLuint valsPerElement);
+		std::string glslDataType(GLenum pixelType, uint32_t valsPerElement);
 
 		/**
 		 * @param baseType the base type of the data, e.g. GL_FLOAT
 		 * @param valsPerElement the number of values per element, e.g. 4
 		 * @return the data type for the shader, e.g. GL_RGBA32F
 		 */
-		GLenum dataType(GLenum baseType, GLuint valsPerElement);
+		GLenum dataType(GLenum baseType, uint32_t valsPerElement);
 
 		/**
 		 * True if the data type is a signed integer type.

--- a/regen/gl-types/gl-object.cpp
+++ b/regen/gl-types/gl-object.cpp
@@ -5,8 +5,8 @@ using namespace regen;
 GLObject::GLObject(
 		CreateObjectFunc createObjects,
 		ReleaseObjectFunc releaseObjects,
-		GLuint numObjects)
-		: ids_(new GLuint[numObjects]),
+		uint32_t numObjects)
+		: ids_(new uint32_t[numObjects]),
 		  copyCounter_(ref_ptr<std::atomic<uint32_t>>::alloc(1)),
 		  numObjects_(numObjects),
 		  objectIndex_(0),
@@ -20,8 +20,8 @@ GLObject::GLObject(
 		CreateObjectFunc2 createObjects,
 		ReleaseObjectFunc releaseObjects,
 		GLenum objectTarget,
-		GLuint numObjects)
-		: ids_(new GLuint[numObjects]),
+		uint32_t numObjects)
+		: ids_(new uint32_t[numObjects]),
 		  copyCounter_(ref_ptr<std::atomic<uint32_t>>::alloc(1)),
 		  numObjects_(numObjects),
 		  objectIndex_(0),

--- a/regen/gl-types/gl-object.h
+++ b/regen/gl-types/gl-object.h
@@ -21,17 +21,17 @@ namespace regen {
 		/**
 		 * Obtain n buffers.
 		 */
-		typedef void (GLAPIENTRY *CreateObjectFunc)(GLsizei n, GLuint *buffers);
+		typedef void (GLAPIENTRY *CreateObjectFunc)(GLsizei n, uint32_t *buffers);
 
 		/**
 		 * Obtain n buffers.
 		 */
-		typedef void (GLAPIENTRY *CreateObjectFunc2)(GLenum target, GLsizei n, GLuint *buffers);
+		typedef void (GLAPIENTRY *CreateObjectFunc2)(GLenum target, GLsizei n, uint32_t *buffers);
 
 		/**
 		 * Release n buffers.
 		 */
-		typedef void (GLAPIENTRY *ReleaseObjectFunc)(GLsizei n, const GLuint *buffers);
+		typedef void (GLAPIENTRY *ReleaseObjectFunc)(GLsizei n, const uint32_t *buffers);
 
 		/**
 		 * @param createObjects allocate buffers.
@@ -96,7 +96,7 @@ namespace regen {
 		uint32_t *ids() const { return ids_; }
 
 	protected:
-		GLuint *ids_;
+		uint32_t *ids_;
 		// an atomic copy counter, for protecting deletion of shared data
 		ref_ptr<std::atomic<uint32_t>> copyCounter_;
 		uint32_t numObjects_;

--- a/regen/gl-types/gl-param.cpp
+++ b/regen/gl-types/gl-param.cpp
@@ -59,7 +59,7 @@ namespace regen {
 		if (it != store.params_.end()) {
 			return it->second;
 		} else {
-			GLuint value;
+			uint32_t value;
 			glGetIntegerv(param, (GLint *) &value);
 			store.params_[param] = value;
 			return value;

--- a/regen/gl-types/gl-rectangle.cpp
+++ b/regen/gl-types/gl-rectangle.cpp
@@ -5,7 +5,7 @@ using namespace regen;
 GLRectangle::GLRectangle(
 		CreateObjectFunc createObjects,
 		ReleaseObjectFunc releaseObjects,
-		GLuint numObjects)
+		uint32_t numObjects)
 		: GLObject(createObjects, releaseObjects, numObjects) {
 	set_rectangleSize(2, 2);
 }
@@ -14,7 +14,7 @@ GLRectangle::GLRectangle(
 		CreateObjectFunc2 createObjects,
 		ReleaseObjectFunc releaseObjects,
 		GLenum objectTarget,
-		GLuint numObjects)
+		uint32_t numObjects)
 		: GLObject(createObjects, releaseObjects, objectTarget, numObjects) {
 	set_rectangleSize(2, 2);
 }

--- a/regen/gl-types/gl-rectangle.h
+++ b/regen/gl-types/gl-rectangle.h
@@ -18,7 +18,7 @@ namespace regen {
 		GLRectangle(
 				CreateObjectFunc createObjects,
 				ReleaseObjectFunc releaseObjects,
-				GLuint numObjects = 1);
+				uint32_t numObjects = 1);
 
 		/**
 		 * @param createObjects allocate buffers.
@@ -29,7 +29,7 @@ namespace regen {
 				CreateObjectFunc2 createObjects,
 				ReleaseObjectFunc releaseObjects,
 				GLenum objectTarget,
-				GLuint numObjects = 1);
+				uint32_t numObjects = 1);
 
 		/**
 		 * Copy constructor.

--- a/regen/gl-types/gl-util.cpp
+++ b/regen/gl-types/gl-util.cpp
@@ -76,8 +76,8 @@ namespace regen {
 
 #endif
 
-	GLuint getGLQueryResult(GLuint query) {
-		GLuint v = 0;
+	uint32_t getGLQueryResult(uint32_t query) {
+		uint32_t v = 0;
 		glGetQueryObjectuiv(query, GL_QUERY_RESULT, &v);
 		return v;
 	}

--- a/regen/gl-types/gl-util.h
+++ b/regen/gl-types/gl-util.h
@@ -59,7 +59,7 @@ namespace regen {
 	/**
 	 * Query a GL query result.
 	 */
-	GLuint getGLQueryResult(GLuint query);
+	uint32_t getGLQueryResult(uint32_t query);
 
 	/**
 	 * Query a GL integer attribute.

--- a/regen/gl-types/input-location.h
+++ b/regen/gl-types/input-location.h
@@ -10,7 +10,7 @@ namespace regen {
 	struct InputLocation {
 		ref_ptr<ShaderInput> input; /**< the shader input. */
 		GLint location; /**< the input location. */
-		GLuint uploadStamp; /**< time stamp of last upload. */
+		uint32_t uploadStamp; /**< time stamp of last upload. */
 		/**
 		 * @param _input input data.
 		 * @param _location input location in shader.

--- a/regen/gl-types/queries/elapsed-time.h
+++ b/regen/gl-types/queries/elapsed-time.h
@@ -11,7 +11,7 @@ namespace regen {
 
 	protected:
 		float readQueryResult() const override {
-			GLuint64 elapsedNano;
+			uint64_t elapsedNano;
 			glGetQueryObjectui64v(id(), GL_QUERY_RESULT, &elapsedNano);
 			return elapsedNano * 1e-6f; // Convert nanoseconds to milliseconds
 		}

--- a/regen/gl-types/render-state.cpp
+++ b/regen/gl-types/render-state.cpp
@@ -40,19 +40,19 @@ using namespace regen;
 
 static inline void Regen_BlendEquation(const BlendEquation &v) { glBlendEquationSeparate(v.x, v.y); }
 
-static inline void Regen_BlendEquationi(GLuint i, const BlendEquation &v) { glBlendEquationSeparatei(i, v.x, v.y); }
+static inline void Regen_BlendEquationi(uint32_t i, const BlendEquation &v) { glBlendEquationSeparatei(i, v.x, v.y); }
 
 static inline void Regen_BlendFunc(const BlendFunction &v) { glBlendFuncSeparate(v.x, v.y, v.z, v.w); }
 
-static inline void Regen_BlendFunci(GLuint i, const BlendFunction &v) { glBlendFuncSeparatei(i, v.x, v.y, v.z, v.w); }
+static inline void Regen_BlendFunci(uint32_t i, const BlendFunction &v) { glBlendFuncSeparatei(i, v.x, v.y, v.z, v.w); }
 
 static inline void Regen_ColorMask(const ColorMask &v) { glColorMask(v.x, v.y, v.z, v.w); }
 
-static inline void Regen_ColorMaski(GLuint i, const ColorMask &v) { glColorMaski(i, v.x, v.y, v.z, v.w); }
+static inline void Regen_ColorMaski(uint32_t i, const ColorMask &v) { glColorMaski(i, v.x, v.y, v.z, v.w); }
 
 static inline void Regen_DepthRange(const DepthRange &v) { glDepthRange(v.x, v.y); }
 
-static inline void Regen_DepthRangei(GLuint i, const DepthRange &v) { glDepthRangeIndexed(i, v.x, v.y); }
+static inline void Regen_DepthRangei(uint32_t i, const DepthRange &v) { glDepthRangeIndexed(i, v.x, v.y); }
 
 static inline void Regen_StencilOp(const StencilOp &v) { glStencilOp(v.x, v.y, v.z); }
 
@@ -64,25 +64,25 @@ static inline void Regen_BlendColor(const Vec4f &v) { glBlendColor(v.x, v.y, v.z
 
 static inline void Regen_Scissor(const Scissor &v) { glScissor(v.x, v.y, v.z, v.w); }
 
-static inline void Regen_Scissori(GLuint i, const Scissor &v) { glScissorIndexed(i, v.x, v.y, v.z, v.w); }
+static inline void Regen_Scissori(uint32_t i, const Scissor &v) { glScissorIndexed(i, v.x, v.y, v.z, v.w); }
 
 static inline void Regen_Viewport(const Viewport &v) { glViewport(v.x, v.y, v.z, v.w); }
 
-static inline void Regen_Texture(GLuint i, const TextureBind &v) { glBindTextureUnit(i, v.id_); }
+static inline void Regen_Texture(uint32_t i, const TextureBind &v) { glBindTextureUnit(i, v.id_); }
 
-static inline void Regen_UniformBufferRange(GLuint i, const BufferRange &v) {
+static inline void Regen_UniformBufferRange(uint32_t i, const BufferRange &v) {
 	// NOTE: When buffer `i` is bound to another target, e.g. GL_SHADER_STORAGE_BUFFER or so,
 	//       then binding it to GL_UNIFORM_BUFFER causes undefined behaviour on some drivers.
 	//       Here, it is considered as an application error, to avoid extra bookkeeping.
 	glBindBufferRange(GL_UNIFORM_BUFFER, i, v.buffer_, v.offset_, v.size_);
 }
-static inline void Regen_FeedbackBufferRange(GLuint i, const BufferRange &v) {
+static inline void Regen_FeedbackBufferRange(uint32_t i, const BufferRange &v) {
 	glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, i, v.buffer_, v.offset_, v.size_);
 }
-static inline void Regen_AtomicCounterBufferRange(GLuint i, const BufferRange &v) {
+static inline void Regen_AtomicCounterBufferRange(uint32_t i, const BufferRange &v) {
 	glBindBufferRange(GL_ATOMIC_COUNTER_BUFFER, i, v.buffer_, v.offset_, v.size_);
 }
-static inline void Regen_ShaderStorageBufferRange(GLuint i, const BufferRange &v) {
+static inline void Regen_ShaderStorageBufferRange(uint32_t i, const BufferRange &v) {
 	glBindBufferRange(GL_SHADER_STORAGE_BUFFER, i, v.buffer_, v.offset_, v.size_);
 }
 
@@ -93,7 +93,7 @@ static inline void Regen_PatchLevel(const PatchLevels &l) {
 
 typedef void (GLAPIENTRY *ToggleFunc)(GLenum);
 
-inline void Regen_Toggle(GLuint index, const GLboolean &v) {
+inline void Regen_Toggle(uint32_t index, const GLboolean &v) {
 	GLenum toggleID = RenderState::toggleToID((RenderState::Toggle) index);
 	static ToggleFunc toggleFunctions[2] = {glDisable, glEnable};
 	toggleFunctions[v](toggleID);
@@ -260,7 +260,7 @@ RenderState::RenderState()
 		if (e == GL_NONE) continue;
 
 		GLboolean enabled = GL_FALSE;
-		for (GLuint j = 0; j < sizeof(enabledToggles) / sizeof(GLenum); ++j) {
+		for (uint32_t j = 0; j < sizeof(enabledToggles) / sizeof(GLenum); ++j) {
 			if (enabledToggles[j] == e) {
 				enabled = GL_TRUE;
 				break;
@@ -295,7 +295,7 @@ RenderState::RenderState()
 	GL_ERROR_LOG();
 }
 
-KeyedStateStack<GLuint>& RenderState::buffer(GLenum target) {
+KeyedStateStack<uint32_t>& RenderState::buffer(GLenum target) {
 	switch (target) {
 		case GL_UNIFORM_BUFFER:
 			return uniformBuffer_;
@@ -364,7 +364,7 @@ static inline int bufferBaseIndex(GLenum target) {
 	}
 }
 
-void RenderState::bindBufferBase(GLenum target, GLuint index, GLuint buffer) {
+void RenderState::bindBufferBase(GLenum target, uint32_t index, uint32_t buffer) {
 	auto arrayIndex = bufferBaseIndex(target);
 	auto &bindings = bufferBaseBindings_[arrayIndex];
 	auto needle = bindings.find(index);

--- a/regen/gl-types/render-state.h
+++ b/regen/gl-types/render-state.h
@@ -37,7 +37,7 @@ namespace regen {
 		/** specifies a mask that is ANDed with both the reference value
 		 * and the stored stencil value when the test is done.
 		 * The initial value is all 1's. */
-		GLuint mask_;
+		uint32_t mask_;
 
 		/**
 		 * @param b another value.
@@ -85,7 +85,7 @@ namespace regen {
 		 * @param target Specifies the target to which the texture is bound.
 		 * @param id Specifies the name of a texture.
 		 */
-		TextureBind(GLenum target, GLuint id)
+		TextureBind(GLenum target, uint32_t id)
 				: target_(target), id_(id) {}
 
 		TextureBind()
@@ -94,7 +94,7 @@ namespace regen {
 		/** Specifies the target to which the texture is bound. */
 		GLenum target_;
 		/** Specifies the name of a texture. */
-		GLuint id_;
+		uint32_t id_;
 
 		/**
 		 * @param b another value.
@@ -112,14 +112,14 @@ namespace regen {
 		 * @param offset The starting offset in basic machine units into the buffer object buffer.
 		 * @param size The amount of data in machine units that can be read from the buffet object while used as an indexed target.
 		 */
-		BufferRange(GLuint buffer, GLintptr offset, GLsizeiptr size)
+		BufferRange(uint32_t buffer, GLintptr offset, GLsizeiptr size)
 				: buffer_(buffer), offset_(offset), size_(size) {}
 
 		BufferRange()
 				: buffer_(0), offset_(0), size_(0) {}
 
 		/** The name of a buffer object to bind to the specified binding point. */
-		GLuint buffer_;
+		uint32_t buffer_;
 		/** The starting offset in basic machine units into the buffer object buffer. */
 		GLintptr offset_;
 		/** The amount of data in machine units that can be read from the buffet object while used as an indexed target. */
@@ -363,83 +363,83 @@ namespace regen {
 		/**
 		 * bind a buffer to given target.
 		 */
-		KeyedStateStack<GLuint>& buffer(GLenum target);
+		KeyedStateStack<uint32_t>& buffer(GLenum target);
 
 		/**
 		 * bind a named buffer object to GL_ARRAY_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &arrayBuffer() { return arrayBuffer_; }
+		inline KeyedStateStack<uint32_t> &arrayBuffer() { return arrayBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_TRANSFORM_FEEDBACK_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &feedbackBuffer() { return feedbackBuffer_; }
+		inline KeyedStateStack<uint32_t> &feedbackBuffer() { return feedbackBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_SHADER_STORAGE_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &shaderStorageBuffer() { return shaderStorageBuffer_; }
+		inline KeyedStateStack<uint32_t> &shaderStorageBuffer() { return shaderStorageBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_UNIFORM_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &uniformBuffer() { return uniformBuffer_; }
+		inline KeyedStateStack<uint32_t> &uniformBuffer() { return uniformBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_PIXEL_PACK_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &pixelPackBuffer() { return pixelPackBuffer_; }
+		inline KeyedStateStack<uint32_t> &pixelPackBuffer() { return pixelPackBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_PIXEL_UNPACK_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &pixelUnpackBuffer() { return pixelUnpackBuffer_; }
+		inline KeyedStateStack<uint32_t> &pixelUnpackBuffer() { return pixelUnpackBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_DISPATCH_INDIRECT_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &dispatchIndirectBuffer() { return dispatchIndirectBuffer_; }
+		inline KeyedStateStack<uint32_t> &dispatchIndirectBuffer() { return dispatchIndirectBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_DRAW_INDIRECT_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &drawIndirectBuffer() { return drawIndirectBuffer_; }
+		inline KeyedStateStack<uint32_t> &drawIndirectBuffer() { return drawIndirectBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_TEXTURE_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &textureBuffer() { return textureBuffer_; }
+		inline KeyedStateStack<uint32_t> &textureBuffer() { return textureBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_COPY_READ_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &copyReadBuffer() { return copyReadBuffer_; }
+		inline KeyedStateStack<uint32_t> &copyReadBuffer() { return copyReadBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_COPY_WRITE_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &copyWriteBuffer() { return copyWriteBuffer_; }
+		inline KeyedStateStack<uint32_t> &copyWriteBuffer() { return copyWriteBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_RENDERBUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &renderBuffer() { return renderBuffer_; }
+		inline KeyedStateStack<uint32_t> &renderBuffer() { return renderBuffer_; }
 
 		/**
 		 * bind a named buffer object to GL_ATOMIC_COUNTER_BUFFER target.
 		 */
-		inline KeyedStateStack<GLuint> &atomicCounterBuffer() { return atomicCounterBuffer_; }
+		inline KeyedStateStack<uint32_t> &atomicCounterBuffer() { return atomicCounterBuffer_; }
 
 		/**
 		 * bind a buffer object to a target.
 		 */
-		void bindBufferBase(GLenum target, GLuint index, GLuint buffer);
+		void bindBufferBase(GLenum target, uint32_t index, uint32_t buffer);
 
 		/**
 		 * Vertex Array Objects (VAO) are OpenGL Objects that store the
 		 * set of bindings between Vertex Attributes and the user's source vertex data.
 		 */
-		inline ByValueStateStack<GLuint> &vao() { return vao_; }
+		inline ByValueStateStack<uint32_t> &vao() { return vao_; }
 
 		/**
 		 * bind a named buffer object to GL_UNIFORM_BUFFER target.
@@ -469,12 +469,12 @@ namespace regen {
 		/**
 		 * Bind a framebuffer to the framebuffer read target.
 		 */
-		inline KeyedStateStack<GLuint> &readFrameBuffer() { return readFrameBuffer_; }
+		inline KeyedStateStack<uint32_t> &readFrameBuffer() { return readFrameBuffer_; }
 
 		/**
 		 * Bind a framebuffer to the framebuffer draw target.
 		 */
-		inline KeyedStateStack<GLuint> &drawFrameBuffer() { return drawFrameBuffer_; }
+		inline KeyedStateStack<uint32_t> &drawFrameBuffer() { return drawFrameBuffer_; }
 
 		/**
 		 * Set the framebuffer viewport.
@@ -489,7 +489,7 @@ namespace regen {
 		/**
 		 * Installs a program object as part of current rendering state.
 		 */
-		inline ByValueStateStack<GLuint> &shader() { return shader_; }
+		inline ByValueStateStack<uint32_t> &shader() { return shader_; }
 
 		/**
 		 * Define the scissor box for a specific viewport.
@@ -588,7 +588,7 @@ namespace regen {
 		 * Specifies a bit mask to enable and disable writing of individual bits
 		 * in the stencil planes. Initially, the mask is all 1's.
 		 */
-		inline ByValueStateStack<GLuint> &stencilMask() { return stencilMask_; }
+		inline ByValueStateStack<uint32_t> &stencilMask() { return stencilMask_; }
 
 		/**
 		 * Set front and back stencil test actions.
@@ -690,32 +690,32 @@ namespace regen {
 
 		IndexedStateStack<GLboolean> toggles_;
 
-		std::map<GLuint,GLuint> bufferBaseBindings_[4];
-		KeyedStateStack<GLuint> arrayBuffer_;
-		KeyedStateStack<GLuint> feedbackBuffer_;
-		KeyedStateStack<GLuint> uniformBuffer_;
-		KeyedStateStack<GLuint> shaderStorageBuffer_;
-		KeyedStateStack<GLuint> pixelPackBuffer_;
-		KeyedStateStack<GLuint> pixelUnpackBuffer_;
-		KeyedStateStack<GLuint> dispatchIndirectBuffer_;
-		KeyedStateStack<GLuint> drawIndirectBuffer_;
-		KeyedStateStack<GLuint> textureBuffer_;
-		KeyedStateStack<GLuint> copyReadBuffer_;
-		KeyedStateStack<GLuint> copyWriteBuffer_;
-		KeyedStateStack<GLuint> renderBuffer_;
-		KeyedStateStack<GLuint> atomicCounterBuffer_;
-		ByValueStateStack<GLuint> vao_;
+		std::map<uint32_t,uint32_t> bufferBaseBindings_[4];
+		KeyedStateStack<uint32_t> arrayBuffer_;
+		KeyedStateStack<uint32_t> feedbackBuffer_;
+		KeyedStateStack<uint32_t> uniformBuffer_;
+		KeyedStateStack<uint32_t> shaderStorageBuffer_;
+		KeyedStateStack<uint32_t> pixelPackBuffer_;
+		KeyedStateStack<uint32_t> pixelUnpackBuffer_;
+		KeyedStateStack<uint32_t> dispatchIndirectBuffer_;
+		KeyedStateStack<uint32_t> drawIndirectBuffer_;
+		KeyedStateStack<uint32_t> textureBuffer_;
+		KeyedStateStack<uint32_t> copyReadBuffer_;
+		KeyedStateStack<uint32_t> copyWriteBuffer_;
+		KeyedStateStack<uint32_t> renderBuffer_;
+		KeyedStateStack<uint32_t> atomicCounterBuffer_;
+		ByValueStateStack<uint32_t> vao_;
 
 		IndexedStateStack<BufferRange> uniformBufferRange_;
 		IndexedStateStack<BufferRange> feedbackBufferRange_;
 		IndexedStateStack<BufferRange> atomicCounterBufferRange_;
 		IndexedStateStack<BufferRange> ssboRange_;
 
-		KeyedStateStack<GLuint> readFrameBuffer_;
-		KeyedStateStack<GLuint> drawFrameBuffer_;
+		KeyedStateStack<uint32_t> readFrameBuffer_;
+		KeyedStateStack<uint32_t> drawFrameBuffer_;
 		ByReferenceStateStack<Viewport> viewport_;
 
-		ByValueStateStack<GLuint> shader_;
+		ByValueStateStack<uint32_t> shader_;
 
 		IndexedStateStack<TextureBind> textures_;
 
@@ -730,7 +730,7 @@ namespace regen {
 		IndexedStateStack<BlendEquation> blendEquation_;
 		IndexedStateStack<BlendFunction> blendFunc_;
 
-		ByValueStateStack<GLuint> stencilMask_;
+		ByValueStateStack<uint32_t> stencilMask_;
 		ByReferenceStateStack<StencilFunc> stencilFunc_;
 		ByReferenceStateStack<StencilOp> stencilOp_;
 

--- a/regen/objects/assimp-importer.h
+++ b/regen/objects/assimp-importer.h
@@ -202,7 +202,7 @@ namespace regen {
 		std::vector<ref_ptr<Mesh> > loadMeshes(
 				const Mat4f &transform,
 				const BufferFlags &bufferFlags,
-				const std::vector<GLuint> &meshIndices);
+				const std::vector<uint32_t> &meshIndices);
 
 		/**
 		 * @return the material associated to a previously loaded meshes.
@@ -217,7 +217,7 @@ namespace regen {
 		/**
 		 * @return number of weights used for bone animation.
 		 */
-		GLuint numBoneWeights(Mesh *meshState);
+		uint32_t numBoneWeights(Mesh *meshState);
 
 		static ref_ptr<AssetImporter> load(LoadingContext &ctx, scene::SceneInputNode &input);
 
@@ -261,8 +261,8 @@ namespace regen {
 				const struct aiNode &node,
 				const Mat4f &transform,
 				const BufferFlags &bufferFlags,
-				const std::vector<GLuint> &meshIndices,
-				GLuint &currentIndex,
+				const std::vector<uint32_t> &meshIndices,
+				uint32_t &currentIndex,
 				std::vector<ref_ptr<Mesh> > &out);
 
 		ref_ptr<Mesh> loadMesh(

--- a/regen/objects/assimp-importer.h
+++ b/regen/objects/assimp-importer.h
@@ -178,11 +178,6 @@ namespace regen {
 		std::vector<ref_ptr<Material> > &materials() { return materials_; }
 
 		/**
-		 * @return a node that animates the light position.
-		 */
-		ref_ptr<LightNode> loadLightNode(const ref_ptr<Light> &light);
-
-		/**
 		 * Create Mesh instances from Asset file.
 		 * Import all meshes defined in Asset file.
 		 * @param transform Transformation applied during import.
@@ -230,7 +225,7 @@ namespace regen {
 
 		ref_ptr<BoneTree> nodeAnimation_;
 		// name to node map
-		std::map<std::string, struct aiNode *> nodes_;
+		std::map<std::string, struct aiNode *> aiBoneNodes_;
 		// root node of skeleton
 		ref_ptr<BoneNode> rootNode_;
 		// maps assimp bone nodes to Bone implementation
@@ -272,9 +267,10 @@ namespace regen {
 
 		void loadNodeAnimation(const AssimpAnimationConfig &animConfig);
 
-		ref_ptr<BoneNode> loadNodeTree();
+		ref_ptr<BoneNode> loadNodeTree(std::vector<ref_ptr<BoneNode>> &nodes);
 
-		ref_ptr<BoneNode> loadNodeTree(struct aiNode *assimpNode, const ref_ptr<BoneNode> &parent);
+		ref_ptr<BoneNode> loadNodeTree(std::vector<ref_ptr<BoneNode>> &nodes,
+			aiNode *assimpNode, const ref_ptr<BoneNode> &parent);
 	};
 } // namespace
 

--- a/regen/objects/attribute-less-mesh.cpp
+++ b/regen/objects/attribute-less-mesh.cpp
@@ -2,7 +2,7 @@
 
 using namespace regen;
 
-AttributeLessMesh::AttributeLessMesh(GLuint numVertices)
+AttributeLessMesh::AttributeLessMesh(uint32_t numVertices)
 		: Mesh(GL_POINTS, BufferUpdateFlags::NEVER) {
 	set_numVertices(numVertices);
 }

--- a/regen/objects/attribute-less-mesh.h
+++ b/regen/objects/attribute-less-mesh.h
@@ -16,7 +16,7 @@ namespace regen {
 		/**
 		 * @param numVertices number of vertices used.
 		 */
-		explicit AttributeLessMesh(GLuint numVertices);
+		explicit AttributeLessMesh(uint32_t numVertices);
 	};
 } // namespace
 

--- a/regen/objects/composite-mesh.h
+++ b/regen/objects/composite-mesh.h
@@ -71,7 +71,7 @@ namespace regen {
 		                                                  const ref_ptr<AssetImporter> &importer);
 
 		static ref_ptr<Particles> createParticleMesh(LoadingContext &ctx, scene::SceneInputNode &input,
-		                                             const GLuint numParticles);
+		                                             const uint32_t numParticles);
 
 		static ref_ptr<TextureMappedText> createTextMesh(LoadingContext &ctx, scene::SceneInputNode &input);
 	};

--- a/regen/objects/lod/tessellation.cpp
+++ b/regen/objects/lod/tessellation.cpp
@@ -11,7 +11,7 @@
 #include "tessellation.h"
 
 struct Edge {
-    GLuint v1, v2;
+    uint32_t v1, v2;
     bool operator==(const Edge &other) const {
         return (v1 == other.v1 && v2 == other.v2) || (v1 == other.v2 && v2 == other.v1);
     }
@@ -21,7 +21,7 @@ namespace std {
     template <>
     struct hash<Edge> {
         std::size_t operator()(const Edge &e) const {
-            return std::hash<GLuint>()(e.v1) ^ std::hash<GLuint>()(e.v2);
+            return std::hash<uint32_t>()(e.v1) ^ std::hash<uint32_t>()(e.v2);
         }
     };
 }

--- a/regen/objects/mesh.cpp
+++ b/regen/objects/mesh.cpp
@@ -176,7 +176,7 @@ void Mesh::set_indexOffset(uint32_t v) {
 	if (shared_->indices_.get()) { shared_->indices_->set_offset(v); }
 }
 
-GLuint Mesh::indexBuffer() const {
+uint32_t Mesh::indexBuffer() const {
 	return elementBuffer_.get() ? elementBuffer_->bufferID() : 0;
 }
 

--- a/regen/objects/particles.cpp
+++ b/regen/objects/particles.cpp
@@ -10,7 +10,7 @@ using namespace regen;
 
 ///////////
 
-Particles::Particles(GLuint numParticles, const std::string &updateShaderKey)
+Particles::Particles(uint32_t numParticles, const std::string &updateShaderKey)
 		: Mesh(GL_POINTS, BufferUpdateFlags::NEVER, VERTEX_LAYOUT_INTERLEAVED),
 		  Animation(true, false),
 		  updateShaderKey_(updateShaderKey),
@@ -30,7 +30,7 @@ Particles::Particles(GLuint numParticles, const std::string &updateShaderKey)
 }
 
 void Particles::begin() {
-	GLuint numParticles = numVertices();
+	uint32_t numParticles = numVertices();
 
 	// Initialize the random number generator and distribution
 	std::random_device rd;
@@ -40,7 +40,7 @@ void Particles::begin() {
 	// get a random seed for each particle
 	ref_ptr<ShaderInput1ui> randomSeed_ = ref_ptr<ShaderInput1ui>::alloc("randomSeed");
 	randomSeed_->setVertexData(numParticles, nullptr);
-	for (GLuint i = 0u; i < numParticles; ++i) {
+	for (uint32_t i = 0u; i < numParticles; ++i) {
 		randomSeed_->setVertex(i, dis(gen));
 	}
 	setInput(randomSeed_);
@@ -49,7 +49,7 @@ void Particles::begin() {
 	// get emitted in the first step
 	ref_ptr<ShaderInput1f> lifetimeInput_ = ref_ptr<ShaderInput1f>::alloc("lifetime");
 	lifetimeInput_->setVertexData(numParticles, nullptr);
-	for (GLuint i = 0u; i < numParticles; ++i) {
+	for (uint32_t i = 0u; i < numParticles; ++i) {
 		lifetimeInput_->setVertex(i, -1.0);
 	}
 	setInput(lifetimeInput_);
@@ -65,7 +65,7 @@ ref_ptr<BufferReference> Particles::end() {
 	bufferRange_.size_ = vboRef_[0]->allocatedSize();
 
 	// Create shader defines.
-	GLuint counter = 0;
+	uint32_t counter = 0;
 	for (auto it = inputs().begin(); it != inputs().end(); ++it) {
 		if (!it->in_->isVertexAttribute()) continue;
 		shaderDefine(
@@ -107,7 +107,7 @@ void Particles::setAdvanceRamp(const std::string &attributeName, const ref_ptr<T
 
 void Particles::configureAdvancing(
 		const ref_ptr<ShaderInput> &in,
-		GLuint counter,
+		uint32_t counter,
 		AdvanceMode mode) {
 	std::string advanceImportKey;
 	std::string advanceFunction;
@@ -275,7 +275,7 @@ void Particles::glAnimate(RenderState *rs, GLdouble dt) {
 	/*
 	// only emit a limited number of particles per frame
 	if (numVertices_ < numParticles_) {
-		GLuint nextNumParticles = numVertices_ + maxEmits_;
+		uint32_t nextNumParticles = numVertices_ + maxEmits_;
 		if (nextNumParticles > numParticles_) {
 			set_numVertices(numParticles_);
 		} else {
@@ -292,7 +292,7 @@ void Particles::glAnimate(RenderState *rs, GLdouble dt) {
 	rs->toggles().pop(RenderState::RASTERIZER_DISCARD);
 
 	// Update particle attribute layout.
-	GLuint currOffset = bufferRange_.offset_;
+	uint32_t currOffset = bufferRange_.offset_;
 	for (auto &particleAttribute: particleAttributes_) {
 		particleAttribute.input->set_buffer(bufferRange_.buffer_, vboRef_[nextIdx]);
 		particleAttribute.input->set_offset(currOffset);

--- a/regen/objects/particles.h
+++ b/regen/objects/particles.h
@@ -68,7 +68,7 @@ namespace regen {
 		 * @param numParticles particle count.
 		 * @param updateShaderKey shader for updating particles.
 		 */
-		explicit Particles(GLuint numParticles,
+		explicit Particles(uint32_t numParticles,
 			const std::string &updateShaderKey="regen.particles.emitter");
 
 		/**
@@ -76,7 +76,7 @@ namespace regen {
 		 * This has only an effect initially.
 		 * @param maxEmits maximum number of particles to emit.
 		 */
-		void setMaxEmits(GLuint maxEmits) { maxEmits_ = maxEmits; }
+		void setMaxEmits(uint32_t maxEmits) { maxEmits_ = maxEmits; }
 
 		/**
 		 * Set the default value for a particle attribute when it is emitted.
@@ -174,8 +174,8 @@ namespace regen {
 		ref_ptr<ShaderState> updateState_;
 		VAO particleVAO_;
 
-		GLuint numParticles_;
-		GLuint maxEmits_;
+		uint32_t numParticles_;
+		uint32_t maxEmits_;
 
 		std::map<std::string, AdvanceMode> advanceModes_;
 		std::map<std::string, std::string> advanceFunctions_;
@@ -189,7 +189,7 @@ namespace regen {
 
 		void createUpdateShader();
 
-		void configureAdvancing(const ref_ptr<ShaderInput> &in, GLuint counter, AdvanceMode mode);
+		void configureAdvancing(const ref_ptr<ShaderInput> &in, uint32_t counter, AdvanceMode mode);
 	};
 
 	std::ostream &operator<<(std::ostream &out, const Particles::AdvanceMode &v);

--- a/regen/objects/primitives/blanket.h
+++ b/regen/objects/primitives/blanket.h
@@ -32,7 +32,7 @@ namespace regen {
 			// zero means infinite
 			float blanketLifetime = 0.0f;
 			// tessellation LOD levels
-			std::vector<GLuint> levelOfDetails = { 1 };
+			std::vector<uint32_t> levelOfDetails = { 1 };
 			// buffer update configuration
 			ClientAccessMode accessMode = BUFFER_CPU_WRITE;
 			BufferUpdateFlags updateHint = BufferUpdateFlags::NEVER;

--- a/regen/objects/primitives/box.cpp
+++ b/regen/objects/primitives/box.cpp
@@ -78,8 +78,8 @@ Box::Config::Config()
 
 void Box::generateLODLevel(
 		const Config &cfg,
-		GLuint sideIndex,
-		GLuint lodLevel,
+		uint32_t sideIndex,
+		uint32_t lodLevel,
 		const std::vector<Tessellation> &tessellations) {
 	static const Vec3f cubeNormals[] = {
 			Vec3f(0.0f, 0.0f, 1.0f), // Front
@@ -103,7 +103,7 @@ void Box::generateLODLevel(
 	auto indexOffset = meshLODs_[lodLevel].d->indexOffset + sideIndex * tessellation.outputFaces.size() * 3;
 	const Vec3f &normal = cubeNormals[sideIndex];
 	const Mat4f &faceRotMat = faceRotations[sideIndex];
-	GLuint nextIndex = indexOffset;
+	uint32_t nextIndex = indexOffset;
 
 	// map client data for writing
 	auto pos = (Vec3f*) pos_->clientBuffer()->clientData(0);
@@ -120,13 +120,13 @@ void Box::generateLODLevel(
 		setIndexValue(indices, indexType, nextIndex++, vertexOffset + tessFace.v3);
 	}
 
-	GLuint triIndices[3];
+	uint32_t triIndices[3];
 	Vec3f triVertices[3];
 	Vec2f triTexco[3];
 
-	for (GLuint faceIndex = 0; faceIndex < tessellation.outputFaces.size(); ++faceIndex) {
+	for (uint32_t faceIndex = 0; faceIndex < tessellation.outputFaces.size(); ++faceIndex) {
 		const auto &face = tessellation.outputFaces[faceIndex];
-		GLuint faceVertIndex = 0;
+		uint32_t faceVertIndex = 0;
 
 		for (const auto &tessIndex: {face.v1, face.v2, face.v3}) {
 			const auto &vertex = tessellation.vertices[tessIndex];
@@ -196,7 +196,7 @@ void Box::generateLODLevel(
 
 		if (cfg.isTangentRequired) {
 			Vec4f tangent = calculateTangent(triVertices, triTexco, normal);
-			for (GLuint i = 0; i < 3; ++i) {
+			for (uint32_t i = 0; i < 3; ++i) {
 				tan[triIndices[i]] = tangent;
 			}
 		}
@@ -205,8 +205,8 @@ void Box::generateLODLevel(
 
 void Box::updateAttributes(const Config &cfg) {
 	std::vector<Tessellation> tessellations;
-	GLuint numVertices = 0;
-	GLuint numIndices = 0;
+	uint32_t numVertices = 0;
+	uint32_t numIndices = 0;
 
 	// Generate base tessellation for a single face (front face)
 	Tessellation baseTess;
@@ -220,7 +220,7 @@ void Box::updateAttributes(const Config &cfg) {
 	baseTess.inputFaces[1] = TessellationFace(1, 2, 3);
 
 	// Generate tessellations for each LOD level
-	for (GLuint lodLevel: cfg.levelOfDetails) {
+	for (uint32_t lodLevel: cfg.levelOfDetails) {
 		auto &lodTess = tessellations.emplace_back();
 		lodTess.vertices = baseTess.vertices;
 		lodTess.inputFaces = baseTess.inputFaces;
@@ -261,7 +261,7 @@ void Box::updateAttributes(const Config &cfg) {
 	minPosition_ = Vec3f::create(999999.9);
 	maxPosition_ = Vec3f::create(-999999.9);
 	for (auto lodLevel = 0u; lodLevel < tessellations.size(); ++lodLevel) {
-		for (GLuint sideIndex = 0; sideIndex < 6; ++sideIndex) {
+		for (uint32_t sideIndex = 0; sideIndex < 6; ++sideIndex) {
 			generateLODLevel(cfg, sideIndex, lodLevel, tessellations);
 		}
 	}

--- a/regen/objects/primitives/box.h
+++ b/regen/objects/primitives/box.h
@@ -42,7 +42,7 @@ namespace regen {
 		 */
 		struct Config {
 			/** number of surface divisions. */
-			std::vector<GLuint> levelOfDetails;
+			std::vector<uint32_t> levelOfDetails;
 			/** scaling for the position attribute. */
 			Vec3f posScale;
 			/** cube xyz rotation. */
@@ -90,8 +90,8 @@ namespace regen {
 
 		void generateLODLevel(
 				const Config &cfg,
-				GLuint sideIndex,
-				GLuint lodLevel,
+				uint32_t sideIndex,
+				uint32_t lodLevel,
 				const std::vector<Tessellation> &tessellations);
 	};
 

--- a/regen/objects/primitives/cone.cpp
+++ b/regen/objects/primitives/cone.cpp
@@ -26,9 +26,9 @@ ConeOpened::ConeOpened(const Config &cfg)
 }
 
 void ConeOpened::generateLODLevel(const Config &cfg,
-								  GLuint lodLevel,
-								  GLuint vertexOffset,
-								  GLuint indexOffset) {
+								  uint32_t lodLevel,
+								  uint32_t vertexOffset,
+								  uint32_t indexOffset) {
 	// map client data for writing
 	auto v_pos = (Vec3f*) pos_->clientBuffer()->clientData(0);
 	auto v_nor = (cfg.isNormalRequired ?
@@ -38,7 +38,7 @@ void ConeOpened::generateLODLevel(const Config &cfg,
 	GLfloat radius = tan(phi) * cfg.height;
 	GLfloat angle = 0.0f;
 	GLfloat angleStep = 2.0f * M_PI / (GLfloat) lodLevel;
-	GLuint i = vertexOffset;
+	uint32_t i = vertexOffset;
 
 	v_pos[i] = Vec3f::zero();
 	if (cfg.isNormalRequired) {
@@ -62,17 +62,17 @@ void ConeOpened::generateLODLevel(const Config &cfg,
 }
 
 void ConeOpened::updateAttributes(const Config &cfg) {
-	std::vector<GLuint> LODs;
-	GLuint vertexOffset = 0;
+	std::vector<uint32_t> LODs;
+	uint32_t vertexOffset = 0;
 	for (auto &lod: cfg.levelOfDetails) {
-		GLuint lodLevel = 4u * pow(lod, 2);
+		uint32_t lodLevel = 4u * pow(lod, 2);
 		LODs.push_back(lodLevel);
 		auto &x = meshLODs_.emplace_back();
 		x.d->numVertices = lodLevel + 2;
 		x.d->vertexOffset = vertexOffset;
 		vertexOffset += x.d->numVertices;
 	}
-	GLuint numVertices = vertexOffset;
+	uint32_t numVertices = vertexOffset;
 
 	minPosition_ = Vec3f::zero();
 	maxPosition_ = Vec3f::zero();
@@ -133,7 +133,7 @@ static void loadConeData(
 		Vec3f &min,
 		Vec3f &max,
 		GLboolean useBase,
-		GLuint subdivisions,
+		uint32_t subdivisions,
 		GLfloat radius,
 		GLfloat height) {
 	GLfloat angle = 0.0f;
@@ -170,9 +170,9 @@ static void loadConeData(
 
 void ConeClosed::generateLODLevel(
 		const Config &cfg,
-		GLuint lodLevel,
-		GLuint vertexOffset,
-		GLuint indexOffset) {
+		uint32_t lodLevel,
+		uint32_t vertexOffset,
+		uint32_t indexOffset) {
 	// map client data for writing
 	auto v_pos = (Vec3f*) pos_->clientBuffer()->clientData(0);
 	auto v_nor = (cfg.isNormalRequired ?
@@ -189,19 +189,19 @@ void ConeClosed::generateLODLevel(
 			cfg.radius, cfg.height);
 
 	// create cone index data
-	const GLuint apexIndex = vertexOffset;
-	const GLuint baseCenterIndex = vertexOffset + 1;
-	GLuint faceIndex = indexOffset;
+	const uint32_t apexIndex = vertexOffset;
+	const uint32_t baseCenterIndex = vertexOffset + 1;
+	uint32_t faceIndex = indexOffset;
 	GLint vIndex = vertexOffset + cfg.isBaseRequired ? 2 : 1;
 	// cone
-	for (GLuint i = 0; i < lodLevel; ++i) {
+	for (uint32_t i = 0; i < lodLevel; ++i) {
 		setIndexValue(indices, indexType, faceIndex++, apexIndex);
 		setIndexValue(indices, indexType, faceIndex++, (i + 1 == lodLevel ? vIndex : vIndex + i + 1));
 		setIndexValue(indices, indexType, faceIndex++, vIndex + i);
 	}
 	// base
 	if (cfg.isBaseRequired) {
-		for (GLuint i = 0; i < lodLevel; ++i) {
+		for (uint32_t i = 0; i < lodLevel; ++i) {
 			setIndexValue(indices, indexType, faceIndex++, baseCenterIndex);
 			setIndexValue(indices, indexType, faceIndex++, vIndex + i);
 			setIndexValue(indices, indexType, faceIndex++, (i + 1 == lodLevel ? vIndex : vIndex + i + 1));
@@ -210,11 +210,11 @@ void ConeClosed::generateLODLevel(
 }
 
 void ConeClosed::updateAttributes(const Config &cfg) {
-	std::vector<GLuint> LODs;
-	GLuint vertexOffset = 0;
-	GLuint indexOffset = 0;
+	std::vector<uint32_t> LODs;
+	uint32_t vertexOffset = 0;
+	uint32_t indexOffset = 0;
 	for (auto &lod: cfg.levelOfDetails) {
-		GLuint lodLevel = 4u * pow(lod, 2);
+		uint32_t lodLevel = 4u * pow(lod, 2);
 		LODs.push_back(lodLevel);
 		auto &x = meshLODs_.emplace_back();
 		x.d->numVertices = lodLevel + 1;
@@ -222,14 +222,14 @@ void ConeClosed::updateAttributes(const Config &cfg) {
 		x.d->vertexOffset = vertexOffset;
 		vertexOffset += x.d->numVertices;
 
-		GLuint numFaces = lodLevel;
+		uint32_t numFaces = lodLevel;
 		if (cfg.isBaseRequired) { numFaces *= 2; }
 		x.d->numIndices = numFaces * 3;
 		x.d->indexOffset = indexOffset;
 		indexOffset += x.d->numIndices;
 	}
-	GLuint numVertices = vertexOffset;
-	GLuint numIndices = indexOffset;
+	uint32_t numVertices = vertexOffset;
+	uint32_t numIndices = indexOffset;
 
 	minPosition_ = Vec3f::zero();
 	maxPosition_ = Vec3f::zero();

--- a/regen/objects/primitives/cone.h
+++ b/regen/objects/primitives/cone.h
@@ -40,7 +40,7 @@ namespace regen {
 			/** generate normal attribute ? */
 			GLboolean isNormalRequired;
 			/** subdivisions = 4*levelOfDetail^2 */
-			std::vector<GLuint> levelOfDetails;
+			std::vector<uint32_t> levelOfDetails;
 			/** Buffer usage hints. */
 			ClientAccessMode accessMode = BUFFER_CPU_WRITE;
 			BufferUpdateFlags updateHint = BufferUpdateFlags::NEVER;
@@ -62,9 +62,9 @@ namespace regen {
 
 	protected:
 		void generateLODLevel(const Config &cfg,
-				GLuint lodLevel,
-				GLuint vertexOffset,
-				GLuint indexOffset);
+				uint32_t lodLevel,
+				uint32_t vertexOffset,
+				uint32_t indexOffset);
 	};
 
 	/**
@@ -97,7 +97,7 @@ namespace regen {
 			/** generate cone base geometry */
 			GLboolean isBaseRequired;
 			/** level of detail for base circle */
-			std::vector<GLuint> levelOfDetails;
+			std::vector<uint32_t> levelOfDetails;
 			/** Buffer usage hints. */
 			ClientAccessMode accessMode = BUFFER_CPU_WRITE;
 			BufferUpdateFlags updateHint = BufferUpdateFlags::NEVER;
@@ -121,9 +121,9 @@ namespace regen {
 		ref_ptr<ShaderInput> indices_;
 
 		void generateLODLevel(const Config &cfg,
-				GLuint lodLevel,
-				GLuint vertexOffset,
-				GLuint indexOffset);
+				uint32_t lodLevel,
+				uint32_t vertexOffset,
+				uint32_t indexOffset);
 	};
 } // namespace
 

--- a/regen/objects/primitives/disc.cpp
+++ b/regen/objects/primitives/disc.cpp
@@ -76,9 +76,9 @@ Disc::Config::Config()
 }
 
 void Disc::generateLODLevel(const Config &cfg,
-							GLuint lodLevel,
-							GLuint vertexOffset,
-							GLuint indexOffset) {
+							uint32_t lodLevel,
+							uint32_t vertexOffset,
+							uint32_t indexOffset) {
 	const float angleStep = 2.0f * M_PI / lodLevel;
 
 	auto v_pos = (Vec3f*) pos_->clientBuffer()->clientData(0);
@@ -91,8 +91,8 @@ void Disc::generateLODLevel(const Config &cfg,
 	auto indices = (byte*)indices_->clientBuffer()->clientData(0);
 	auto indexType = indices_->baseType();
 
-	GLuint vertexIndex = vertexOffset;
-	for (GLuint i = 0; i <= lodLevel; ++i) {
+	uint32_t vertexIndex = vertexOffset;
+	for (uint32_t i = 0; i <= lodLevel; ++i) {
 		float angle = i * angleStep;
 		float cosAngle = cos(angle);
 		float sinAngle = sin(angle);
@@ -118,8 +118,8 @@ void Disc::generateLODLevel(const Config &cfg,
 	}
 
 	// Generate indices
-	GLuint index = indexOffset;
-	for (GLuint i = 0; i < lodLevel; ++i) {
+	uint32_t index = indexOffset;
+	for (uint32_t i = 0; i < lodLevel; ++i) {
 		setIndexValue(indices, indexType, index++, vertexOffset + lodLevel);
 		setIndexValue(indices, indexType, index++, vertexOffset + i + 1);
 		setIndexValue(indices, indexType, index++, vertexOffset + i);
@@ -127,11 +127,11 @@ void Disc::generateLODLevel(const Config &cfg,
 }
 
 void Disc::updateAttributes(const Config &cfg) {
-	std::vector<GLuint> LODs;
-	GLuint vertexOffset = 0;
-	GLuint indexOffset = 0;
+	std::vector<uint32_t> LODs;
+	uint32_t vertexOffset = 0;
+	uint32_t indexOffset = 0;
 	for (auto &lod: cfg.levelOfDetails) {
-		GLuint lodLevel = 4u * pow(2u, lod);
+		uint32_t lodLevel = 4u * pow(2u, lod);
 		LODs.push_back(lodLevel);
 		auto &x = meshLODs_.emplace_back();
 		x.d->numVertices = lodLevel + 1;
@@ -141,8 +141,8 @@ void Disc::updateAttributes(const Config &cfg) {
 		vertexOffset += x.d->numVertices;
 		indexOffset += x.d->numIndices;
 	}
-	GLuint numVertices = vertexOffset;
-	GLuint numIndices = indexOffset;
+	uint32_t numVertices = vertexOffset;
+	uint32_t numIndices = indexOffset;
 
 	pos_->setVertexData(numVertices);
 	if (cfg.isNormalRequired) {

--- a/regen/objects/primitives/disc.h
+++ b/regen/objects/primitives/disc.h
@@ -31,7 +31,7 @@ namespace regen {
 		 */
 		struct Config {
 			/** number of surface divisions. */
-			std::vector<GLuint> levelOfDetails;
+			std::vector<uint32_t> levelOfDetails;
 			/** scaling for the position attribute. */
 			Vec3f posScale;
 			/** cube xyz rotation. */
@@ -78,9 +78,9 @@ namespace regen {
 		ref_ptr<ShaderInput> indices_;
 
 		void generateLODLevel(const Config &cfg,
-				GLuint lodLevel,
-				GLuint vertexOffset,
-				GLuint indexOffset);
+				uint32_t lodLevel,
+				uint32_t vertexOffset,
+				uint32_t indexOffset);
 	};
 
 	std::ostream &operator<<(std::ostream &out, const Disc::TexcoMode &mode);

--- a/regen/objects/primitives/frame.cpp
+++ b/regen/objects/primitives/frame.cpp
@@ -120,10 +120,10 @@ void FrameMesh::updateAttributes(const Config &cfg) {
 			TriangleVertex(Vec3f(-1.0, 1.0, -1.0), 3)
 	};
 
-	const GLuint numBoxes = 4;
-	const GLuint numFaces = 6;
+	const uint32_t numBoxes = 4;
+	const uint32_t numFaces = 6;
 	// -4 because we can skip left/right face of two border boxes
-	GLuint numVertices = pow(4.0, cfg.levelOfDetail) * (numBoxes * numFaces - 4) * 2 * 3;
+	uint32_t numVertices = pow(4.0, cfg.levelOfDetail) * (numBoxes * numFaces - 4) * 2 * 3;
 
 	pos_->setVertexData(numVertices);
 	if (cfg.isNormalRequired) {
@@ -188,9 +188,9 @@ void FrameMesh::updateAttributes(const Config &cfg) {
 	minPosition_ = Vec3f::create(999999.0f);
 	maxPosition_ = Vec3f::create(-999999.0f);
 
-	GLuint vertexBase = 0;
-	for (GLuint boxIndex = 0; boxIndex < numBoxes; ++boxIndex) {
-		for (GLuint sideIndex = 0; sideIndex < numFaces; ++sideIndex) {
+	uint32_t vertexBase = 0;
+	for (uint32_t boxIndex = 0; boxIndex < numBoxes; ++boxIndex) {
+		for (uint32_t sideIndex = 0; sideIndex < numFaces; ++sideIndex) {
 			if (boxIndex == 2 || boxIndex == 3) {
 				if (sideIndex == 4 || sideIndex == 5) {
 					continue;
@@ -206,12 +206,12 @@ void FrameMesh::updateAttributes(const Config &cfg) {
 			facesLevel0[1] = TriangleFace(level0[1], level0[2], level0[3]);
 			auto faces = tessellate(cfg.levelOfDetail, facesLevel0);
 
-			for (GLuint faceIndex = 0; faceIndex < faces.size(); ++faceIndex) {
-				GLuint vertexIndex = faceIndex * 3 + vertexBase;
+			for (uint32_t faceIndex = 0; faceIndex < faces.size(); ++faceIndex) {
+				uint32_t vertexIndex = faceIndex * 3 + vertexBase;
 				TriangleFace &face = faces[faceIndex];
 				auto *f = (TriangleVertex *) &face;
 
-				for (GLuint i = 0; i < 3; ++i) {
+				for (uint32_t i = 0; i < 3; ++i) {
 					auto transformedVertex = (transformations[boxIndex] * (initialBoxScale * f[i].p));
 					minPosition_.setMin(transformedVertex.xyz());
 					maxPosition_.setMax(transformedVertex.xyz());
@@ -219,13 +219,13 @@ void FrameMesh::updateAttributes(const Config &cfg) {
 				}
 				if (cfg.isNormalRequired) {
 					auto nor = transformations[boxIndex].rotateVector(normal);
-					for (GLuint i = 0; i < 3; ++i) {
+					for (uint32_t i = 0; i < 3; ++i) {
 						v_nor[vertexIndex + i] = nor;
 					}
 				}
 
 				if (texcoMode == TEXCO_MODE_UV) {
-					for (GLuint i = 0; i < 3; ++i) {
+					for (uint32_t i = 0; i < 3; ++i) {
 						// Directly assign UV coordinates based on vertex positions
 						Vec3f pos = f[i].p;
 						// Normalize the vertex position to [0, 1]
@@ -254,7 +254,7 @@ void FrameMesh::updateAttributes(const Config &cfg) {
 					Vec3f *vertices = v_pos + vertexIndex;
 					Vec2f *texcos = v_texco + vertexIndex;
 					Vec4f tangent = calculateTangent(vertices, texcos, normal);
-					for (GLuint i = 0; i < 3; ++i) {
+					for (uint32_t i = 0; i < 3; ++i) {
 						v_tan[vertexIndex + i] = tangent;
 					}
 				}

--- a/regen/objects/primitives/frame.h
+++ b/regen/objects/primitives/frame.h
@@ -31,7 +31,7 @@ namespace regen {
 		 */
 		struct Config {
 			/** number of surface divisions. */
-			GLuint levelOfDetail;
+			uint32_t levelOfDetail;
 			/** scaling for the position attribute. */
 			Vec3f posScale;
 			/** cube xyz rotation. */

--- a/regen/objects/primitives/point.cpp
+++ b/regen/objects/primitives/point.cpp
@@ -4,7 +4,7 @@ using namespace regen;
 
 ///////////
 
-Point::Point(GLuint numVertices)
+Point::Point(uint32_t numVertices)
 		: Mesh(GL_POINTS, BufferUpdateFlags::NEVER) {
 	set_numVertices(numVertices);
 

--- a/regen/objects/primitives/point.h
+++ b/regen/objects/primitives/point.h
@@ -6,7 +6,7 @@
 namespace regen {
 	class Point : public Mesh {
 	public:
-		explicit Point(GLuint numVertices=1);
+		explicit Point(uint32_t numVertices=1);
 	protected:
 		ref_ptr<ShaderInput3f> pos_;
 	};

--- a/regen/objects/primitives/rectangle.h
+++ b/regen/objects/primitives/rectangle.h
@@ -25,7 +25,7 @@ namespace regen {
 		 */
 		struct Config {
 			/** number of surface divisions. */
-			std::vector<GLuint> levelOfDetails;
+			std::vector<uint32_t> levelOfDetails;
 			/** scaling for the position attribute. */
 			Vec3f posScale;
 			/** cube xyz rotation. */

--- a/regen/objects/primitives/skirt-quad.cpp
+++ b/regen/objects/primitives/skirt-quad.cpp
@@ -23,8 +23,8 @@ namespace regen {
 				const Rectangle::Config &cfg,
 				const Tessellation &tessellation,
 				const Mat4f &rotMat,
-				GLuint vertexOffset,
-				GLuint indexOffset);
+				uint32_t vertexOffset,
+				uint32_t indexOffset);
 	};
 }
 
@@ -63,8 +63,8 @@ SkirtMesh::SkirtMesh(const BufferUpdateFlags &updateHint)
 }
 
 void SkirtMesh::updateAttributes(const Rectangle::Config &rectangleConfig) {
-	GLuint numVertices = 0;
-	GLuint numIndices = 0;
+	uint32_t numVertices = 0;
+	uint32_t numIndices = 0;
 	for (auto &lodTess : skirtTess_) {
 		auto &x = meshLODs_.emplace_back();
 		x.d->numVertices = lodTess.vertices.size();
@@ -180,14 +180,14 @@ void SkirtMesh::addSkirtLOD(
 void SkirtMesh::generateLODLevel(const Rectangle::Config &cfg,
 								 const Tessellation &skirtTess,
 								 const Mat4f &rotMat,
-								 GLuint vertexOffset,
-								 GLuint indexOffset) {
+								 uint32_t vertexOffset,
+								 uint32_t indexOffset) {
 	// map client data for writing
 	auto v_pos = (Vec3f*) pos_->clientBuffer()->clientData(0);
 	auto indices = (byte*)indices_->clientBuffer()->clientData(0);
 	auto indexType = indices_->baseType();
 
-	GLuint nextIndex = indexOffset;
+	uint32_t nextIndex = indexOffset;
 	for (auto &tessFace: skirtTess.outputFaces) {
 		setIndexValue(indices, indexType, nextIndex++, vertexOffset + tessFace.v1);
 		setIndexValue(indices, indexType, nextIndex++, vertexOffset + tessFace.v2);
@@ -201,7 +201,7 @@ void SkirtMesh::generateLODLevel(const Rectangle::Config &cfg,
 		startPos = Vec3f(0.0f, 0.0f, 0.0f);
 	}
 
-	for (GLuint faceIndex = 0; faceIndex < skirtTess.outputFaces.size(); ++faceIndex) {
+	for (uint32_t faceIndex = 0; faceIndex < skirtTess.outputFaces.size(); ++faceIndex) {
 		auto &face = skirtTess.outputFaces[faceIndex];
 
 		for (auto &tessIndex: {face.v1, face.v2, face.v3}) {

--- a/regen/objects/primitives/sphere.cpp
+++ b/regen/objects/primitives/sphere.cpp
@@ -68,7 +68,7 @@ static Vec3f computeSphereTangent(const Vec3f &v) {
 }
 
 void pushVertex(
-		GLuint vertexIndex,
+		uint32_t vertexIndex,
 		GLdouble u,
 		GLdouble v,
 		const Sphere::Config &cfg,
@@ -98,9 +98,9 @@ void pushVertex(
 }
 
 void Sphere::generateLODLevel(const Config &cfg,
-							  GLuint lodLevel,
-							  GLuint vertexOffset,
-							  GLuint indexOffset) {
+							  uint32_t lodLevel,
+							  uint32_t vertexOffset,
+							  uint32_t indexOffset) {
 	// map client data for writing
 	auto v_pos = (Vec3f*) pos_->clientBuffer()->clientData(0);
 	auto v_nor = (cfg.isNormalRequired ?
@@ -114,10 +114,10 @@ void Sphere::generateLODLevel(const Config &cfg,
 	auto indexType = indices_->baseType();
 
 	GLdouble stepSizeInv = 1.0 / (GLdouble) lodLevel;
-	GLuint vertexIndex = vertexOffset, faceIndex = indexOffset / 6;
+	uint32_t vertexIndex = vertexOffset, faceIndex = indexOffset / 6;
 
-	for (GLuint i = 0; i < lodLevel; i++) {
-		for (GLuint j = 0; j < lodLevel; j++) {
+	for (uint32_t i = 0; i < lodLevel; i++) {
+		for (uint32_t j = 0; j < lodLevel; j++) {
 			GLdouble u0 = (GLdouble) i * stepSizeInv;
 			GLdouble u1 = (GLdouble) (i + 1) * stepSizeInv;
 			GLdouble v0 = (GLdouble) j * stepSizeInv;
@@ -126,7 +126,7 @@ void Sphere::generateLODLevel(const Config &cfg,
 			if (cfg.isHalfSphere && u0 < 0.5) continue;
 
 			// create two triangles for each quad
-			GLuint index = (faceIndex++) * 6;
+			uint32_t index = (faceIndex++) * 6;
 			setIndexValue(indices, indexType, index + 0, vertexIndex + 0);
 			setIndexValue(indices, indexType, index + 1, vertexIndex + 1);
 			setIndexValue(indices, indexType, index + 2, vertexIndex + 2);
@@ -144,13 +144,13 @@ void Sphere::generateLODLevel(const Config &cfg,
 }
 
 void Sphere::updateAttributes(const Config &cfg) {
-	std::vector<GLuint> LODs;
-	GLuint vertexOffset = 0;
-	GLuint indexOffset = 0;
+	std::vector<uint32_t> LODs;
+	uint32_t vertexOffset = 0;
+	uint32_t indexOffset = 0;
 	for (auto &lod: cfg.levelOfDetails) {
-		GLuint lodLevel = 4 + lod * lod;
+		uint32_t lodLevel = 4 + lod * lod;
 		LODs.push_back(lodLevel);
-		GLuint numFaces;
+		uint32_t numFaces;
 		if (cfg.isHalfSphere) {
 			numFaces = lodLevel * lodLevel;
 		} else {
@@ -164,8 +164,8 @@ void Sphere::updateAttributes(const Config &cfg) {
 		vertexOffset += x.d->numVertices;
 		indexOffset += x.d->numIndices;
 	}
-	GLuint numVertices = vertexOffset;
-	GLuint numIndices = indexOffset;
+	uint32_t numVertices = vertexOffset;
+	uint32_t numIndices = indexOffset;
 
 	// allocate attributes
 	pos_->setVertexData(numVertices);
@@ -244,7 +244,7 @@ void SphereSprite::updateAttributes(const Config &cfg) {
 	minPosition_ = Vec3f::create(999999.0f);
 	maxPosition_ = Vec3f::create(-999999.0f);
 	Vec3f v;
-	for (GLuint i = 0; i < cfg.sphereCount; ++i) {
+	for (uint32_t i = 0; i < cfg.sphereCount; ++i) {
 		mappedRadius.w[i] = cfg.radius[i];
 		mappedPosition.w[i] = cfg.position[i];
 

--- a/regen/objects/primitives/sphere.h
+++ b/regen/objects/primitives/sphere.h
@@ -41,7 +41,7 @@ namespace regen {
 			/** scaling vector for TEXCO_MODE_UV */
 			Vec2f texcoScale;
 			/** number of surface divisions */
-			std::vector<GLuint> levelOfDetails;
+			std::vector<uint32_t> levelOfDetails;
 			/** texture coordinate mode */
 			TexcoMode texcoMode;
 			/** generate normal attribute */
@@ -83,9 +83,9 @@ namespace regen {
 		GLfloat radius_;
 
 		void generateLODLevel(const Config &cfg,
-				GLuint lodLevel,
-				GLuint vertexOffset,
-				GLuint indexOffset);
+				uint32_t lodLevel,
+				uint32_t vertexOffset,
+				uint32_t indexOffset);
 	};
 
 	std::ostream &operator<<(std::ostream &out, const Sphere::TexcoMode &mode);
@@ -113,7 +113,7 @@ namespace regen {
 			/** one position for each sphere. */
 			Vec3f *position;
 			/** number of spheres. */
-			GLuint sphereCount;
+			uint32_t sphereCount;
 			/** Buffer usage hints. */
 			ClientAccessMode accessMode = BUFFER_CPU_WRITE;
 			BufferUpdateFlags updateHint = BufferUpdateFlags::NEVER;

--- a/regen/objects/primitives/torus.h
+++ b/regen/objects/primitives/torus.h
@@ -34,7 +34,7 @@ namespace regen {
 		 */
 		struct Config {
 			/** number of surface divisions. */
-			std::vector<GLuint> levelOfDetails;
+			std::vector<uint32_t> levelOfDetails;
 			/** scaling for the position attribute. */
 			Vec3f posScale;
 			/** cube xyz rotation. */
@@ -83,9 +83,9 @@ namespace regen {
 		ref_ptr<ShaderInput> indices_;
 
 		void generateLODLevel(const Config &cfg,
-				GLuint lodLevel,
-				GLuint vertexOffset,
-				GLuint indexOffset);
+				uint32_t lodLevel,
+				uint32_t vertexOffset,
+				uint32_t indexOffset);
 	};
 
 	std::ostream &operator<<(std::ostream &out, const Torus::TexcoMode &mode);

--- a/regen/objects/silhouette-mesh.cpp
+++ b/regen/objects/silhouette-mesh.cpp
@@ -198,7 +198,7 @@ ref_ptr<SilhouetteMesh> SilhouetteMesh::load(LoadingContext &ctx, scene::SceneIn
 		cfg.silhouette.tileCounts[2] = lodVec.z;
 		cfg.silhouette.tileCounts[3] = lodVec.w;
 	} else {
-		cfg.silhouette.tileCounts.push_back(input.getValue<GLuint>("lod", 8));
+		cfg.silhouette.tileCounts.push_back(input.getValue<uint32_t>("lod", 8));
 	}
 	if (input.hasAttribute("alpha-cut")) {
 		cfg.silhouette.alphaCut = input.getValue<float>("alpha-cut", 0.01f);

--- a/regen/objects/sky-box.cpp
+++ b/regen/objects/sky-box.cpp
@@ -16,7 +16,7 @@
 
 using namespace regen;
 
-static Box::Config cubeCfg(GLuint levelOfDetail) {
+static Box::Config cubeCfg(uint32_t levelOfDetail) {
 	Box::Config cfg;
 	cfg.isNormalRequired = GL_FALSE;
 	cfg.isTangentRequired = GL_FALSE;
@@ -29,7 +29,7 @@ static Box::Config cubeCfg(GLuint levelOfDetail) {
 	return cfg;
 }
 
-SkyBox::SkyBox(GLuint levelOfDetail, const std::string &shaderKey)
+SkyBox::SkyBox(uint32_t levelOfDetail, const std::string &shaderKey)
 		: Box(cubeCfg(levelOfDetail)), HasShader(shaderKey) {
 	joinStates(ref_ptr<CullFaceState>::alloc(GL_FRONT));
 

--- a/regen/objects/sky-box.h
+++ b/regen/objects/sky-box.h
@@ -17,7 +17,7 @@ namespace regen {
 		/**
 		 * @param levelOfDetail LoD for Box mesh.
 		 */
-		explicit SkyBox(GLuint levelOfDetail = 0, const std::string &shaderKey = "regen.models.sky-box");
+		explicit SkyBox(uint32_t levelOfDetail = 0, const std::string &shaderKey = "regen.models.sky-box");
 
 		/**
 		 * @return the cube map texture.

--- a/regen/objects/sky/cloud-layer.cpp
+++ b/regen/objects/sky/cloud-layer.cpp
@@ -5,17 +5,17 @@
 
 using namespace regen;
 
-static GLfloat *createNoiseSlice(GLuint texSize, GLuint octave) {
-	GLuint size2 = texSize * texSize;
+static GLfloat *createNoiseSlice(uint32_t texSize, uint32_t octave) {
+	uint32_t size2 = texSize * texSize;
 	GLfloat oneOverTexSize = 1.f / static_cast<float>(texSize);
 	osgHimmel::Noise n(1 << (octave + 2),
 					   math::random<float>(0.f, 1.f),
 					   math::random<float>(0.f, 1.f));
 
 	auto *noise = new float[size2];
-	GLuint o;
-	for (GLuint s = 0; s < texSize; ++s)
-		for (GLuint t = 0; t < texSize; ++t) {
+	uint32_t o;
+	for (uint32_t s = 0; s < texSize; ++s)
+		for (uint32_t t = 0; t < texSize; ++t) {
 			o = t * texSize + s;
 			noise[o] = n.noise2(
 					static_cast<float>(s) * oneOverTexSize,
@@ -25,7 +25,7 @@ static GLfloat *createNoiseSlice(GLuint texSize, GLuint octave) {
 	return noise;
 }
 
-static ref_ptr<Texture3D> createNoiseArray(GLuint texSize, GLuint octave, GLuint slices) {
+static ref_ptr<Texture3D> createNoiseArray(uint32_t texSize, uint32_t octave, uint32_t slices) {
 	ref_ptr<Texture3D> tex = ref_ptr<Texture3D>::alloc();
 	//ref_ptr<Texture2DArray> tex = ref_ptr<Texture2DArray>::alloc();
 	tex->set_rectangleSize(texSize, texSize);
@@ -46,7 +46,7 @@ static ref_ptr<Texture3D> createNoiseArray(GLuint texSize, GLuint octave, GLuint
 }
 
 
-CloudLayer::CloudLayer(const ref_ptr<Sky> &sky, GLuint textureSize)
+CloudLayer::CloudLayer(const ref_ptr<Sky> &sky, uint32_t textureSize)
 		: SkyLayer(sky) {
 	state()->joinStates(ref_ptr<BlendFuncState>::alloc(
 			GL_SRC_ALPHA, GL_ONE,

--- a/regen/objects/sky/cloud-layer.h
+++ b/regen/objects/sky/cloud-layer.h
@@ -9,7 +9,7 @@
 namespace regen {
 	class CloudLayer : public SkyLayer {
 	public:
-		explicit CloudLayer(const ref_ptr<Sky> &sky, GLuint textureSize = 2048);
+		explicit CloudLayer(const ref_ptr<Sky> &sky, uint32_t textureSize = 2048);
 
 		void set_altitude(float altitude) { altitude_->setVertex(0, altitude); }
 

--- a/regen/objects/sky/sky.cpp
+++ b/regen/objects/sky/sky.cpp
@@ -51,6 +51,14 @@ Sky::Sky(const ref_ptr<Camera> &cam, const ref_ptr<Screen> &screen)
 	R_->setUniformData(Mat4f::identity());
 	uniformBlock->addStagedInput(R_);
 
+	q_ = ref_ptr<ShaderInput1f>::alloc("q");
+	q_->setUniformData(0.0f);
+	uniformBlock->addStagedInput(q_);
+
+	sqrt_q_ = ref_ptr<ShaderInput1f>::alloc("sqrt_q");
+	sqrt_q_->setUniformData(0.0f);
+	uniformBlock->addStagedInput(sqrt_q_);
+
 	// directional light that approximates the sun
 	sun_ = ref_ptr<Light>::alloc(Light::DIRECTIONAL);
 	sun_->set_isAttenuated(false);
@@ -58,14 +66,6 @@ Sky::Sky(const ref_ptr<Camera> &cam, const ref_ptr<Screen> &screen)
 	sun_->setDiffuse(0, Vec3f::zero());
 	sun_->setDirection(0, Vec3f::one());
 	state()->setInput(sun_->lightUBO(), "SunLight", "_Sun");
-
-	q_ = ref_ptr<ShaderInput1f>::alloc("q");
-	q_->setUniformData(0.0f);
-	state()->setInput(q_);
-
-	sqrt_q_ = ref_ptr<ShaderInput1f>::alloc("sqrt_q");
-	sqrt_q_->setUniformData(0.0f);
-	state()->setInput(sqrt_q_);
 
 	// directional light that approximates the moon
 	moon_ = ref_ptr<Light>::alloc(Light::DIRECTIONAL);

--- a/regen/objects/terrain/blanket-trail.cpp
+++ b/regen/objects/terrain/blanket-trail.cpp
@@ -56,7 +56,7 @@ void BlanketTrail::setModelTransform(const ref_ptr<ModelTransformation> &tf) {
 
 		Mat4f *mat0 = (Mat4f*) modelMat->clientData(0);
 		Mat4f *mat1 = (Mat4f*) modelMat->clientData(1);
-		for (GLuint j = 0; j < numBlankets_; j += 1) {
+		for (uint32_t j = 0; j < numBlankets_; j += 1) {
 			mat0[j] = Mat4f::identity();
 			if(mat1) mat1[j] = Mat4f::identity();
 		}
@@ -99,7 +99,7 @@ void BlanketTrail::insertBlanket(const Vec3f &pos, const Vec3f &dir, uint32_t ma
 
 ref_ptr<BlanketTrail> BlanketTrail::load(LoadingContext &ctx,
 			scene::SceneInputNode &input,
-			const std::vector<GLuint> &lodLevels) {
+			const std::vector<uint32_t> &lodLevels) {
 	auto scene = ctx.scene();
 	ref_ptr<ModelTransformation> tf;
 	ref_ptr<State> dummy = ref_ptr<State>::alloc();
@@ -127,7 +127,7 @@ ref_ptr<BlanketTrail> BlanketTrail::load(LoadingContext &ctx,
 	meshCfg.updateHint = updateFlags;
 	meshCfg.mapMode = input.getValue<BufferMapMode>("map-mode", BUFFER_MAP_DISABLED);
 	meshCfg.accessMode = input.getValue<ClientAccessMode>("access-mode", BUFFER_CPU_WRITE);
-	meshCfg.numTrails = input.getValue<GLuint>("blanket-trails", 1u);
+	meshCfg.numTrails = input.getValue<uint32_t>("blanket-trails", 1u);
 	meshCfg.blanketFrequency = input.getValue<GLfloat>("blanket-frequency", 0.5f);
 	auto blanket = ref_ptr<BlanketTrail>::alloc(groundMesh, meshCfg);
 

--- a/regen/objects/terrain/blanket-trail.h
+++ b/regen/objects/terrain/blanket-trail.h
@@ -68,7 +68,7 @@ namespace regen {
 
 		static ref_ptr<BlanketTrail> load(LoadingContext &ctx,
 			scene::SceneInputNode &input,
-			const std::vector<GLuint> &lodLevels);
+			const std::vector<uint32_t> &lodLevels);
 
 	protected:
 		ref_ptr<Ground> groundMesh_;

--- a/regen/objects/terrain/grass-patch.cpp
+++ b/regen/objects/terrain/grass-patch.cpp
@@ -221,7 +221,7 @@ ref_ptr<GrassPatch> GrassPatch::load(
 		silhouetteCfg.silhouette.tileCounts[2] = lodVec.z;
 		silhouetteCfg.silhouette.tileCounts[3] = lodVec.w;
 	} else {
-		silhouetteCfg.silhouette.tileCounts.push_back(input.getValue<GLuint>("lod", 8));
+		silhouetteCfg.silhouette.tileCounts.push_back(input.getValue<uint32_t>("lod", 8));
 	}
 	if (input.hasAttribute("alpha-cut")) {
 		silhouetteCfg.silhouette.alphaCut = input.getValue<float>("alpha-cut", 0.01f);

--- a/regen/objects/terrain/ground-path.cpp
+++ b/regen/objects/terrain/ground-path.cpp
@@ -269,7 +269,7 @@ ref_ptr<GroundPath> GroundPath::load(LoadingContext &ctx, scene::SceneInputNode 
 		cfg.levelOfDetails[2] = lodVec.z;
 		cfg.levelOfDetails[3] = lodVec.w;
 	} else {
-		cfg.levelOfDetails.push_back(input.getValue<GLuint>("lod-level", 0));
+		cfg.levelOfDetails.push_back(input.getValue<uint32_t>("lod-level", 0));
 	}
 	cfg.isTexCoordRequired = input.getValue<bool>("use-texco", false);
 	cfg.isNormalRequired = input.getValue<bool>("use-normal", false);

--- a/regen/objects/terrain/ground.cpp
+++ b/regen/objects/terrain/ground.cpp
@@ -48,7 +48,7 @@ Ground::Ground() : SkirtQuad() {
 }
 
 void Ground::setLODConfig(uint32_t numPatchesPerRow,
-		const std::vector<GLuint> &levelOfDetails) {
+		const std::vector<uint32_t> &levelOfDetails) {
 	rectangleConfig_.levelOfDetails = levelOfDetails;
 	numPatchesPerRow_ = numPatchesPerRow;
 	updatePatchSize();

--- a/regen/objects/terrain/ground.h
+++ b/regen/objects/terrain/ground.h
@@ -106,7 +106,7 @@ namespace regen {
 		 * @param levelOfDetails lod levels for each patch.
 		 */
 		void setLODConfig(uint32_t numPatchesPerRow,
-				const std::vector<GLuint> &levelOfDetails);
+				const std::vector<uint32_t> &levelOfDetails);
 
 		/**
 		 * Set the geometry of the ground.

--- a/regen/objects/terrain/proc-tree.cpp
+++ b/regen/objects/terrain/proc-tree.cpp
@@ -69,7 +69,7 @@ ProcTree::ProcTree(scene::SceneInputNode &input) : ProcTree() {
 		silhouetteCfg_.silhouette.tileCounts[3] = lodVec.w;
 		useSilhouetteMesh_ = true;
 	} else {
-		silhouetteCfg_.silhouette.tileCounts.push_back(input.getValue<GLuint>("lod", 8));
+		silhouetteCfg_.silhouette.tileCounts.push_back(input.getValue<uint32_t>("lod", 8));
 	}
 	if (input.hasAttribute("alpha-cut")) {
 		silhouetteCfg_.silhouette.alphaCut = input.getValue<float>("alpha-cut", 0.01f);

--- a/regen/objects/text/font.cpp
+++ b/regen/objects/text/font.cpp
@@ -17,7 +17,7 @@ FT_Library Font::ftlib_ = FT_Library();
 Font::FontMap Font::fonts_ = FontMap();
 GLboolean Font::isFreetypeInitialized_ = GL_FALSE;
 
-ref_ptr<Font> Font::get(const std::string &f, GLuint size, GLuint dpi) {
+ref_ptr<Font> Font::get(const std::string &f, uint32_t size, uint32_t dpi) {
 	if (!isFreetypeInitialized_) {
 		if (FT_Init_FreeType(&ftlib_)) { throw Font::Error("FT_Init_FreeType failed."); }
 		isFreetypeInitialized_ = GL_TRUE;
@@ -42,8 +42,8 @@ ref_ptr<Font> Font::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 	}
 	return regen::Font::get(
 			resourcePath(input.getValue("file")),
-			input.getValue<GLuint>("size", 16u),
-			input.getValue<GLuint>("dpi", 96u));
+			input.getValue<uint32_t>("size", 16u),
+			input.getValue<uint32_t>("dpi", 96u));
 }
 
 void Font::closeLibrary() {
@@ -51,7 +51,7 @@ void Font::closeLibrary() {
 	isFreetypeInitialized_ = GL_FALSE;
 }
 
-Font::Font(const std::string &fontPath, GLuint size, GLuint dpi)
+Font::Font(const std::string &fontPath, uint32_t size, uint32_t dpi)
 		: fontPath_(fontPath),
 		  size_(size),
 		  dpi_(dpi),
@@ -84,8 +84,8 @@ Font::Font(const std::string &fontPath, GLuint size, GLuint dpi)
 	// for Texture2DArray.
 	int pixels_x = ::FT_MulFix((face->bbox.xMax - face->bbox.xMin), face->size->metrics.x_scale);
 	int pixels_y = ::FT_MulFix((face->bbox.yMax - face->bbox.yMin), face->size->metrics.y_scale);
-	auto textureWidth = (GLuint) (pixels_x / 64);
-	auto textureHeight = (GLuint) (pixels_y / 64);
+	auto textureWidth = (uint32_t) (pixels_x / 64);
+	auto textureHeight = (uint32_t) (pixels_y / 64);
 	// make sure texture dimensions are multiple of 2
 	if (textureWidth % 2 != 0) textureWidth += 1;
 	if (textureHeight % 2 != 0) textureHeight += 1;
@@ -127,7 +127,7 @@ Font::~Font() {
 const Font::FaceData &Font::faceData(GLushort ch) const { return faceData_[ch]; }
 
 GLubyte *Font::invertPixmapWithAlpha(
-		const FT_Bitmap &bitmap, GLuint width, GLuint height) {
+		const FT_Bitmap &bitmap, uint32_t width, uint32_t height) {
 	const unsigned int arraySize = width * height;
 	auto *inverse = new GLubyte[arraySize];
 	auto *inverse_ptr = inverse;
@@ -145,7 +145,7 @@ GLubyte *Font::invertPixmapWithAlpha(
 	return inverse;
 }
 
-void Font::initGlyph(FT_Face face, GLushort ch, GLuint textureWidth, GLuint textureHeight) {
+void Font::initGlyph(FT_Face face, GLushort ch, uint32_t textureWidth, uint32_t textureHeight) {
 	FaceData &glyphData = faceData_[ch];
 	FT_Glyph glyph;
 	GLubyte *inverted;

--- a/regen/objects/text/font.h
+++ b/regen/objects/text/font.h
@@ -73,7 +73,7 @@ namespace regen {
 		 * @param size font size, as usual
 		 * @param dpi dots per inch for font
 		 */
-		static ref_ptr<Font> get(const std::string &filename, GLuint size, GLuint dpi = 96);
+		static ref_ptr<Font> get(const std::string &filename, uint32_t size, uint32_t dpi = 96);
 
 		/**
 		 * Load a font.
@@ -92,7 +92,7 @@ namespace regen {
 		 * @param size font size, as usual
 		 * @param dpi dots per inch for font
 		 */
-		Font(const std::string &filename, GLuint size, GLuint dpi = 96);
+		Font(const std::string &filename, uint32_t size, uint32_t dpi = 96);
 
 		~Font() override;
 
@@ -124,8 +124,8 @@ namespace regen {
 		static GLboolean isFreetypeInitialized_;
 
 		const std::string fontPath_;
-		const GLuint size_;
-		const GLuint dpi_;
+		const uint32_t size_;
+		const uint32_t dpi_;
 		ref_ptr<Texture2DArray> arrayTexture_;
 		FaceData *faceData_;
 		GLfloat lineHeight_;
@@ -139,9 +139,9 @@ namespace regen {
 
 		Font &operator=(const Font &) { return *this; }
 
-		static GLubyte *invertPixmapWithAlpha(const FT_Bitmap &bitmap, GLuint width, GLuint height);
+		static GLubyte *invertPixmapWithAlpha(const FT_Bitmap &bitmap, uint32_t width, uint32_t height);
 
-		void initGlyph(FT_Face face, GLushort ch, GLuint textureWidth, GLuint textureHeight);
+		void initGlyph(FT_Face face, GLushort ch, uint32_t textureWidth, uint32_t textureHeight);
 	};
 } // namespace
 

--- a/regen/objects/text/texture-mapped-text.cpp
+++ b/regen/objects/text/texture-mapped-text.cpp
@@ -61,7 +61,7 @@ void TextureMappedText::set_value(
 
 void TextureMappedText::updateAttributes(Alignment alignment, GLfloat maxLineWidth) {
 	Vec3f translation, glyphTranslation;
-	GLuint vertexCounter = 0u;
+	uint32_t vertexCounter = 0u;
 
 	GLfloat actualMaxLineWidth = 0.0;
 
@@ -89,7 +89,7 @@ void TextureMappedText::updateAttributes(Alignment alignment, GLfloat maxLineWid
 
 		// get line width and split the line
 		// where it exceeds the width limit
-		for (GLuint i = 0; i < it->size(); ++i) {
+		for (uint32_t i = 0; i < it->size(); ++i) {
 			const wchar_t &ch = (*it)[i];
 			buf = lineWidth + font_->faceData(ch).advanceX * height_;
 			if (maxLineWidth > 0.0 && buf > maxLineWidth && lastSpaceIndex != 0) {
@@ -134,7 +134,7 @@ void TextureMappedText::updateAttributes(Alignment alignment, GLfloat maxLineWid
 
 		// create the geometry with appropriate
 		// translation and size for each glyph
-		for (GLuint i = 0; i < it->size(); ++i) {
+		for (uint32_t i = 0; i < it->size(); ++i) {
 			const wchar_t &ch = (*it)[i];
 			const Font::FaceData &data = font_->faceData(ch);
 
@@ -157,7 +157,7 @@ void TextureMappedText::updateAttributes(Alignment alignment, GLfloat maxLineWid
 	// apply offset to each vertex
 	if (centerAtOrigin_) {
 		GLfloat centerOffset = actualMaxLineWidth * 0.5f;
-		for (GLuint i = 0; i < vertexCounter; ++i) {
+		for (uint32_t i = 0; i < vertexCounter; ++i) {
 			v_pos.w[i].x -= centerOffset;
 		}
 	}
@@ -175,7 +175,7 @@ void TextureMappedText::updateAttributes(Alignment alignment, GLfloat maxLineWid
 	// set center and extends for bounding box
 	minPosition_ = v_pos.w[0];
 	maxPosition_ = v_pos.w[0];
-	for (GLuint i = 1; i < vertexCounter; ++i) {
+	for (uint32_t i = 1; i < vertexCounter; ++i) {
 		minPosition_.setMin(v_pos.w[i]);
 		maxPosition_.setMax(v_pos.w[i]);
 	}
@@ -188,8 +188,8 @@ void TextureMappedText::makeGlyphGeometry(
 		ClientData_rw<Vec3f> &posAttribute,
 		ClientData_rw<Vec3f> &norAttribute,
 		ClientData_rw<Vec3f> &texcoAttribute,
-		GLuint *vertexCounter) {
-	GLuint &i = *vertexCounter;
+		uint32_t *vertexCounter) {
+	uint32_t &i = *vertexCounter;
 	Vec3f p0 = translation + Vec3f(0.0, data.height * height_, 0.0);
 	Vec3f p1 = translation + Vec3f(0.0, 0.0, 0.0);
 	Vec3f p2 = translation + Vec3f(data.width * height_, 0.0, 0.0);

--- a/regen/objects/text/texture-mapped-text.h
+++ b/regen/objects/text/texture-mapped-text.h
@@ -71,7 +71,7 @@ namespace regen {
 		std::list<std::wstring> value_;
 		GLfloat height_;
 		GLboolean centerAtOrigin_;
-		GLuint numCharacters_;
+		uint32_t numCharacters_;
 
 		ref_ptr<ShaderInput4f> textColor_;
 
@@ -88,7 +88,7 @@ namespace regen {
 				ClientData_rw<Vec3f> &posAttribute,
 				ClientData_rw<Vec3f> &norAttribute,
 				ClientData_rw<Vec3f> &texcoAttribute,
-				GLuint *vertexCounter);
+				uint32_t *vertexCounter);
 	};
 } // namespace
 

--- a/regen/scene/node-processor.h
+++ b/regen/scene/node-processor.h
@@ -93,7 +93,7 @@ namespace regen::scene {
 			}
 			if (input.hasAttribute("sort")) {
 				// Sort node children by model view matrix.
-				auto sortMode = input.getValue<GLuint>("sort", 0);
+				auto sortMode = input.getValue<uint32_t>("sort", 0);
 				ref_ptr<Camera> sortCam =
 						scene->getResource<Camera>(input.getValue<std::string>("sort-camera", ""));
 				if (sortCam.get() == nullptr) {
@@ -133,9 +133,9 @@ namespace regen::scene {
 				scene::SceneLoader *scene,
 				SceneInputNode &input,
 				const ref_ptr<StateNode> &parent) {
-			GLuint numIterations = 1;
+			uint32_t numIterations = 1;
 			if (input.hasAttribute("num-iterations")) {
-				numIterations = input.getValue<GLuint>("num-iterations", 1u);
+				numIterations = input.getValue<uint32_t>("num-iterations", 1u);
 			}
 
 			ref_ptr<State> state = ref_ptr<State>::alloc();

--- a/regen/scene/scene-input.cpp
+++ b/regen/scene/scene-input.cpp
@@ -14,7 +14,7 @@ using namespace std;
 #include <regen/utility/string-util.h>
 
 static void pushIndexToSequence(
-		GLuint numIndices, list<IndexRange> &indices, const IndexRange &indexRange) {
+		uint32_t numIndices, list<IndexRange> &indices, const IndexRange &indexRange) {
 	if (indexRange.from >= numIndices || indexRange.to >= numIndices) {
 		REGEN_WARN("Invalid index range " << indexRange.from << "-" << indexRange.to
 				<< " for numIndices=" << numIndices << ".");
@@ -54,7 +54,7 @@ string SceneInputNode::getDescription() {
 	return ss.str();
 }
 
-list<IndexRange> SceneInputNode::getIndexSequence(GLuint numIndices) {
+list<IndexRange> SceneInputNode::getIndexSequence(uint32_t numIndices) {
 	list<IndexRange> indices;
 	if (hasAttribute("index")) {
 		pushIndexToSequence(numIndices, indices,
@@ -63,15 +63,15 @@ list<IndexRange> SceneInputNode::getIndexSequence(GLuint numIndices) {
 		pushIndexToSequence(numIndices, indices,
 			IndexRange(getValue<GLint>("instance", 0u)));
 	} else if (hasAttribute("from-index") || hasAttribute("to-index")) {
-		auto from = getValue<GLuint>("from-index", 0u);
-		auto to = getValue<GLuint>("to-index", numIndices - 1);
-		auto step = getValue<GLuint>("index-step", 1u);
+		auto from = getValue<uint32_t>("from-index", 0u);
+		auto to = getValue<uint32_t>("to-index", numIndices - 1);
+		auto step = getValue<uint32_t>("index-step", 1u);
 		pushIndexToSequence(numIndices, indices,
 			IndexRange(from, to, step));
 	} else if (hasAttribute("from-instance") || hasAttribute("to-instance")) {
-		auto from = getValue<GLuint>("from-instance", 0u);
-		auto to = getValue<GLuint>("to-instance", numIndices - 1);
-		auto step = getValue<GLuint>("instance-step", 1u);
+		auto from = getValue<uint32_t>("from-instance", 0u);
+		auto to = getValue<uint32_t>("to-instance", numIndices - 1);
+		auto step = getValue<uint32_t>("instance-step", 1u);
 		pushIndexToSequence(numIndices, indices,
 			IndexRange(from, to, step));
 	} else if (hasAttribute("indices")) {
@@ -87,7 +87,7 @@ list<IndexRange> SceneInputNode::getIndexSequence(GLuint numIndices) {
 		for (auto & it : indicesStr)
 			pushIndexToSequence(numIndices, indices, IndexRange(atoi(it.c_str())));
 	} else if (hasAttribute("random-indices")) {
-		auto indexCount = getValue<GLuint>("random-indices", numIndices);
+		auto indexCount = getValue<uint32_t>("random-indices", numIndices);
 		while (indexCount > 0) {
 			--indexCount;
 			pushIndexToSequence(numIndices, indices, IndexRange(rand() % numIndices));

--- a/regen/scene/scene-input.h
+++ b/regen/scene/scene-input.h
@@ -171,6 +171,37 @@ namespace regen::scene {
 
 		/**
 		 * @param key the attribute key.
+		 * @param delimiter Delimiter for array items.
+		 * @return Get the typed attribute value as array or empty array if attribute
+		 *          not found.
+		 */
+		template<typename T>
+		std::vector<T> getArray(const std::string &key, const char delimiter = ',') {
+			std::vector<T> out;
+			if (hasAttribute(key)) {
+				std::string attValue = getValue(key);
+				std::stringstream ss1(attValue);
+				std::string item;
+				while (std::getline(ss1, item, delimiter)) {
+					std::stringstream itemStream(item);
+					T value;
+					if ((itemStream >> value).fail()) {
+						REGEN_WARN("Failed to parse array item '" << item <<
+																 "' for node " << getDescription() << ".");
+					} else {
+						out.push_back(value);
+					}
+				}
+			} else {
+				if (parent_ != nullptr) {
+					return parent_->getArray<T>(key, delimiter);
+				}
+			}
+			return out;
+		}
+
+		/**
+		 * @param key the attribute key.
 		 * @return Get the typed attribute value or std::nullopt if attribute
 		 *          not found.
 		 */

--- a/regen/scene/scene-input.h
+++ b/regen/scene/scene-input.h
@@ -206,7 +206,7 @@ namespace regen::scene {
 		 * @param maxIndex Maximal index in output list.
 		 * @return The list of indices.
 		 */
-		std::list<IndexRange> getIndexSequence(GLuint maxIndex);
+		std::list<IndexRange> getIndexSequence(uint32_t maxIndex);
 
 	protected:
 		SceneInputNode *parent_;

--- a/regen/scene/scene-loader.cpp
+++ b/regen/scene/scene-loader.cpp
@@ -111,7 +111,7 @@ void SceneLoader::loadShapes() {
 	}
 }
 
-void SceneLoader::addEventHandler(GLuint eventID,
+void SceneLoader::addEventHandler(uint32_t eventID,
                                   const ref_ptr<EventHandler> &eventHandler) {
 	application_->connect(eventID, eventHandler);
 }
@@ -317,7 +317,7 @@ ref_ptr<BoneAnimationItem> SceneLoader::getAnimationRanges(const std::string &as
 		range.name = rangeNode->getValue("name");
 		range.range = rangeNode->getValue<Vec2d>("range", Vec2d::zero());
 		range.trackName = rangeNode->getValue("track");
-		range.trackIndex = rangeNode->getValue<GLuint>("track-index", 0u);
+		range.trackIndex = rangeNode->getValue<uint32_t>("track-index", 0u);
 		rangeNameMap[range.name] = &range;
 		if (rangeNode->hasAttribute("motion")) {
 			auto &newClip = item->clips.emplace_back();

--- a/regen/scene/scene-loader.h
+++ b/regen/scene/scene-loader.h
@@ -93,7 +93,7 @@ namespace regen::scene {
 		 * @param eventID The Application event id.
 		 * @param eventHandler The EventHandler.
 		 */
-		void addEventHandler(GLuint eventID, const ref_ptr<EventHandler> &eventHandler);
+		void addEventHandler(uint32_t eventID, const ref_ptr<EventHandler> &eventHandler);
 
 		/**
 		 * Note: Event handlers are not automatically removed.

--- a/regen/scene/scene.cpp
+++ b/regen/scene/scene.cpp
@@ -202,7 +202,7 @@ void Scene::resizeGL(const Vec2i &size) {
 void GLAPIENTRY openglDebugCallback(
     GLenum source,
     GLenum type,
-    GLuint id,
+    uint32_t id,
     GLenum severity,
     GLsizei length,
     const GLchar *message,

--- a/regen/scene/scene.cpp
+++ b/regen/scene/scene.cpp
@@ -77,6 +77,9 @@ Scene::Scene(const int& /*argc*/, const char** /*argv*/)
 	TextureLoaderRegistry::registerLoader(std::make_unique<STBLoader>());
 #endif
 	TextureLoaderRegistry::registerLoader(std::make_unique<DevilLoader>());
+
+	// Create worker threads in the job pool
+	getJobPool();
 }
 
 void Scene::addShaderPath(const std::string &path) {

--- a/regen/scene/scene.h
+++ b/regen/scene/scene.h
@@ -336,6 +336,14 @@ namespace regen {
 		void setWorldTime(float t);
 
 		/**
+		 * @return the job pool.
+		 */
+		static JobPool& getJobPool() {
+			static JobPool jobPool(getMaxNumJobs());
+			return jobPool;
+		}
+
+		/**
 		 * Run some function within a thread with GL context.
 		 * NOTE: Returns without waiting for the function to finish.
 		 * @param f the function to run.
@@ -400,6 +408,21 @@ namespace regen {
 		bool isGLInitialized_;
 		bool isTimeInitialized_;
 		bool isVSyncEnabled_;
+
+		static uint32_t getMaxNumJobs() {
+			// Note: -2 is for graphics and animation thread.
+			// Note: But we may run other dedicated threads.
+			const uint32_t numRemainingCores =
+					std::max(1u, std::thread::hardware_concurrency() - 2);
+			// if we have a lot of cores, be a bit more conservative
+			if (numRemainingCores > 8u) {
+				return numRemainingCores - 2u;
+			} else if (numRemainingCores > 4u) {
+				return numRemainingCores - 1u;
+			} else {
+				return numRemainingCores;
+			}
+		}
 
 		void setupShaderLoading();
 

--- a/regen/scene/shader-input-processor.h
+++ b/regen/scene/shader-input-processor.h
@@ -207,7 +207,7 @@ namespace regen {
 						REGEN_WARN("No Mesh found for '" << input.getDescription() << "'.");
 						return {};
 					}
-					auto meshIndex = input.getValue<GLuint>("mesh-index", 0);
+					auto meshIndex = input.getValue<uint32_t>("mesh-index", 0);
 					ref_ptr<Mesh> mesh = compositeMesh->meshes().front();
 					if (compositeMesh->meshes().size() > meshIndex) {
 						mesh = compositeMesh->meshes().at(meshIndex);
@@ -367,11 +367,11 @@ namespace regen {
 				ref_ptr<U> v = ref_ptr<U>::alloc(input.getValue("name"));
 				v->set_isConstant(input.getValue<bool>("is-constant", false));
 
-				auto numInstances = input.getValue<GLuint>("num-instances", 1u);
-				auto numVertices = input.getValue<GLuint>("num-vertices", 1u);
+				auto numInstances = input.getValue<uint32_t>("num-instances", 1u);
+				auto numVertices = input.getValue<uint32_t>("num-vertices", 1u);
 				bool isInstanced = input.getValue<bool>("is-instanced", false);
 				bool isAttribute = input.getValue<bool>("is-attribute", false);
-				GLuint count = 1;
+				uint32_t count = 1;
 				// read the gpu-usage flag
 				if (input.getValue<std::string>("gpu-usage", "READ") == "WRITE") {
 					v->setServerAccessMode(BUFFER_GPU_WRITE);
@@ -393,7 +393,7 @@ namespace regen {
 				if (isInstanced || isAttribute) {
 					auto values = v->mapClientDataRaw(BUFFER_GPU_WRITE);
 					auto typedValues = (T *) values.w;
-					for (GLuint i = 0; i < count; i += 1) typedValues[i] = defaultValue;
+					for (uint32_t i = 0; i < count; i += 1) typedValues[i] = defaultValue;
 					values.unmap();
 					setInput(input, v.get(), count);
 				}

--- a/regen/scene/shape-processor.cpp
+++ b/regen/scene/shape-processor.cpp
@@ -444,7 +444,7 @@ void ShapeProcessor::processInput(
 		numInstances = transform->numInstances();
 	}
 	if (input.hasAttribute("num-instances")) {
-		numInstances = input.getValue<GLuint>("num-instances", numInstances);
+		numInstances = input.getValue<uint32_t>("num-instances", numInstances);
 	}
 
 	if (isPhysicalShape) {
@@ -457,7 +457,7 @@ void ShapeProcessor::processInput(
 			scene->getPhysics()->addObject(physicalObject);
 		} else {
 			auto motionAnim = ref_ptr<ModelMatrixUpdater>::alloc(transform);
-			for (GLuint i = 0; i < numInstances; ++i) {
+			for (uint32_t i = 0; i < numInstances; ++i) {
 				auto motion = ref_ptr<Mat4fMotion>::alloc(motionAnim, i);
 				auto physicalProps = createPhysicalProps(input, mesh, motion);
 				auto physicalObject = ref_ptr<PhysicalObject>::alloc(physicalProps);
@@ -473,7 +473,7 @@ void ShapeProcessor::processInput(
 		// add shape to spatial index
 		auto spatialIndex = getSpatialIndex(scene, input);
 		if (spatialIndex.get()) {
-			for (GLuint i = 0; i < numInstances; ++i) {
+			for (uint32_t i = 0; i < numInstances; ++i) {
 				auto shape = createShape(input, mesh, parts);
 				if (!shape.get()) {
 					REGEN_WARN("Skipping shape node " << input.getDescription() << " without shape.");

--- a/regen/scene/value-generator.h
+++ b/regen/scene/value-generator.h
@@ -26,7 +26,7 @@ namespace regen {
 			 * @param defaultValue The default value.
 			 */
 			ValueGenerator(SceneInputNode *n,
-						   const GLuint numValues,
+						   const uint32_t numValues,
 						   const T &defaultValue = T(0))
 					: n_(n),
 					  numValues_(numValues),
@@ -52,7 +52,7 @@ namespace regen {
 
 		protected:
 			SceneInputNode *n_;
-			GLuint numValues_;
+			uint32_t numValues_;
 			Vec4ui counter_;
 			T value_;
 			std::string mode_;
@@ -75,8 +75,8 @@ namespace regen {
 					stepY * (counter_.y + math::random<float>()*varianceY) +
 					stepZ * (counter_.z + math::random<float>()*varianceZ);
 
-				auto xCount = n_->getValue<GLuint>("x-count", numValues_);
-				auto yCount = n_->getValue<GLuint>("y-count", 1);
+				auto xCount = n_->getValue<uint32_t>("x-count", numValues_);
+				auto yCount = n_->getValue<uint32_t>("y-count", 1);
 				counter_.x += 1;
 				if (counter_.x >= xCount) {
 					counter_.x = 0;

--- a/regen/shader/directive-processor.cpp
+++ b/regen/shader/directive-processor.cpp
@@ -347,7 +347,7 @@ bool DirectiveProcessor::process(PreProcessorState &state, string &line) {
 	} else if (hasPrefix(statement, "#version ")) {
 		string versionStr = truncPrefix(statement, "#version ");
 		boost::trim(versionStr);
-		auto version = (GLuint) atoi(versionStr.c_str());
+		auto version = (uint32_t) atoi(versionStr.c_str());
 		if (state.version < version) { state.version = version; }
 		// remove version directives, must be prepended later
 		return DirectiveProcessor::getline(state, line);

--- a/regen/shader/glsl-processor.h
+++ b/regen/shader/glsl-processor.h
@@ -71,7 +71,7 @@ namespace regen {
 		/** The currently pre-processed shader stage. */
 		GLenum currStage;
 		/** The minimum GLSL version */
-		GLuint version;
+		uint32_t version;
 		/** Input stream providing unprocessed GLSL code. */
 		std::stringstream inStream;
 	};

--- a/regen/shader/io-processor.cpp
+++ b/regen/shader/io-processor.cpp
@@ -205,7 +205,7 @@ IOProcessor::InputOutput IOProcessor::getUniformIO(const NamedShaderInput &unifo
 	io.interpolation = "";
 	io.ioType = "uniform";
 	io.value = "";
-	GLuint numElements = uniform.in_->numArrayElements() * uniform.in_->numInstances();
+	uint32_t numElements = uniform.in_->numArrayElements() * uniform.in_->numInstances();
 	io.numElements = (numElements > 1 || uniform.in_->forceArray()) ?
 					 REGEN_STRING(numElements) : "";
 	if (uniform.in_->numInstances()>1 && currStage_ != GL_COMPUTE_SHADER) {
@@ -253,7 +253,7 @@ void IOProcessor::declareSpecifiedInput(PreProcessorState &state) {
 		} else {
 			io.dataType = it.type_;
 		}
-		GLuint numElements = in->numArrayElements() * in->numInstances();
+		uint32_t numElements = in->numArrayElements() * in->numInstances();
 		io.numElements = (numElements > 1 || in->forceArray()) ?
 						 REGEN_STRING(numElements) : "";
 		if (io.dataType == "samplerBuffer") {

--- a/regen/shader/preprocessor-config.h
+++ b/regen/shader/preprocessor-config.h
@@ -12,7 +12,7 @@ namespace regen {
 		 * Default constructor.
 		 */
 		PreProcessorConfig(
-				GLuint _version,
+				uint32_t _version,
 				const std::map<GLenum, std::string> &_unprocessed,
 				const std::map<std::string, std::string> &_defines = std::map<std::string, std::string>(),
 				const std::map<std::string, std::string> &_externalFunctions = std::map<std::string, std::string>(),
@@ -26,7 +26,7 @@ namespace regen {
 				  includes(_includes) {}
 
 		/** GLSL version. */
-		GLuint version;
+		uint32_t version;
 		/** Input GLSL code. */
 		const std::map<GLenum, std::string> &unprocessed;
 		/** Shader configuration using macros. */

--- a/regen/shader/regen/animation/boid.glsl
+++ b/regen/shader/regen/animation/boid.glsl
@@ -463,11 +463,6 @@ void main() {
 
     // Write back to SSBOs
 #ifdef HAS_boidData
-    // FIXME: for some reason it does not work well when writing into index gid.
-    //        But I think this would actually be better, as the model matrices would be sorted
-    //        (kind of), which could help with LOD computation and doing things next frame.
-    //        But it is significantly slower, also boid behavior does not seem right.
-    //uint writeIdx = gid;
     uint writeIdx = in_values[gid];
 #else
     uint writeIdx = gid;

--- a/regen/shader/regen/particles/emitter.glsl
+++ b/regen/shader/regen/particles/emitter.glsl
@@ -68,9 +68,7 @@ void particleUpdateVelocity(float dt)
     out_velocity += velocityChange * dt;
 }
 
-void particleUpdate(float dt, inout uint seed)
-{
-    // TODO: why scale time?
+void particleUpdate(float dt, inout uint seed) {
     float dt_ms = dt*0.001;
 
     out_lifetime -= dt_ms;

--- a/regen/shader/regen/particles/sprite.glsl
+++ b/regen/shader/regen/particles/sprite.glsl
@@ -172,9 +172,9 @@ void main() {
     out_color.rgb *= diffuseColor;
     #endif
     // apply the brightness of the particle
-    // TODO: this is not super useful with ADD blending, low values make the particle disappear
-    //        so this is actually more of a density threshold than a brightness.
-    //        not sure what the best strategy is here....
+    // NOTE: This is not super useful with ADD blending, low values make the particle disappear
+    //   so this is actually more of a density threshold than a brightness.
+    //   not sure what the best strategy is here....
     out_color.rgb *= in_particleBrightness;
     out_color.a *= opacity;
     #ifdef OPACITY_WEIGHTED_COLOR

--- a/regen/shader/regen/weather/bright-stars.glsl
+++ b/regen/shader/regen/weather/bright-stars.glsl
@@ -108,7 +108,7 @@ void emitBrightStar(int layer) {
     
     vec3 u = cross(p, vec3(0, 0, 1));
     vec3 v = cross(p, u);
-    // TODO: Low LoD yields in artifacts for big stars and algorithms which require
+    // NOTE: Low LoD yields in artifacts for big stars and algorithms which require
     //       good tesselation such as paraboloid mapping.
     emitVertex(p - normalize(-u -v) * in_k[0], vec2(-1.0, -1.0), layer);
     emitVertex(p - normalize(-u +v) * in_k[0], vec2(-1.0,  1.0), layer);

--- a/regen/shader/shader-input.cpp
+++ b/regen/shader/shader-input.cpp
@@ -161,7 +161,7 @@ void ShaderInput::set_isVertexAttribute(bool isVertexAttribute) {
 	}
 }
 
-void ShaderInput::set_buffer(GLuint buffer, const ref_ptr<BufferReference> &it) {
+void ShaderInput::set_buffer(uint32_t buffer, const ref_ptr<BufferReference> &it) {
 	buffer_ = buffer;
 	bufferIterator_ = it;
 	bufferStamp_ = stampOfReadData();
@@ -185,7 +185,7 @@ void ShaderInput::enableUniform(GLint loc) const {
 /////////////
 ////////////
 
-void ShaderInput::writeVertex(GLuint index, const byte *data) {
+void ShaderInput::writeVertex(uint32_t index, const byte *data) {
 	// NOTE: it is maybe a bit confusing, but the semantics of writeVertex is currently
 	//       different for uniform array data vs vertex data.
 	//       For vertex data, it is assumed that data is one vertex including all array elements.
@@ -230,7 +230,7 @@ void ShaderInput::updateAlignedSize() {
 	}
 }
 
-void ShaderInput::setInstanceData(GLuint numInstances, GLuint divisor, const byte *data) {
+void ShaderInput::setInstanceData(uint32_t numInstances, uint32_t divisor, const byte *data) {
 	auto dataSize_bytes = elementSize_ * numInstances / divisor;
 
 	if (dataSize_bytes != unalignedSize_ || isVertexAttribute_ || !hasClientData()) {
@@ -254,7 +254,7 @@ void ShaderInput::setInstanceData(GLuint numInstances, GLuint divisor, const byt
 	}
 }
 
-void ShaderInput::setVertexData(GLuint numVertices, const byte *data) {
+void ShaderInput::setVertexData(uint32_t numVertices, const byte *data) {
 	auto dataSize_bytes = elementSize_ * numVertices;
 
 	if (dataSize_bytes != unalignedSize_ || !isVertexAttribute_ || !hasClientData()) {
@@ -279,7 +279,7 @@ void ShaderInput::setVertexData(GLuint numVertices, const byte *data) {
 }
 
 // TODO: remove?
-void ShaderInput::writeServerData(GLuint index) const {
+void ShaderInput::writeServerData(uint32_t index) const {
 	if (!hasClientData() || !hasServerData()) return;
 	auto mappedClientData = clientBuffer_->mapRange(BUFFER_GPU_READ, 0, inputSize_);
 	auto clientData = mappedClientData.r;
@@ -303,8 +303,8 @@ void ShaderInput::writeServerData() const {
 	if (static_cast<uint32_t>(stride_) == elementSize_) {
 		glNamedBufferSubData(buffer_, offset_, inputSize_, clientData);
 	} else {
-		GLuint offset = offset_;
-		for (GLuint i = 0; i < count; ++i) {
+		uint32_t offset = offset_;
+		for (uint32_t i = 0; i < count; ++i) {
 			glNamedBufferSubData(buffer_, offset, elementSize_, clientData);
 			offset += stride_;
 			clientData += elementSize_;
@@ -329,7 +329,7 @@ void ShaderInput::readServerData() {
 	if (static_cast<uint32_t>(stride_) == elementSize_) {
 		std::memcpy(clientData, serverData, inputSize_);
 	} else {
-		for (GLuint i = 0; i < numVertices_; ++i) {
+		for (uint32_t i = 0; i < numVertices_; ++i) {
 			std::memcpy(clientData, serverData, elementSize_);
 			serverData += stride_;
 			clientData += elementSize_;
@@ -365,7 +365,7 @@ ref_ptr<ShaderInput> ShaderInput::create(const ref_ptr<ShaderInput> &in) {
 
 	const std::string &name = in->name();
 	GLenum baseType = in->baseType();
-	GLuint valsPerElement = in->valsPerElement();
+	uint32_t valsPerElement = in->valsPerElement();
 
 	switch (baseType) {
 		case GL_FLOAT:

--- a/regen/shader/shader-input.h
+++ b/regen/shader/shader-input.h
@@ -524,13 +524,6 @@ namespace regen {
 		void readServerData();
 
 		/**
-		 * Write a single vertex to the GL server.
-		 * @param rs The RenderState.
-		 * @param index The vertex index.
-		 */
-		void writeServerData(uint32_t index) const;
-
-		/**
 		 * Write this attribute to the GL server.
 		 * @param rs The RenderState.
 		 */

--- a/regen/shader/shader-input.h
+++ b/regen/shader/shader-input.h
@@ -254,7 +254,7 @@ namespace regen {
 		/**
 		 * @param numVertices the vertex count.
 		 */
-		void set_numVertices(GLuint numVertices) { numVertices_ = numVertices; }
+		void set_numVertices(uint32_t numVertices) { numVertices_ = numVertices; }
 
 		/**
 		 * Attribute size for all vertices.
@@ -264,13 +264,13 @@ namespace regen {
 		/**
 		 * Attribute size for all vertices.
 		 */
-		void set_inputSize(GLuint size) { inputSize_ = size; }
+		void set_inputSize(uint32_t size) { inputSize_ = size; }
 
 		/**
 		 * VBO that contains this vertex data.
 		 * Iterator should be exclusively owned by this instance.
 		 */
-		void set_buffer(GLuint buffer, const ref_ptr<BufferReference> &ref);
+		void set_buffer(uint32_t buffer, const ref_ptr<BufferReference> &ref);
 
 		/**
 		 * VBO that contains this vertex data.
@@ -291,7 +291,7 @@ namespace regen {
 		 * Offset in the VBO to the first
 		 * attribute element.
 		 */
-		void set_offset(GLuint offset) { offset_ = offset; }
+		void set_offset(uint32_t offset) { offset_ = offset; }
 
 		/**
 		 * Offset in the VBO to the first
@@ -387,14 +387,14 @@ namespace regen {
 		 * if the data pointer is not null.
 		 * numVertices*elementSize bytes will be allocated.
 		 */
-		void setVertexData(GLuint numVertices, const byte *vertexData = nullptr);
+		void setVertexData(uint32_t numVertices, const byte *vertexData = nullptr);
 
 		/**
 		 * Allocates RAM for the attribute and does a memcpy
 		 * if the data pointer is not null.
 		 * numInstances*elementSize/divisor bytes will be allocated.
 		 */
-		void setInstanceData(GLuint numInstances, GLuint divisor, const byte *instanceData = nullptr);
+		void setInstanceData(uint32_t numInstances, uint32_t divisor, const byte *instanceData = nullptr);
 
 		/**
 		 * @param data the input data.
@@ -508,7 +508,7 @@ namespace regen {
 		 * @param index vertex index.
 		 * @param data the data, will be copied into the internal data buffer.
 		 */
-		void writeVertex(GLuint index, const byte *data);
+		void writeVertex(uint32_t index, const byte *data);
 
 		/**
 		 * Deallocates data pointer owned by this instance.
@@ -528,7 +528,7 @@ namespace regen {
 		 * @param rs The RenderState.
 		 * @param index The vertex index.
 		 */
-		void writeServerData(GLuint index) const;
+		void writeServerData(uint32_t index) const;
 
 		/**
 		 * Write this attribute to the GL server.
@@ -731,8 +731,8 @@ namespace regen {
 		ShaderStructBase(
 				const std::string &structTypeName,
 				const std::string &name,
-				GLuint structSize,
-				GLuint numArrayElements,
+				uint32_t structSize,
+				uint32_t numArrayElements,
 				GLboolean normalize)
 				: ShaderInput(name, GL_NONE, structSize, 1, numArrayElements, normalize),
 				  structTypeName_(structTypeName) {
@@ -763,7 +763,7 @@ namespace regen {
 		ShaderInputStruct(
 				const std::string &typeName,
 				const std::string &name,
-				GLuint numArrayElements,
+				uint32_t numArrayElements,
 				GLboolean normalize = GL_FALSE)
 				: ShaderStructBase(typeName, name, sizeof(StructType), numArrayElements, normalize) {}
 
@@ -784,7 +784,7 @@ namespace regen {
 		 * @param vertexIndex index in data array.
 		 * @param val the new value.
 		 */
-		void setVertex(GLuint i, const StructType &val) {
+		void setVertex(uint32_t i, const StructType &val) {
 			mapClientVertex<StructType>(BUFFER_GPU_WRITE, i).w = val;
 		}
 
@@ -792,7 +792,7 @@ namespace regen {
 		 * @param vertexIndex index in data array.
 		 * @return data value at given index.
 		 */
-		ClientVertex_ro<StructType> getVertex(GLuint i) const {
+		ClientVertex_ro<StructType> getVertex(uint32_t i) const {
 			return mapClientVertex<StructType>(BUFFER_GPU_READ, i);
 		}
 
@@ -821,7 +821,7 @@ namespace regen {
 		 */
 		ShaderInputTyped(
 				const std::string &name,
-				GLuint numArrayElements,
+				uint32_t numArrayElements,
 				GLboolean normalize)
 				: ShaderInput(name,
 							  TypeValue,
@@ -854,7 +854,7 @@ namespace regen {
 		 * @param vertexIndex index in data array.
 		 * @param val the new value.
 		 */
-		void setVertex(GLuint i, const ValueType &val) {
+		void setVertex(uint32_t i, const ValueType &val) {
 			mapClientVertex<ValueType>(BUFFER_GPU_WRITE, i).w = val;
 		}
 
@@ -862,7 +862,7 @@ namespace regen {
 		 * @param vertexIndex index in data array.
 		 * @return data value at given index.
 		 */
-		ClientVertex_ro<ValueType> getVertex(GLuint i) const {
+		ClientVertex_ro<ValueType> getVertex(uint32_t i) const {
 			return mapClientVertex<ValueType>(BUFFER_GPU_READ, i);
 		}
 
@@ -871,14 +871,14 @@ namespace regen {
 		 * @param vertexIndex index in data array.
 		 * @param val the new value.
 		 */
-		void setVertexClamped(GLuint i, const ValueType &val) { setVertex(numElements_ui_ > i ? i : 0, val); }
+		void setVertexClamped(uint32_t i, const ValueType &val) { setVertex(numElements_ui_ > i ? i : 0, val); }
 
 		/**
 		 * Get vertex at index or the first vertex if index is out of bounds.
 		 * @param vertexIndex index in data array.
 		 * @return data value at given index.
 		 */
-		auto getVertexClamped(GLuint i) const { return getVertex(numElements_ui_ > i ? i : 0); }
+		auto getVertexClamped(uint32_t i) const { return getVertex(numElements_ui_ > i ? i : 0); }
 
 		/**
 		 * Write ShaderInput.
@@ -965,7 +965,7 @@ namespace regen {
 				uint32_t numArrayElements = 1,
 				bool normalize = false);
 
-		void setVertex3(GLuint i, const Vec3f &val) {
+		void setVertex3(uint32_t i, const Vec3f &val) {
 			auto mapped = mapClientVertex<Vec4f>(BUFFER_GPU_WRITE, i);
 			mapped.w.xyz() = val;
 		}

--- a/regen/shader/shader-state.cpp
+++ b/regen/shader/shader-state.cpp
@@ -62,7 +62,7 @@ GLboolean ShaderState::createShader(const StateConfig &cfg, const std::string &s
 
 GLboolean ShaderState::createShader(const StateConfig &cfg, const std::vector<std::string> &shaderKeys) {
 	std::map<GLenum, std::string> unprocessedCode;
-	for (GLuint i = 0u; i < shaderKeys.size(); ++i) {
+	for (uint32_t i = 0u; i < shaderKeys.size(); ++i) {
 		auto stage = glenum::glslStages()[i];
 		if (!shaderKeys[i].empty()) {
 			loadStage(cfg.defines_, shaderKeys[i], unprocessedCode, stage);

--- a/regen/shader/shader.cpp
+++ b/regen/shader/shader.cpp
@@ -83,7 +83,7 @@ void Shader::preProcess(
 /////////////
 
 void Shader::printLog(
-		GLuint shader,
+		uint32_t shader,
 		GLenum shaderType,
 		const char *shaderCode,
 		GLboolean success) {
@@ -111,7 +111,7 @@ void Shader::printLog(
 	if (!success && shaderCode != nullptr) {
 		std::vector<std::string> codeLines;
 		boost::split(codeLines, shaderCode, boost::is_any_of("\n"));
-		for (GLuint i = 0; i < codeLines.size(); ++i) {
+		for (uint32_t i = 0; i < codeLines.size(); ++i) {
 			REGEN_LOG(logLevel,
 					  std::setw(3) << i << std::setw(0) << " " << codeLines[i]);
 		}
@@ -162,7 +162,7 @@ Shader::Shader(const std::map<GLenum, std::string> &shaderCodes)
 
 Shader::Shader(
 		const std::map<GLenum, std::string> &shaderNames,
-		const std::map<GLenum, ref_ptr<GLuint> > &shaderStages)
+		const std::map<GLenum, ref_ptr<uint32_t> > &shaderStages)
 		: shaderCodes_(shaderNames),
 		  shaders_(shaderStages),
 		  feedbackLayout_(GL_SEPARATE_ATTRIBS),
@@ -203,7 +203,7 @@ const std::string &Shader::stageCode(GLenum stage) const {
 	}
 }
 
-ref_ptr<GLuint> Shader::stage(GLenum s) const {
+ref_ptr<uint32_t> Shader::stage(GLenum s) const {
 	auto it = shaders_.find(s);
 	if (it != shaders_.end()) {
 		return it->second;

--- a/regen/shader/shader.h
+++ b/regen/shader/shader.h
@@ -50,7 +50,7 @@ namespace regen {
 		 * @param success compiling/linking success ?
 		 */
 		static void printLog(
-				GLuint shader,
+				uint32_t shader,
 				GLenum shaderType,
 				const char *shaderCode,
 				GLboolean success);
@@ -71,7 +71,7 @@ namespace regen {
 		 */
 		Shader(
 				const std::map<GLenum, std::string> &shaderCode,
-				const std::map<GLenum, ref_ptr<GLuint> > &shaderObjects);
+				const std::map<GLenum, ref_ptr<uint32_t> > &shaderObjects);
 
 		/**
 		 * Create a new shader with given stage map.
@@ -193,7 +193,7 @@ namespace regen {
 		 * GL_GEOMETRY_SHADER, ...
 		 * Returns a NULL reference if no such shader stage is used.
 		 */
-		ref_ptr<GLuint> stage(GLenum stage) const;
+		ref_ptr<uint32_t> stage(GLenum stage) const;
 
 		/**
 		 * Returns shader stage GLSL code from enumeration.

--- a/regen/shapes/bounding-shape.h
+++ b/regen/shapes/bounding-shape.h
@@ -63,7 +63,7 @@ namespace regen {
 		 * @brief Set the instance ID of this shape
 		 * @param instanceID The instance ID
 		 */
-		void setInstanceID(GLuint instanceID) { instanceID_ = instanceID; }
+		void setInstanceID(uint32_t instanceID) { instanceID_ = instanceID; }
 
 		/**
 		 * @brief Get the instance ID of this shape

--- a/regen/shapes/quad-tree.h
+++ b/regen/shapes/quad-tree.h
@@ -11,9 +11,6 @@
 #include "regen/utility/aligned-array.h"
 
 namespace regen {
-	// forward declaration of QuadTreeTraversal
-	struct QuadTreeTraversal;
-
 	/**
 	 * A quad tree data structure for spatial indexing.
 	 * It fits the scene into a quad which it subdivides at places where

--- a/regen/shapes/spatial-index-debug.h
+++ b/regen/shapes/spatial-index-debug.h
@@ -43,8 +43,8 @@ namespace regen {
 		void debugFrustum(const Frustum &frustum, const Vec3f &color = Vec3f(0.0f, 1.0f, 0.0f));
 
 		ref_ptr<VAO> vao_;
-		GLuint vbo_{};
-		GLuint bufferSize_;
+		uint32_t vbo_{};
+		uint32_t bufferSize_;
 
 		friend class SpatialIndex;
 	};

--- a/regen/shapes/spatial-index.cpp
+++ b/regen/shapes/spatial-index.cpp
@@ -778,7 +778,7 @@ ref_ptr<SpatialIndex> SpatialIndex::load(LoadingContext &ctx, scene::SceneInputN
 
 	if (indexType == "quadtree") {
 		auto quadTree = ref_ptr<QuadTree>::alloc();
-		//quadTree->setMaxObjectsPerNode(input.getValue<GLuint>("max-objects-per-node", 4u));
+		//quadTree->setMaxObjectsPerNode(input.getValue<uint32_t>("max-objects-per-node", 4u));
 		quadTree->setMinNodeSize(input.getValue<float>("min-node-size", 0.1f));
 
 		if (input.hasAttribute("test-mode-3d")) {
@@ -792,7 +792,7 @@ ref_ptr<SpatialIndex> SpatialIndex::load(LoadingContext &ctx, scene::SceneInputN
 			}
 		}
 		if (input.hasAttribute("batch-size-3d")) {
-			quadTree->setBatchSize3D(input.getValue<GLuint>("batch-size-3d", 2048u));
+			quadTree->setBatchSize3D(input.getValue<uint32_t>("batch-size-3d", 2048u));
 		}
 		if (input.hasAttribute("close-distance")) {
 			auto dst = input.getValue<float>("close-distance", 20.0f);
@@ -800,7 +800,7 @@ ref_ptr<SpatialIndex> SpatialIndex::load(LoadingContext &ctx, scene::SceneInputN
 			quadTree->setCloseDistanceSquared(dst * dst);
 		}
 		if (input.hasAttribute("subdivision-threshold")) {
-			quadTree->setSubdivisionThreshold(input.getValue<GLuint>("subdivision-threshold", 4u));
+			quadTree->setSubdivisionThreshold(input.getValue<uint32_t>("subdivision-threshold", 4u));
 		}
 
 		index = quadTree;

--- a/regen/shapes/spatial-index.cpp
+++ b/regen/shapes/spatial-index.cpp
@@ -620,12 +620,8 @@ void SpatialIndex::resetCamera(IndexCamera *indexCamera, DistanceKeySize distanc
 
 void SpatialIndex::updateVisibility(uint32_t traversalMask) {
 	if constexpr (SPATIAL_INDEX_USE_MULTITHREADING) {
+		JobPool& pool = Scene::getJobPool();
 		uint32_t numIndexedCameras = indexCameras_.size();
-		if (!jobPool_) {
-			uint32_t numThreads = numIndexedCameras - 1; // leave one for the local thread
-			numThreads = std::max(1u, std::min(numThreads, maxNumThreads_));
-			jobPool_ = std::make_unique<JobPool>(numThreads);
-		}
 
 		// Schedule jobs for all index cameras, but keep the one with the most keys for the local thread.
 		IndexCamera *localIndexCamera = &indexCameras_.front();
@@ -636,16 +632,16 @@ void SpatialIndex::updateVisibility(uint32_t traversalMask) {
 			if (nextIndexCamera->numKeys > localIndexCamera->numKeys) {
 				std::swap(localIndexCamera, nextIndexCamera);
 			}
-			jobPool_->addJobPreFrame(Job{ .fn = visibilityJobFunc, .arg = nextIndexCamera });
+			pool.addJobPreFrame(Job{ .fn = visibilityJobFunc, .arg = nextIndexCamera });
 		}
 
 		// Execute jobs
-		jobPool_->beginFrame(1u); // one local job
+		pool.beginFrame(1u); // one local job
 		Job localJob { .fn = visibilityJobFunc, .arg = localIndexCamera };
 		do {
-			jobPool_->performJob(localJob);
-		} while (jobPool_->stealJob(localJob));
-		jobPool_->endFrame();
+			pool.performJob(localJob);
+		} while (pool.stealJob(localJob));
+		pool.endFrame();
 	} else { // no multithreading
 		for (auto &indexCamera: indexCameras_) {
 			resetCamera(&indexCamera, distanceBits_, traversalMask);
@@ -818,11 +814,6 @@ ref_ptr<SpatialIndex> SpatialIndex::load(LoadingContext &ctx, scene::SceneInputN
 			REGEN_WARN("Invalid distance-bits value " << distanceBits << ", using default 24 bits.");
 			index->setDistanceBits(DISTANCE_KEY_24);
 		}
-	}
-	if (input.hasAttribute("max-threads")) {
-		auto maxThreads = input.getValue<int>("max-threads", 4);
-		maxThreads = std::max(1, maxThreads);
-		index->setMaxNumThreads(static_cast<uint8_t>(maxThreads));
 	}
 
 	return index;

--- a/regen/shapes/spatial-index.h
+++ b/regen/shapes/spatial-index.h
@@ -127,12 +127,6 @@ namespace regen {
 		static ref_ptr<SpatialIndex> load(LoadingContext &ctx, scene::SceneInputNode &input);
 
 		/**
-		 * @brief Set the maximum number of threads to use
-		 * @param maxNumThreads The maximum number of threads
-		 */
-		void setMaxNumThreads(uint8_t maxNumThreads) { maxNumThreads_ = maxNumThreads; }
-
-		/**
 		 * @brief Set the number of bits to use for distance in sort key
 		 * @param distanceBits The number of bits
 		 */
@@ -281,10 +275,6 @@ namespace regen {
 		void removeDebugShape(const ref_ptr<BoundingShape> &shape);
 
 	protected:
-		// pool for multithreaded jobs
-		std::unique_ptr<JobPool> jobPool_;
-		// max number of threads to use
-		uint32_t maxNumThreads_ = std::thread::hardware_concurrency();
 		// number of bits to use for distance in sort key
 		DistanceKeySize distanceBits_ = DISTANCE_KEY_24;
 

--- a/regen/simulation/boid-simulation.cpp
+++ b/regen/simulation/boid-simulation.cpp
@@ -31,6 +31,7 @@ void BoidSimulation::initBoidSimulation0() {
 	avoidanceWeight_ = createUniform<ShaderInput1f,float>("avoidanceWeight", 1.0f);
 	avoidanceDistance_ = createUniform<ShaderInput1f,float>("avoidanceDistance", 0.1f);
 	visualRange_ = createUniform<ShaderInput1f,float>("visualRange", 1.6f);
+	attractionRange_ = createUniform<ShaderInput1f,float>("attractionRange", 160.0f);
 	lookAheadDistance_ = createUniform<ShaderInput1f,float>("lookAheadDistance", 0.1f);
 	repulsionFactor_ = createUniform<ShaderInput1f,float>("repulsionFactor", 20.0f);
 	maxNumNeighbors_ = createUniform<ShaderInput1ui,unsigned int>("maxNumNeighbors", 20);
@@ -45,6 +46,10 @@ void BoidSimulation::initBoidSimulation0() {
 void BoidSimulation::setVisualRange(float range) {
 	visualRange_->setVertex(0, range);
 	cellSize_->setVertex(0, range * 2.0f );
+}
+
+void BoidSimulation::setAttractionRange(float range) {
+	attractionRange_->setVertex(0, range);
 }
 
 void BoidSimulation::setSimulationBounds(const Bounds<Vec3f> &bounds) {
@@ -230,6 +235,9 @@ void BoidSimulation::loadSettings(LoadingContext &ctx, scene::SceneInputNode &in
 	}
 	if (input.hasAttribute("visual-range")) {
 		setVisualRange(input.getValue<float>("visual-range", 1.0f));
+	}
+	if (input.hasAttribute("attraction-range")) {
+		setAttractionRange(input.getValue<float>("attraction-range", 10.0f));
 	}
 	if (input.hasAttribute("coherence-weight")) {
 		setCoherenceWeight(input.getValue<float>("coherence-weight", 0.5f));

--- a/regen/simulation/boid-simulation.h
+++ b/regen/simulation/boid-simulation.h
@@ -37,6 +37,12 @@ namespace regen {
 		void setVisualRange(float range);
 
 		/**
+		 * Set the attraction range of the boids, i.e. how far they are attracted to the neighbors.
+		 * @param range the attraction range.
+		 */
+		void setAttractionRange(float range);
+
+		/**
 		 * Set the look ahead factor of the boids.
 		 * @param factor the look ahead factor.
 		 */
@@ -188,6 +194,7 @@ namespace regen {
 
 		ref_ptr<ShaderInput1ui> maxNumNeighbors_;
 		ref_ptr<ShaderInput1f> visualRange_;
+		ref_ptr<ShaderInput1f> attractionRange_;
 		ref_ptr<ShaderInput1f> maxBoidSpeed_;
 		ref_ptr<ShaderInput1f> maxAngularSpeed_;
 		ref_ptr<ShaderInput1f> coherenceWeight_;

--- a/regen/simulation/boids-cpu.cpp
+++ b/regen/simulation/boids-cpu.cpp
@@ -41,6 +41,7 @@ struct BoidsCPU::Private {
 
 	// Configuration parameters
 	float visualRange_ = 1.6f;
+	float attractionRange_ = 160.0f;
 	float visualRangeSq_ = 0.0f;
 	float avoidanceDistance_ = 0.0f;
 	float avoidanceDistanceHalf_ = 0.0f;
@@ -232,6 +233,7 @@ void BoidsCPU::animate(double dt) {
 	priv_->repulsionTimesSeparation_ = repulsionFactor_->getVertex(0).r * separationWeight_->getVertex(0).r;
 	priv_->visualRange_ = visualRange_->getVertex(0).r;
 	priv_->visualRangeSq_ = priv_->visualRange_ * priv_->visualRange_;
+	priv_->attractionRange_ = attractionRange_->getVertex(0).r;
 	priv_->separationWeight_ = separationWeight_->getVertex(0).r;
 	priv_->alignmentWeight_ = alignmentWeight_->getVertex(0).r;
 	priv_->coherenceWeight_ = coherenceWeight_->getVertex(0).r;
@@ -387,7 +389,6 @@ void zeroAligned(AlignedArray<int32_t> &vec) {
     int* data = vec.data();
     size_t i = 0;
     // Use AVX2 to set 8 ints (32 bytes) at a time
-    // TODO: use simd abstraction API
     __m256i zero = _mm256_setzero_si256();
     for (; i + 8 <= size; i += 8) {
         _mm256_store_si256(reinterpret_cast<__m256i*>(data + i), zero);
@@ -824,7 +825,7 @@ bool BoidsCPU::avoidDanger(const Vec3f &boidPos, Vec3f &boidForce) {
 }
 
 void BoidsCPU::attract(const Vec3f &boidPos, Vec3f &boidForce) {
-	auto maxDistance = priv_->visualRange_ * 100; // TODO: parameter
+	auto maxDistance = priv_->attractionRange_;
 	Vec3f dir;
 	for (auto &attractor: attractors_) {
 		dir = Vec3f::zero();

--- a/regen/simulation/bullet-debug-drawer.h
+++ b/regen/simulation/bullet-debug-drawer.h
@@ -42,8 +42,8 @@ namespace regen {
 		ref_ptr<ShaderInput3f> lineVertices_;
 
 		ref_ptr<VAO> vao_;
-		GLuint vbo_{};
-		GLuint bufferSize_;
+		uint32_t vbo_{};
+		uint32_t bufferSize_;
 		int m_debugMode;
 
 		regen::RenderState *renderState_{};

--- a/regen/simulation/impulse-controller.cpp
+++ b/regen/simulation/impulse-controller.cpp
@@ -53,7 +53,7 @@ ref_ptr<ImpulseController> ImpulseController::load(
 	ref_ptr<Mesh> mesh;
 	auto compositeMesh = scene->getResources()->getMesh(scene, node.getValue("mesh"));
 	if (compositeMesh.get() != nullptr && !compositeMesh->meshes().empty()) {
-		auto meshIndex = node.getValue<GLuint>("mesh-index", 0u);
+		auto meshIndex = node.getValue<uint32_t>("mesh-index", 0u);
 		if (meshIndex >= compositeMesh->meshes().size()) {
 			REGEN_WARN("Invalid mesh index for '" << node.getDescription() << "'.");
 			meshIndex = 0;

--- a/regen/simulation/model-matrix-motion.cpp
+++ b/regen/simulation/model-matrix-motion.cpp
@@ -43,7 +43,7 @@ void ModelMatrixUpdater::animate(GLdouble dt) {
 }
 
 
-Mat4fMotion::Mat4fMotion(const ref_ptr<ModelMatrixUpdater> &modelMatrix, GLuint index)
+Mat4fMotion::Mat4fMotion(const ref_ptr<ModelMatrixUpdater> &modelMatrix, uint32_t index)
 		: modelMatrix_(modelMatrix),
 		  glModelMatrix_(modelMatrix->backBuffer() + index),
 		  tfIndex_(index) {

--- a/regen/states/atomic-states.h
+++ b/regen/states/atomic-states.h
@@ -308,7 +308,7 @@ namespace regen {
 		 * @param numPatchVertices Specifies the number of vertices that
 		 * will be used to make up a single patch primitive.
 		 */
-		explicit PatchVerticesState(GLuint numPatchVertices)
+		explicit PatchVerticesState(uint32_t numPatchVertices)
 				: ServerSideState(), numPatchVertices_(numPatchVertices) {}
 
 		void enable(RenderState *rs) override { rs->patchVertices().push(numPatchVertices_); }
@@ -316,7 +316,7 @@ namespace regen {
 		void disable(RenderState *rs) override { rs->patchVertices().pop(); }
 
 	protected:
-		GLuint numPatchVertices_;
+		uint32_t numPatchVertices_;
 	};
 
 	/**
@@ -499,7 +499,7 @@ namespace regen {
 	protected:
 		ref_ptr<FBO> fbo_;
 		/** Current index. */
-		GLuint index_;
+		uint32_t index_;
 	};
 
 	/**

--- a/regen/states/blit-state.cpp
+++ b/regen/states/blit-state.cpp
@@ -111,7 +111,7 @@ ref_ptr<BlitState> BlitState::load(LoadingContext &ctx, scene::SceneInputNode &i
 			return {};
 		}
 	}
-	bool keepAspect = input.getValue<GLuint>("keep-aspect", false);
+	bool keepAspect = input.getValue<uint32_t>("keep-aspect", false);
 	if (src.get() != nullptr && dst.get() != nullptr) {
 		if (input.getValue("src-attachment") == "depth" || input.getValue("dst-attachment") == "depth") {
 			auto blit = ref_ptr<BlitToFBO>::alloc(
@@ -123,8 +123,8 @@ ref_ptr<BlitState> BlitState::load(LoadingContext &ctx, scene::SceneInputNode &i
 			blit->set_filterMode(GL_NEAREST);
 			return blit;
 		} else {
-			auto srcAttachment = input.getValue<GLuint>("src-attachment", 0u);
-			auto dstAttachment = input.getValue<GLuint>("dst-attachment", 0u);
+			auto srcAttachment = input.getValue<uint32_t>("src-attachment", 0u);
+			auto dstAttachment = input.getValue<uint32_t>("dst-attachment", 0u);
 			auto state = ref_ptr<BlitToFBO>::alloc(
 					src, dst,
 					GL_COLOR_ATTACHMENT0 + srcAttachment,
@@ -142,7 +142,7 @@ ref_ptr<BlitState> BlitState::load(LoadingContext &ctx, scene::SceneInputNode &i
 		}
 	} else if (src.get() != nullptr) {
 		// Blit Texture to Screen
-		auto srcAttachment = input.getValue<GLuint>("src-attachment", 0u);
+		auto srcAttachment = input.getValue<uint32_t>("src-attachment", 0u);
 		return ref_ptr<BlitToScreen>::alloc(src,
 											scene->screen(),
 											GL_COLOR_ATTACHMENT0 + srcAttachment,

--- a/regen/states/direct-shading.cpp
+++ b/regen/states/direct-shading.cpp
@@ -29,7 +29,7 @@ static std::string shadowFilterMode(ShadowFilterMode f) {
 	return "Single";
 }
 
-void DirectShading::updateDefine(DirectLight &l, GLuint lightIndex) {
+void DirectShading::updateDefine(DirectLight &l, uint32_t lightIndex) {
 	shaderDefine(
 			REGEN_STRING("LIGHT" << lightIndex << "_ID"),
 			REGEN_STRING(l.id_));
@@ -88,8 +88,8 @@ void DirectShading::addLight(
 		const ref_ptr<Texture> &shadow,
 		const ref_ptr<Texture> &shadowColor,
 		ShadowFilterMode shadowFilter) {
-	GLuint lightID = ++idCounter_;
-	GLuint lightIndex = lights_.size();
+	uint32_t lightID = ++idCounter_;
+	uint32_t lightIndex = lights_.size();
 
 	{
 		DirectLight dl;
@@ -190,7 +190,7 @@ void DirectShading::removeLight(const ref_ptr<Light> &l) {
 	}
 	lights_.erase(it);
 
-	GLuint numLights = lights_.size(), lightIndex = 0;
+	uint32_t numLights = lights_.size(), lightIndex = 0;
 	// update shader defines
 	shaderDefine("NUM_LIGHTS", REGEN_STRING(numLights));
 	for (auto &light: lights_) {

--- a/regen/states/direct-shading.h
+++ b/regen/states/direct-shading.h
@@ -59,7 +59,7 @@ namespace regen {
 		GLint idCounter_;
 
 		struct DirectLight {
-			GLuint id_;
+			uint32_t id_;
 			ref_ptr<Light> light_;
 			ref_ptr<LightCamera> camera_;
 			ref_ptr<Texture> shadow_;
@@ -73,7 +73,7 @@ namespace regen {
 		std::list<DirectLight> lights_;
 		ref_ptr<ShaderInput3f> ambientLight_;
 
-		void updateDefine(DirectLight &l, GLuint lightIndex);
+		void updateDefine(DirectLight &l, uint32_t lightIndex);
 	};
 } // namespace
 

--- a/regen/states/feedback-state.cpp
+++ b/regen/states/feedback-state.cpp
@@ -2,7 +2,7 @@
 
 using namespace regen;
 
-FeedbackSpecification::FeedbackSpecification(GLuint feedbackCount)
+FeedbackSpecification::FeedbackSpecification(uint32_t feedbackCount)
 		: State(),
 		  feedbackCount_(feedbackCount),
 		  feedbackMode_(GL_SEPARATE_ATTRIBS),
@@ -14,7 +14,7 @@ ref_ptr<ShaderInput> FeedbackSpecification::addFeedback(const ref_ptr<ShaderInpu
 	// remove if already added
 	if (feedbackAttributeMap_.count(in->name()) > 0) { removeFeedback(in.get()); }
 
-	GLuint feedbackCount = (feedbackCount_ == 0 ? in->numVertices() : feedbackCount_);
+	uint32_t feedbackCount = (feedbackCount_ == 0 ? in->numVertices() : feedbackCount_);
 	feedbackCount_ = feedbackCount;
 
 	// create feedback attribute
@@ -55,7 +55,7 @@ GLboolean FeedbackSpecification::hasFeedback(const std::string &name) const {
 
 FeedbackState::FeedbackState(
 			GLenum feedbackPrimitive,
-			GLuint feedbackCount,
+			uint32_t feedbackCount,
 			VertexLayout vertexLayout)
 		: FeedbackSpecification(feedbackCount),
 		  feedbackPrimitive_(feedbackPrimitive) {
@@ -116,14 +116,14 @@ void FeedbackState::disable(RenderState *rs) {
 	else {
 		rs->endTransformFeedback();
 		if (!rs->isTransformFeedbackAcive()) {
-			for (GLuint bufferIndex = 0u; bufferIndex < feedbackAttributes_.size(); ++bufferIndex) {
+			for (uint32_t bufferIndex = 0u; bufferIndex < feedbackAttributes_.size(); ++bufferIndex) {
 				rs->feedbackBufferRange().pop(bufferIndex);
 			}
 		}
 	}
 }
 
-void FeedbackState::draw(GLuint numInstances) {
+void FeedbackState::draw(uint32_t numInstances) {
 	glDrawArraysInstancedEXT(
 			feedbackPrimitive_,
 			0,

--- a/regen/states/feedback-state.h
+++ b/regen/states/feedback-state.h
@@ -7,7 +7,7 @@
 namespace regen {
 	class FeedbackSpecification : public State {
 	public:
-		explicit FeedbackSpecification(GLuint feedbackCount);
+		explicit FeedbackSpecification(uint32_t feedbackCount);
 
 		/**
 		 * @return number of captured vertices.
@@ -67,10 +67,10 @@ namespace regen {
 	protected:
 		typedef std::list<ref_ptr<ShaderInput> > FeedbackList;
 
-		GLuint feedbackCount_;
+		uint32_t feedbackCount_;
 		GLenum feedbackMode_;
 		GLenum feedbackStage_;
-		GLuint requiredBufferSize_;
+		uint32_t requiredBufferSize_;
 
 		FeedbackList feedbackAttributes_;
 		std::map<std::string, FeedbackList::iterator> feedbackAttributeMap_;
@@ -92,7 +92,7 @@ namespace regen {
 		 */
 		FeedbackState(
 				GLenum feedbackPrimitive,
-				GLuint feedbackCount,
+				uint32_t feedbackCount,
 				VertexLayout vertexLayout = VERTEX_LAYOUT_INTERLEAVED);
 
 		/**
@@ -113,7 +113,7 @@ namespace regen {
 		/**
 		 * Render primitives from transform feedback array data.
 		 */
-		void draw(GLuint numInstances);
+		void draw(uint32_t numInstances);
 
 		// override
 		void enable(RenderState *rs) override;
@@ -123,7 +123,7 @@ namespace regen {
 	protected:
 		GLenum feedbackPrimitive_;
 
-		GLuint allocatedBufferSize_;
+		uint32_t allocatedBufferSize_;
 		ref_ptr<VBO> feedbackBuffer_;
 		BufferRange bufferRange_;
 		ref_ptr<BufferReference> feedbackRef_;

--- a/regen/states/geometric-picking.cpp
+++ b/regen/states/geometric-picking.cpp
@@ -55,7 +55,6 @@ GeomPicking::GeomPicking(const ref_ptr<Camera> &camera, const ref_ptr<ShaderInpu
 	feedbackRange_.size_ = bufferSize_;
 
 	// Create a double-buffered PBO for reading the feedback buffer
-	// TODO: check if it is better to use two buffers, one mapped and one that we copy to like we did before.
 	BufferFlags mappingFlags(
 			TRANSFORM_FEEDBACK_BUFFER,
 			BufferUpdateFlags::FULL_PER_FRAME);

--- a/regen/states/geometric-picking.cpp
+++ b/regen/states/geometric-picking.cpp
@@ -96,7 +96,7 @@ void GeomPicking::traverse(RenderState *rs) {
 	state_->enable(rs);
 
 	int feedbackCount = 0;
-	GLuint feedbackQuery = 0;
+	uint32_t feedbackQuery = 0;
 	glGenQueries(1, &feedbackQuery);
 	for (auto &pickableNode: childs()) {
 		auto pickableMesh = pickableNode->findStateWithType<Mesh>();

--- a/regen/states/geometric-picking.h
+++ b/regen/states/geometric-picking.h
@@ -38,7 +38,7 @@ namespace regen {
 
 	protected:
 		ref_ptr<Camera> camera_;
-		GLuint maxPickedObjects_;
+		uint32_t maxPickedObjects_;
 
 		GLboolean hasPickedObject_;
 		PickData pickedObject_;
@@ -57,7 +57,7 @@ namespace regen {
 		ref_ptr<BufferReference> vboRef_;
 		ref_ptr<StagingStructBuffer<PickData>> pickMapping_;
 		BufferRange feedbackRange_;
-		GLuint bufferSize_;
+		uint32_t bufferSize_;
 
 		void updateMouse();
 	};

--- a/regen/states/light-state.cpp
+++ b/regen/states/light-state.cpp
@@ -259,19 +259,3 @@ ref_ptr<Light> Light::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 
 	return light;
 }
-
-//////////
-//////////
-//////////
-
-LightNode::LightNode(
-		const ref_ptr<Light> &light,
-		const ref_ptr<BoneNode> &n)
-		: State(), light_(light), animNode_(n) {
-	lightPosition_ = light->positionStaged(0).r.xyz();
-}
-
-void LightNode::update(GLdouble /*dt*/) {
-	Vec3f v = animNode_->localTransform.transformVector(lightPosition_);
-	light_->setPosition(0, v);
-}

--- a/regen/states/light-state.cpp
+++ b/regen/states/light-state.cpp
@@ -213,7 +213,7 @@ ref_ptr<Light> Light::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 			}
 			auto setTarget = target_opt.value().in;
 			auto numInstances = std::max(
-					child->getValue<GLuint>("num-instances", 1u),
+					child->getValue<uint32_t>("num-instances", 1u),
 					setTarget->numInstances());
 			// allocate memory for the shader input
 			setTarget->setInstanceData(numInstances, 1, nullptr);

--- a/regen/states/light-state.h
+++ b/regen/states/light-state.h
@@ -190,30 +190,6 @@ namespace regen {
 	std::istream &operator>>(std::istream &in, Light::Type &v);
 
 	/**
-	 * \brief Animates Light position using an AnimationNode.
-	 */
-	class LightNode : public State {
-	public:
-		/**
-		 * @param light a light.
-		 * @param n a animation node.
-		 */
-		LightNode(
-				const ref_ptr<Light> &light,
-				const ref_ptr<BoneNode> &n);
-
-		/**
-		 * @param dt update light position using the niamtion node.
-		 */
-		void update(GLdouble dt);
-
-	protected:
-		ref_ptr<Light> light_;
-		Vec3f lightPosition_; //!< the light position in local space
-		ref_ptr<BoneNode> animNode_;
-	};
-
-	/**
 	 * \brief Configures filtering.
 	 */
 	enum ShadowFilterMode {

--- a/regen/states/material-state.cpp
+++ b/regen/states/material-state.cpp
@@ -476,7 +476,7 @@ ref_ptr<Material> Material::load(LoadingContext &ctx, scene::SceneInputNode &inp
 			REGEN_WARN("Skipping unknown Asset for '" << input.getDescription() << "'.");
 		} else {
 			const std::vector<ref_ptr<Material> > materials = assetLoader->materials();
-			auto materialIndex = input.getValue<GLuint>("asset-index", 0u);
+			auto materialIndex = input.getValue<uint32_t>("asset-index", 0u);
 			if (materialIndex >= materials.size()) {
 				REGEN_WARN("Invalid Material index '" << materialIndex <<
 													  "' for Asset '" << input.getValue("asset") << "'.");

--- a/regen/states/model-transformation.cpp
+++ b/regen/states/model-transformation.cpp
@@ -367,11 +367,11 @@ static void makeInstances(InstancePlaneGenerator &generator, unsigned int i, uns
 	makeInstances(generator, cell, weights);
 }
 
-static GLuint transformMatrixPlane(
+static uint32_t transformMatrixPlane(
 		scene::SceneLoader *scene,
 		scene::SceneInputNode &input,
 		const ref_ptr<ModelTransformation> &tf,
-		GLuint numInstances) {
+		uint32_t numInstances) {
 	auto areaSize = input.getValue<Vec2f>("area-size", Vec2f::create(10.0f));
 	auto areaHalfSize = areaSize * 0.5f;
 

--- a/regen/states/state-config.h
+++ b/regen/states/state-config.h
@@ -46,12 +46,12 @@ namespace regen {
 		/**
 		 * @param version the GLSL version.
 		 */
-		void setVersion(GLuint version) { if (version > version_) version_ = version; }
+		void setVersion(uint32_t version) { if (version > version_) version_ = version; }
 
 		/**
 		 * @return the GLSL version.
 		 */
-		GLuint version() const { return version_; }
+		uint32_t version() const { return version_; }
 
 		/**
 		 * Macro key-value map. Macros are prepended to loaded shaders.
@@ -106,7 +106,7 @@ namespace regen {
 		}
 
 	protected:
-		GLuint version_;
+		uint32_t version_;
 	};
 } // namespace
 

--- a/regen/states/state-configurer.cpp
+++ b/regen/states/state-configurer.cpp
@@ -47,7 +47,7 @@ StateConfigurer::StateConfigurer()
 
 StateConfig &StateConfigurer::cfg() { return cfg_; }
 
-void StateConfigurer::setVersion(GLuint version) { cfg_.setVersion(version); }
+void StateConfigurer::setVersion(uint32_t version) { cfg_.setVersion(version); }
 
 void StateConfigurer::addNode(const StateNode *node) {
 	bool hadFBOBefore = hasFBO_;

--- a/regen/states/state-configurer.h
+++ b/regen/states/state-configurer.h
@@ -40,7 +40,7 @@ namespace regen {
 		/**
 		 * @param version the minimum GLSL version.
 		 */
-		void setVersion(GLuint version);
+		void setVersion(uint32_t version);
 
 		/**
 		 * Load shader configuration based on a given node (and parent nodes).
@@ -94,7 +94,7 @@ namespace regen {
 		StateConfig cfg_;
 		std::map<std::string, ShaderInputList::iterator> inputNames_;
 		std::set<const TextureState*> textureStates_;
-		GLuint numLights_;
+		uint32_t numLights_;
 		bool hasFBO_ = false;
 
 		void preAddState(const State *s);

--- a/regen/states/state-node.h
+++ b/regen/states/state-node.h
@@ -220,13 +220,13 @@ namespace regen {
 		/**
 		 * @param numIterations The number of iterations.
 		 */
-		explicit LoopNode(GLuint numIterations);
+		explicit LoopNode(uint32_t numIterations);
 
 		/**
 		 * @param state Associated state.
 		 * @param numIterations The number of iterations.
 		 */
-		LoopNode(const ref_ptr<State> &state, GLuint numIterations);
+		LoopNode(const ref_ptr<State> &state, uint32_t numIterations);
 
 		/**
 		 * @return The number of iterations.
@@ -236,7 +236,7 @@ namespace regen {
 		/**
 		 * @param numIterations The number of iterations.
 		 */
-		void set_numIterations(GLuint numIterations);
+		void set_numIterations(uint32_t numIterations);
 
 		// Override
 		void traverse(RenderState *rs) override;

--- a/regen/states/state.cpp
+++ b/regen/states/state.cpp
@@ -39,10 +39,6 @@ State::~State() {
 	attached_.clear();
 }
 
-const std::vector<NamedShaderInput> &State::inputs() const {
-	return inputs_;
-}
-
 int32_t State::numVertices() const {
 	return shared_->numVertices_;
 }
@@ -150,9 +146,8 @@ void State::setInput(const ref_ptr<ShaderInput> &in, const std::string &name, co
 		inputMap_.insert(inputName);
 	}
 
-	// TODO: Rather push back here. But it seems some code relies on the order of inputs.
-	//       This should be fixed in the future.
-	inputs_.insert(inputs_.begin(), NamedShaderInput{in, inputName, "", memberSuffix});
+	inputs_.emplace_back(NamedShaderInput{
+		in, inputName, "", memberSuffix});
 }
 
 void State::removeInput(const ref_ptr<ShaderInput> &in) {
@@ -171,9 +166,10 @@ void State::removeInput(const std::string &name) {
 }
 
 void State::collectShaderInput(ShaderInputList &out) {
-	out.insert(out.end(), inputs_.begin(), inputs_.end());
-	auto local = joined_;
-	for (auto &buddy: *local.get()) { buddy->collectShaderInput(out); }
+	out.insert(out.end(), inputs_.rbegin(), inputs_.rend());
+	for (auto &buddy: *joined_.get()) {
+		buddy->collectShaderInput(out);
+	}
 }
 
 std::optional<StateInput> State::findShaderInput(const std::string &name) {

--- a/regen/states/state.h
+++ b/regen/states/state.h
@@ -69,7 +69,7 @@ namespace regen {
 		/**
 		 * @return Previously added shader inputs.
 		 */
-		const std::vector<NamedShaderInput> &inputs() const;
+		const std::vector<NamedShaderInput> &inputs() const { return inputs_; }
 
 		/**
 		 * @param name the shader input name.

--- a/regen/states/state.h
+++ b/regen/states/state.h
@@ -226,7 +226,7 @@ namespace regen {
 		std::map<std::string, std::string> shaderDefines_;
 		std::vector<std::string> shaderIncludes_;
 		std::map<std::string, std::string> shaderFunctions_;
-		GLuint shaderVersion_ = 330;
+		uint32_t shaderVersion_ = 330;
 
 		template<typename F> void updateVector(F &&fn) {
 			// Make a copy, modify, then atomically swap

--- a/regen/states/tesselation-state.cpp
+++ b/regen/states/tesselation-state.cpp
@@ -44,7 +44,7 @@ namespace regen {
 	}
 }
 
-TesselationState::TesselationState(GLuint numPatchVertices)
+TesselationState::TesselationState(uint32_t numPatchVertices)
 		: State(),
 		  lodMetric_(CAMERA_DISTANCE),
 		  numPatchVertices_(numPatchVertices) {
@@ -107,7 +107,7 @@ const ref_ptr<ShaderInput1f> &TesselationState::lodFactor() const { return lodFa
 
 ref_ptr<TesselationState> TesselationState::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 	ref_ptr<TesselationState> tess = ref_ptr<TesselationState>::alloc(
-			input.getValue<GLuint>("num-patch-vertices", 3u));
+			input.getValue<uint32_t>("num-patch-vertices", 3u));
 
 	tess->innerLevel()->setVertex(0,
 								  input.getValue<Vec4f>("inner-level", Vec4f::create(8.0f)));

--- a/regen/states/tesselation-state.h
+++ b/regen/states/tesselation-state.h
@@ -37,7 +37,7 @@ namespace regen {
 		 * @param numPatchVertices Specifies the number of vertices that
 		 * will be used to make up a single patch primitive.
 		 */
-		explicit TesselationState(GLuint numPatchVertices);
+		explicit TesselationState(uint32_t numPatchVertices);
 
 		static ref_ptr<TesselationState> load(LoadingContext &ctx, scene::SceneInputNode &input);
 
@@ -71,7 +71,7 @@ namespace regen {
 
 	protected:
 		LoDMetric lodMetric_;
-		GLuint numPatchVertices_;
+		uint32_t numPatchVertices_;
 
 		ref_ptr<ShaderInput1f> lodFactor_;
 		ref_ptr<ShaderInput4f> outerLevel_;

--- a/regen/textures/devil-loader.cpp
+++ b/regen/textures/devil-loader.cpp
@@ -9,8 +9,8 @@ bool DevilLoader::canLoad(std::string_view fileExt) const {
 	return true; // all formats supported by DevIL
 }
 
-void DevilLoader::scaleImage(GLuint w, GLuint h, GLuint d) {
-	GLuint width_ = ilGetInteger(IL_IMAGE_WIDTH);
+void DevilLoader::scaleImage(uint32_t w, uint32_t h, uint32_t d) {
+	uint32_t width_ = ilGetInteger(IL_IMAGE_WIDTH);
 	// scale image to desired size
 	if (w > 0 && h > 0) {
 		if (width_ > w) {
@@ -74,7 +74,7 @@ void DevilLoader::save(const ref_ptr<ImageData> &img, std::string_view file) {
 	if (boost::filesystem::exists(file)) {
 		boost::filesystem::remove(file);
 	}
-	GLuint ilID;
+	uint32_t ilID;
 	ilGenImages(1, &ilID);
 	ilBindImage(ilID);
 	REGEN_INFO("Saving image to '" << file << "'"
@@ -110,7 +110,7 @@ ImageDataArray DevilLoader::load(std::string_view file, const TextureConfig &cfg
 		throw textures::Error(REGEN_STRING("Unable to open image file at '" << file << "'."));
 	}
 
-	GLuint ilID;
+	uint32_t ilID;
 	ilGenImages(1, &ilID);
 	ilBindImage(ilID);
 	if (ilLoadImage(file.data()) == IL_FALSE) {

--- a/regen/textures/devil-loader.h
+++ b/regen/textures/devil-loader.h
@@ -27,7 +27,7 @@ namespace regen {
 		 * Scale the currently bound image to the given size.
 		 * If w or h is 0, the image will not be scaled in that dimension.
 		 */
-		static void scaleImage(GLuint w, GLuint h, GLuint d);
+		static void scaleImage(uint32_t w, uint32_t h, uint32_t d);
 
 		/**
 		 * Convert the currently bound image to the given format and type.

--- a/regen/textures/fbo-state.cpp
+++ b/regen/textures/fbo-state.cpp
@@ -119,7 +119,7 @@ void FBOState::disable(RenderState *rs) {
 	}
 }
 
-void FBOState::resize(GLuint width, GLuint height) {
+void FBOState::resize(uint32_t width, uint32_t height) {
 	fbo_->resize(width, height, fbo_->depth());
 }
 
@@ -139,7 +139,7 @@ static std::vector<std::string> getFBOAttachments(scene::SceneInputNode &input, 
 static std::vector<GLenum> getFBOAttachments_(scene::SceneInputNode &input, const std::string &key) {
 	auto attachments_str = getFBOAttachments(input, key);
 	std::vector<GLenum> attachments(attachments_str.size());
-	for (GLuint i = 0u; i < attachments_str.size(); ++i) {
+	for (uint32_t i = 0u; i < attachments_str.size(); ++i) {
 		auto &attachments_str_i = attachments_str[i];
 		if (attachments_str_i.empty()) {
 			REGEN_WARN("Empty attachment in " << input.getDescription() << ".");

--- a/regen/textures/fbo-state.h
+++ b/regen/textures/fbo-state.h
@@ -30,7 +30,7 @@ namespace regen {
 		/**
 		 * Resize attached textures.
 		 */
-		void resize(GLuint width, GLuint height);
+		void resize(uint32_t width, uint32_t height);
 
 		/**
 		 * Clear depth buffer to preset values.

--- a/regen/textures/fbo.cpp
+++ b/regen/textures/fbo.cpp
@@ -38,7 +38,7 @@ void FBO::Screen::applyDrawBuffer(GLenum attachment) {
 	}
 }
 
-FBO::FBO(GLuint width, GLuint height, GLuint depth)
+FBO::FBO(uint32_t width, uint32_t height, uint32_t depth)
 		: GLRectangle(glCreateFramebuffers, glDeleteFramebuffers),
 		  depthAttachmentTarget_(GL_NONE),
 		  depthAttachmentFormat_(GL_NONE),
@@ -189,15 +189,15 @@ GLenum FBO::addTexture(const ref_ptr<Texture> &tex) {
 }
 
 ref_ptr<Texture> FBO::createTexture(
-		GLuint width,
-		GLuint height,
-		GLuint depth,
-		GLuint count,
+		uint32_t width,
+		uint32_t height,
+		uint32_t depth,
+		uint32_t count,
 		GLenum targetType,
 		GLenum format,
 		GLint internalFormat,
 		GLenum pixelType,
-		GLuint numSamples) {
+		uint32_t numSamples) {
 	ref_ptr<Texture> tex;
 	ref_ptr<Texture3D> tex3d;
 
@@ -253,7 +253,7 @@ ref_ptr<Texture> FBO::createTexture(
 	tex->set_pixelType(pixelType);
 	tex->allocTexture();
 
-	for (GLuint j = 0; j < count; ++j) {
+	for (uint32_t j = 0; j < count; ++j) {
 		if (numSamples == 1) {
 			tex->set_wrapping(TextureWrapping::create(GL_CLAMP_TO_EDGE));
 			tex->set_filter(TextureFilter::create(GL_LINEAR));
@@ -265,16 +265,16 @@ ref_ptr<Texture> FBO::createTexture(
 }
 
 ref_ptr<Texture> FBO::addTexture(
-		GLuint count,
+		uint32_t count,
 		GLenum targetType,
 		GLenum format,
 		GLint internalFormat,
 		GLenum pixelType,
-		GLuint numSamples) {
+		uint32_t numSamples) {
 	ref_ptr<Texture> tex = createTexture(width(), height(), depth_,
 										 count, targetType, format, internalFormat, pixelType, numSamples);
 
-	for (GLuint j = 0; j < tex->numObjects(); ++j) {
+	for (uint32_t j = 0; j < tex->numObjects(); ++j) {
 		addTexture(tex);
 		tex->nextObject();
 	}
@@ -290,12 +290,12 @@ GLenum FBO::addRenderBuffer(const ref_ptr<RenderBuffer> &rbo) {
 	return attachment;
 }
 
-ref_ptr<RenderBuffer> FBO::addRenderBuffer(GLuint count) {
+ref_ptr<RenderBuffer> FBO::addRenderBuffer(uint32_t count) {
 	RenderState *rs = RenderState::get();
 	ref_ptr<RenderBuffer> rbo = ref_ptr<RenderBuffer>::alloc(count);
 
 	rbo->set_rectangleSize(width(), height());
-	for (GLuint j = 0; j < count; ++j) {
+	for (uint32_t j = 0; j < count; ++j) {
 		rbo->begin(rs);
 		rbo->storage();
 		rbo->end(rs);
@@ -358,8 +358,8 @@ void FBO::blitCopy(
 }
 
 void FBO::blitCopyToScreen(
-		GLuint screenWidth,
-		GLuint screenHeight,
+		uint32_t screenWidth,
+		uint32_t screenHeight,
 		GLenum readAttachment,
 		GLbitfield mask,
 		GLenum filter,
@@ -438,7 +438,7 @@ void FBO::clearStencilAttachment(GLint stencil) {
 			&stencil);
 }
 
-void FBO::resize(GLuint w, GLuint h, GLuint depth) {
+void FBO::resize(uint32_t w, uint32_t h, uint32_t depth) {
 	RenderState *rs = RenderState::get();
 	if (w == width() && h == height() && depth == depth_) {
 		return; // no resize needed
@@ -481,14 +481,14 @@ void FBO::resize(GLuint w, GLuint h, GLuint depth) {
 
 	uint32_t attachmentIdx = 0;
 	// resize color attachments
-	for (GLuint colorIdx = 0; colorIdx < colorTextures_.size(); ++colorIdx) {
+	for (uint32_t colorIdx = 0; colorIdx < colorTextures_.size(); ++colorIdx) {
 		auto &tex = colorTextures_[colorIdx];
 		tex->set_rectangleSize(w, h);
 		auto *tex3D = dynamic_cast<Texture3D *>(tex.get());
 		if (tex3D != nullptr) { tex3D->set_depth(depth); }
 		tex->allocTexture();
 
-		for (GLuint i = 0; i < tex->numObjects(); ++i) {
+		for (uint32_t i = 0; i < tex->numObjects(); ++i) {
 			attachTexture(tex, colorAttachments_.buffers_[attachmentIdx++]);
 			tex->nextObject();
 		}
@@ -500,7 +500,7 @@ void FBO::resize(GLuint w, GLuint h, GLuint depth) {
 		//  - use attachmentIdx to avoid conflicts with color attachments
 		REGEN_WARN("RBO attachment resizing not implemented. ");
 		rbo->set_rectangleSize(w, h);
-		for (GLuint i = 0; i < rbo->numObjects(); ++i) {
+		for (uint32_t i = 0; i < rbo->numObjects(); ++i) {
 			rbo->begin(rs);
 			rbo->storage();
 			rbo->end(rs);
@@ -576,7 +576,7 @@ ref_ptr<FBO> FBO::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 		if (n->getCategory() == "texture") {
 			LoadingContext texCfg(ctx.scene(), ctx.parent());
 			ref_ptr<Texture> tex = Texture::load(texCfg, *n.get());
-			for (GLuint j = 0; j < tex->numObjects(); ++j) {
+			for (uint32_t j = 0; j < tex->numObjects(); ++j) {
 				fbo->addTexture(tex);
 				tex->nextObject();
 			}
@@ -594,7 +594,7 @@ ref_ptr<FBO> FBO::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 						n->getValue<std::string>("pixel-type", "UNSIGNED_BYTE"));
 				GLenum textureTarget = glenum::textureTarget(
 						n->getValue<std::string>("target", "TEXTURE_2D"));
-				auto numSamples = n->getValue<GLuint>("num-samples", 1);
+				auto numSamples = n->getValue<uint32_t>("num-samples", 1);
 
 				GLenum depthFormat;
 				if (depthSize <= 16) depthFormat = GL_DEPTH_COMPONENT16;

--- a/regen/textures/fbo.h
+++ b/regen/textures/fbo.h
@@ -120,7 +120,7 @@ namespace regen {
 		 * for all attached textured and formats of
 		 * all attached draw buffer must be equal.
 		 */
-		FBO(GLuint width, GLuint height, GLuint depth = 1);
+		FBO(uint32_t width, uint32_t height, uint32_t depth = 1);
 
 		FBO(const FBO &) = delete;
 
@@ -152,7 +152,7 @@ namespace regen {
 		/**
 		 * Resizes all textures attached to this FBO.
 		 */
-		void resize(GLuint width, GLuint height, GLuint depth);
+		void resize(uint32_t width, uint32_t height, uint32_t depth);
 
 		/**
 		 * @return the FBO viewport.
@@ -172,7 +172,7 @@ namespace regen {
 		/**
 		 * @return depth of attachment textures.
 		 */
-		GLuint depth() const { return depth_; }
+		uint32_t depth() const { return depth_; }
 
 		/**
 		 * Creates depth attachment.
@@ -234,7 +234,7 @@ namespace regen {
 		/**
 		 * Add n RenderBuffer's to the FBO.
 		 */
-		ref_ptr<RenderBuffer> addRenderBuffer(GLuint count);
+		ref_ptr<RenderBuffer> addRenderBuffer(uint32_t count);
 
 		/**
 		 * Add a RenderBuffer to the FBO.
@@ -255,26 +255,26 @@ namespace regen {
 		 * @return the texture created.
 		 */
 		static ref_ptr<Texture> createTexture(
-				GLuint width,
-				GLuint height,
-				GLuint depth,
-				GLuint count,
+				uint32_t width,
+				uint32_t height,
+				uint32_t depth,
+				uint32_t count,
 				GLenum targetType,
 				GLenum format,
 				GLint internalFormat,
 				GLenum pixelType,
-				GLuint numSamples=1);
+				uint32_t numSamples=1);
 
 		/**
 		 * Add n Texture's to the FBO.
 		 */
 		ref_ptr<Texture> addTexture(
-				GLuint count,
+				uint32_t count,
 				GLenum targetType,
 				GLenum format,
 				GLint internalFormat,
 				GLenum pixelType,
-				GLuint numSamples=1);
+				uint32_t numSamples=1);
 
 		/**
 		 * Add a Texture to the FBO.
@@ -330,7 +330,7 @@ namespace regen {
 		 * Blit fbo attachment into screen back buffer.
 		 */
 		void blitCopyToScreen(
-				GLuint screenWidth, GLuint screenHeight,
+				uint32_t screenWidth, uint32_t screenHeight,
 				GLenum readAttachment,
 				GLbitfield mask = GL_COLOR_BUFFER_BIT,
 				GLenum filter = GL_NEAREST,
@@ -371,7 +371,7 @@ namespace regen {
 		GLenum readBuffer_ = GL_NONE;
 
 		DrawBuffers colorAttachments_;
-		GLuint depth_;
+		uint32_t depth_;
 
 		GLenum depthAttachmentTarget_;
 		GLenum depthAttachmentFormat_;

--- a/regen/textures/noise-texture.cpp
+++ b/regen/textures/noise-texture.cpp
@@ -51,7 +51,7 @@ void NoiseTexture::setNoiseGenerator(const ref_ptr<NoiseGenerator> &generator) {
 	updateNoise();
 }
 
-NoiseTexture2D::NoiseTexture2D(GLuint width, GLuint height, GLboolean isSeamless)
+NoiseTexture2D::NoiseTexture2D(uint32_t width, uint32_t height, GLboolean isSeamless)
 		: Texture2D(), NoiseTexture(isSeamless) {
 	set_rectangleSize(width, height);
 	set_pixelType(GL_UNSIGNED_BYTE);
@@ -65,8 +65,8 @@ void NoiseTexture2D::updateNoise() {
 
 	auto *data = new GLubyte[width() * height()];
 	GLubyte *dataPtr = data;
-	for (GLuint x = 0u; x < width(); ++x) {
-		for (GLuint y = 0u; y < height(); ++y) {
+	for (uint32_t x = 0u; x < width(); ++x) {
+		for (uint32_t y = 0u; y < height(); ++y) {
 			float fx = noiseScale_ * float(x) / float(width());
 			float fy = noiseScale_ * float(y) / float(height());
 			GLfloat val = sampleNoise(gen, fx, fy, 0.0, isSeamless_, false);
@@ -84,7 +84,7 @@ void NoiseTexture2D::updateNoise() {
 	set_wrapping(TextureWrapping::create(GL_MIRRORED_REPEAT));
 }
 
-NoiseTexture3D::NoiseTexture3D(GLuint width, GLuint height, GLuint depth, GLboolean isSeamless)
+NoiseTexture3D::NoiseTexture3D(uint32_t width, uint32_t height, uint32_t depth, GLboolean isSeamless)
 		: Texture3D(), NoiseTexture(isSeamless) {
 	set_rectangleSize(width, height);
 	set_depth(depth);
@@ -100,9 +100,9 @@ void NoiseTexture3D::updateNoise() {
 
 	auto *data = new GLubyte[width() * height() * depth()];
 	GLubyte *dataPtr = data;
-	for (GLuint x = 0u; x < width(); ++x) {
-		for (GLuint y = 0u; y < height(); ++y) {
-			for (GLuint z = 0u; z < depth(); ++z) {
+	for (uint32_t x = 0u; x < width(); ++x) {
+		for (uint32_t y = 0u; y < height(); ++y) {
+			for (uint32_t z = 0u; z < depth(); ++z) {
 				float fx = noiseScale_ * float(x) / float(width());
 				float fy = noiseScale_ * float(y) / float(height());
 				float fz = noiseScale_ * float(z) / float(depth());

--- a/regen/textures/noise-texture.h
+++ b/regen/textures/noise-texture.h
@@ -128,7 +128,7 @@ namespace regen {
 		 * @param height the height of the texture.
 		 * @param isSeamless true if the texture should be seamless.
 		 */
-		NoiseTexture2D(GLuint width, GLuint height, GLboolean isSeamless = GL_FALSE);
+		NoiseTexture2D(uint32_t width, uint32_t height, GLboolean isSeamless = GL_FALSE);
 
 		~NoiseTexture2D() override = default;
 
@@ -146,7 +146,7 @@ namespace regen {
 		 * @param depth the depth of the texture.
 		 * @param isSeamless true if the texture should be seamless.
 		 */
-		NoiseTexture3D(GLuint width, GLuint height, GLuint depth, GLboolean isSeamless = GL_FALSE);
+		NoiseTexture3D(uint32_t width, uint32_t height, uint32_t depth, GLboolean isSeamless = GL_FALSE);
 
 		~NoiseTexture3D() override = default;
 

--- a/regen/textures/ramp-texture.cpp
+++ b/regen/textures/ramp-texture.cpp
@@ -5,7 +5,7 @@ using namespace regen;
 RampTexture::RampTexture(
 			GLenum format,
 			GLenum internalFormat,
-			GLuint width)
+			uint32_t width)
 		: Texture1D() {
 	set_rectangleSize(width, 1);
 	set_pixelType(GL_UNSIGNED_BYTE);

--- a/regen/textures/ramp-texture.h
+++ b/regen/textures/ramp-texture.h
@@ -17,7 +17,7 @@ namespace regen {
 		 * @param internalFormat the texture internal format.
 		 * @param width the texture width.
 		 */
-		RampTexture(GLenum format, GLenum internalFormat, GLuint width);
+		RampTexture(GLenum format, GLenum internalFormat, uint32_t width);
 
 		/**
 		 * Creates a ramp texture with the given format and data.

--- a/regen/textures/render-buffer.cpp
+++ b/regen/textures/render-buffer.cpp
@@ -2,7 +2,7 @@
 
 using namespace regen;
 
-RenderBuffer::RenderBuffer(GLuint numBuffers)
+RenderBuffer::RenderBuffer(uint32_t numBuffers)
 		: GLRectangle(glCreateRenderbuffers, glDeleteRenderbuffers, numBuffers),
 		  format_(GL_RGBA) {
 }
@@ -13,7 +13,7 @@ void RenderBuffer::begin(RenderState *rs) { rs->renderBuffer().push(id()); }
 
 void RenderBuffer::end(RenderState *rs) { rs->renderBuffer().pop(); }
 
-void RenderBuffer::storageMS(GLuint numSamples) const {
+void RenderBuffer::storageMS(uint32_t numSamples) const {
 	glNamedRenderbufferStorageMultisample(
 			id(), numSamples, format_, width(), height());
 }

--- a/regen/textures/render-buffer.h
+++ b/regen/textures/render-buffer.h
@@ -16,7 +16,7 @@ namespace regen {
 		/**
 		 * @param numObjects number of GL buffers.
 		 */
-		explicit RenderBuffer(GLuint numObjects = 1);
+		explicit RenderBuffer(uint32_t numObjects = 1);
 
 		/**
 		 * Binds this RenderBuffer.
@@ -40,7 +40,7 @@ namespace regen {
 		 * Establish data storage, format and dimensions
 		 * of a renderbuffer object's image using multisampling.
 		 */
-		void storageMS(GLuint numMultisamples) const;
+		void storageMS(uint32_t numMultisamples) const;
 
 		/**
 		 * Establish data storage, format and dimensions of a

--- a/regen/textures/stb-loader.cpp
+++ b/regen/textures/stb-loader.cpp
@@ -17,8 +17,6 @@ bool STBLoader::canLoad(std::string_view fileExt) const {
 		|| fileExt == ".bmp"
 		|| fileExt == ".tga"
 		|| fileExt == ".gif"
-		// TODO: Support loading float textures, but need to use a different API.
-		// || fileExt == ".hdr"
 		|| fileExt == ".psd"
 		|| fileExt == ".pic") {
 		return true;

--- a/regen/textures/texture-buffer.cpp
+++ b/regen/textures/texture-buffer.cpp
@@ -34,13 +34,13 @@ void TextureBuffer::attach(const ref_ptr<BufferReference> &ref) {
 	GL_ERROR_LOG();
 }
 
-void TextureBuffer::attach(GLuint storage) {
+void TextureBuffer::attach(uint32_t storage) {
 	attachedVBORef_ = {};
 	glTextureBuffer(id(), texelFormat_, storage);
 	GL_ERROR_LOG();
 }
 
-void TextureBuffer::attach(GLuint storage, GLuint offset, GLuint size) {
+void TextureBuffer::attach(uint32_t storage, uint32_t offset, uint32_t size) {
 	attachedVBORef_ = {};
 #ifdef GL_ARB_texture_buffer_range
 	glTextureBufferRange(id(), texelFormat_, storage, offset, size);

--- a/regen/textures/texture-buffer.h
+++ b/regen/textures/texture-buffer.h
@@ -29,12 +29,12 @@ namespace regen {
 		/**
 		 * Attach the storage for a buffer object to the active buffer texture.
 		 */
-		void attach(GLuint storage);
+		void attach(uint32_t storage);
 
 		/**
 		 * Attach the storage for a buffer object to the active buffer texture.
 		 */
-		void attach(GLuint storage, GLuint offset, GLuint size);
+		void attach(uint32_t storage, uint32_t offset, uint32_t size);
 
 
 	private:

--- a/regen/textures/texture-loader.cpp
+++ b/regen/textures/texture-loader.cpp
@@ -119,11 +119,11 @@ ref_ptr<Texture> textures::load(std::string_view file, const TextureConfig &texC
 }
 
 ref_ptr<Texture> textures::load(
-		GLuint textureType,
-		GLuint numBytes,
+		uint32_t textureType,
+		uint32_t numBytes,
 		const void *rawData,
 		const TextureConfig &texCfg) {
-	GLuint ilID;
+	uint32_t ilID;
 	ilGenImages(1, &ilID);
 	ilBindImage(ilID);
 	if (ilLoadL(textureType, rawData, numBytes) == IL_FALSE) {
@@ -234,7 +234,7 @@ ref_ptr<Texture2DArray> textures::loadArray(
 		const std::vector<TextureDescription> &textureFiles,
 		const TextureConfig &texCfg_) {
 	TextureConfig arrayTexCfg = texCfg_;
-	GLuint numTextures = textureFiles.size();
+	uint32_t numTextures = textureFiles.size();
 	ref_ptr<Texture2DArray> tex = ref_ptr<Texture2DArray>::alloc();
 	tex->set_depth(numTextures);
 
@@ -382,8 +382,8 @@ ref_ptr<TextureCube> textures::loadCube(
 ref_ptr<Texture> textures::loadRAW(
 		const std::string &path,
 		const Vec3ui &size,
-		GLuint numComponents,
-		GLuint bytesPerComponent) {
+		uint32_t numComponents,
+		uint32_t bytesPerComponent) {
 	std::ifstream f(path.c_str(),
 					std::ios::in
 					| std::ios::binary

--- a/regen/textures/texture-state.cpp
+++ b/regen/textures/texture-state.cpp
@@ -217,7 +217,7 @@ using namespace regen;
 
 #define REGEN_TEX_NAME(x) REGEN_STRING(x << stateID_)
 
-GLuint TextureState::idCounter_ = 0;
+uint32_t TextureState::idCounter_ = 0;
 
 TextureState::TextureState(const ref_ptr<Texture> &texture, const std::string &name)
 		: State(),
@@ -272,7 +272,7 @@ void TextureState::set_name(const std::string &name) {
 	shaderDefine("HAS_" + name_, "TRUE");
 }
 
-void TextureState::set_texcoChannel(GLuint texcoChannel) {
+void TextureState::set_texcoChannel(uint32_t texcoChannel) {
 	texcoChannel_ = texcoChannel;
 	shaderDefine(REGEN_TEX_NAME("TEX_TEXCO"), REGEN_STRING("texco" << texcoChannel_));
 }
@@ -568,7 +568,7 @@ ref_ptr<State> TextureIndexState::load(LoadingContext &ctx, scene::SceneInputNod
 	}
 
 	if (input.hasAttribute("value")) {
-		auto index = input.getValue<GLuint>("index", 0u);
+		auto index = input.getValue<uint32_t>("index", 0u);
 		return ref_ptr<TextureSetIndex>::alloc(tex, index);
 	} else if (input.getValue<bool>("set-next-index", true)) {
 		return ref_ptr<TextureNextIndex>::alloc(tex);

--- a/regen/textures/texture-state.h
+++ b/regen/textures/texture-state.h
@@ -183,7 +183,7 @@ namespace regen {
 		/**
 		 * @param channel  the texture coordinate channel.
 		 */
-		void set_texcoChannel(GLuint channel);
+		void set_texcoChannel(uint32_t channel);
 
 		/**
 		 * @return the texture coordinate channel.
@@ -301,7 +301,7 @@ namespace regen {
 				const std::string &attachmentKey = "attachment");
 
 	protected:
-		static GLuint idCounter_;
+		static uint32_t idCounter_;
 
 		uint32_t stateID_;
 
@@ -359,7 +359,7 @@ namespace regen {
 		 * @param tex texture reference.
 		 * @param objectIndex the buffer index that should be activated.
 		 */
-		TextureSetIndex(const ref_ptr<Texture> &tex, GLuint objectIndex)
+		TextureSetIndex(const ref_ptr<Texture> &tex, uint32_t objectIndex)
 				: tex_(tex), objectIndex_(objectIndex) {}
 
 		// override
@@ -367,7 +367,7 @@ namespace regen {
 
 	protected:
 		ref_ptr<Texture> tex_;
-		GLuint objectIndex_;
+		uint32_t objectIndex_;
 	};
 
 	/**

--- a/regen/textures/texture.cpp
+++ b/regen/textures/texture.cpp
@@ -21,7 +21,7 @@ using namespace regen;
 #include "fbo.h"
 #include "texture-binder.h"
 
-Texture::Texture(GLenum textureTarget, GLuint numTextures)
+Texture::Texture(GLenum textureTarget, uint32_t numTextures)
 		: GLRectangle(
 				glCreateTextures,
 				glDeleteTextures,
@@ -317,7 +317,7 @@ void Texture::allocTexture() {
 	}
 	texBind_.id_ = ids_[0];
 	objectIndex_ = 0;
-	for (GLuint j = 0; j < numObjects_; ++j) {
+	for (uint32_t j = 0; j < numObjects_; ++j) {
 		(this->*(this->allocTexture_))();
 		if (isReAlloc) {
 			set_wrapping(wrappingMode_);
@@ -440,7 +440,7 @@ static std::vector<GLubyte> readTextureData_cfg(LoadingContext&, scene::SceneInp
 		int texelWidth = child->getValue<int>("width", 1);
 		for (int i = 0; i < texelWidth; ++i) {
 			if (numPixelComponents == 1) {
-				data.push_back(child->getValue<GLuint>("v", 0u));
+				data.push_back(child->getValue<uint32_t>("v", 0u));
 			} else if (numPixelComponents == 2) {
 				auto v = child->getValue<Vec2ui>("v", Vec2ui::zero());
 				data.push_back(v.x);
@@ -547,8 +547,8 @@ ref_ptr<Texture> Texture::load(LoadingContext &ctx, scene::SceneInputNode &input
 				tex = textures::loadRAW(
 						filePath,
 						input.getValue<Vec3ui>("raw-size", Vec3ui::create(256u)),
-						input.getValue<GLuint>("raw-components", 3u),
-						input.getValue<GLuint>("raw-bytes", 4u));
+						input.getValue<uint32_t>("raw-components", 3u),
+						input.getValue<uint32_t>("raw-bytes", 4u));
 			} else {
 				tex = textures::load(filePath, texConfig);
 			}
@@ -626,7 +626,7 @@ ref_ptr<Texture> Texture::load(LoadingContext &ctx, scene::SceneInputNode &input
 		auto numTexels = input.getValue<GLint>("num-texels", 256u);
 		tex = regen::textures::loadSpectrum(spectrum.x, spectrum.y, numTexels);
 	} else if (typeName == "bloom") {
-		auto numMips = input.getValue<GLuint>("num-mips", 5u);
+		auto numMips = input.getValue<uint32_t>("num-mips", 5u);
 		auto bloomTexture = ref_ptr<BloomTexture>::alloc(numMips);
 		auto inputFBO = ctx.scene()->getResource<FBO>(input.getValue("input-fbo"));
 		if (inputFBO.get() == nullptr) {
@@ -643,20 +643,20 @@ ref_ptr<Texture> Texture::load(LoadingContext &ctx, scene::SceneInputNode &input
 		auto sizeRel = input.getValue<Vec3f>("size", Vec3f(256.0, 256.0, 1.0));
 		Vec3i sizeAbs = getSize(screen->viewport().r, sizeMode, sizeRel);
 
-		auto texCount = input.getValue<GLuint>("count", 1);
-		auto pixelComponents = input.getValue<GLuint>("pixel-components", 4);
+		auto texCount = input.getValue<uint32_t>("count", 1);
+		auto pixelComponents = input.getValue<uint32_t>("pixel-components", 4);
 		auto pixelType = glenum::pixelType(
 				input.getValue<std::string>("pixel-type", "UNSIGNED_BYTE"));
 		auto textureTarget = glenum::textureTarget(
 				input.getValue<std::string>("target", sizeAbs.z > 1 ? "TEXTURE_3D" : "TEXTURE_2D"));
-		auto numSamples = input.getValue<GLuint>("num-samples", 1);
+		auto numSamples = input.getValue<uint32_t>("num-samples", 1);
 
 		GLenum internalFormat;
 		if (input.hasAttribute("internal-format")) {
 			internalFormat = glenum::textureInternalFormat(
 					input.getValue<std::string>("internal-format", "RGBA8"));
 		} else {
-			auto pixelSize = input.getValue<GLuint>("pixel-size", 16);
+			auto pixelSize = input.getValue<uint32_t>("pixel-size", 16);
 			internalFormat = glenum::textureInternalFormat(pixelType,
 														   pixelComponents, pixelSize);
 		}
@@ -769,7 +769,7 @@ void Texture::configure(ref_ptr<Texture> &tex, scene::SceneInputNode &input) {
 	GL_ERROR_LOG();
 }
 
-Texture1D::Texture1D(GLuint numTextures)
+Texture1D::Texture1D(uint32_t numTextures)
 		: Texture(GL_TEXTURE_1D, numTextures) {
 	dim_ = 1;
 	samplerType_ = "sampler1D";
@@ -778,7 +778,7 @@ Texture1D::Texture1D(GLuint numTextures)
 	updateSubImage_ = &Texture1D::updateSubImage1D;
 }
 
-Texture2D::Texture2D(GLenum textureTarget, GLuint numTextures)
+Texture2D::Texture2D(GLenum textureTarget, uint32_t numTextures)
 		: Texture(textureTarget, numTextures) {
 	dim_ = 2;
 	samplerType_ = "sampler2D";
@@ -787,7 +787,7 @@ Texture2D::Texture2D(GLenum textureTarget, GLuint numTextures)
 	updateSubImage_ = &Texture2D::updateSubImage2D;
 }
 
-TextureMips2D::TextureMips2D(GLuint numMips)
+TextureMips2D::TextureMips2D(uint32_t numMips)
 		: Texture2D(GL_TEXTURE_2D, 1) {
 	numMips_ = 1; // we do not use the built-in mipmap generation
 	mipTextures_.resize(numMips);
@@ -800,12 +800,12 @@ TextureMips2D::TextureMips2D(GLuint numMips)
 	}
 }
 
-TextureRectangle::TextureRectangle(GLuint numTextures)
+TextureRectangle::TextureRectangle(uint32_t numTextures)
 		: Texture2D(GL_TEXTURE_RECTANGLE, numTextures) {
 	samplerType_ = "sampler2DRect";
 }
 
-Texture2DDepth::Texture2DDepth(GLenum textureTarget, GLuint numTextures)
+Texture2DDepth::Texture2DDepth(GLenum textureTarget, uint32_t numTextures)
 		: Texture2D(textureTarget, numTextures) {
 	format_ = GL_DEPTH_COMPONENT;
 	internalFormat_ = GL_DEPTH_COMPONENT24;
@@ -814,7 +814,7 @@ Texture2DDepth::Texture2DDepth(GLenum textureTarget, GLuint numTextures)
 
 Texture2DMultisample::Texture2DMultisample(
 		GLsizei numSamples,
-		GLuint numTextures,
+		uint32_t numTextures,
 		GLboolean fixedSampleLocations)
 		: Texture2D(GL_TEXTURE_2D_MULTISAMPLE, numTextures) {
 	fixedSampleLocations_ = fixedSampleLocations;
@@ -839,7 +839,7 @@ Texture2DMultisampleDepth::Texture2DMultisampleDepth(
 	updateSubImage_ = &Texture2DMultisampleDepth::updateSubImage_noop;
 }
 
-Texture3D::Texture3D(GLenum textureTarget, GLuint numTextures)
+Texture3D::Texture3D(GLenum textureTarget, uint32_t numTextures)
 		: Texture(textureTarget, numTextures) {
 	dim_ = 3;
 	samplerType_ = "sampler3D";
@@ -848,22 +848,22 @@ Texture3D::Texture3D(GLenum textureTarget, GLuint numTextures)
 	updateSubImage_ = &Texture3D::updateSubImage3D;
 }
 
-void Texture3D::set_depth(GLuint numTextures) {
+void Texture3D::set_depth(uint32_t numTextures) {
 	imageDepth_ = numTextures;
 }
 
-Texture3DDepth::Texture3DDepth(GLuint numTextures)
+Texture3DDepth::Texture3DDepth(uint32_t numTextures)
 		: Texture3D(GL_TEXTURE_3D, numTextures) {
 	format_ = GL_DEPTH_COMPONENT;
 	internalFormat_ = GL_DEPTH_COMPONENT24;
 }
 
-Texture2DArray::Texture2DArray(GLenum textureTarget, GLuint numTextures)
+Texture2DArray::Texture2DArray(GLenum textureTarget, uint32_t numTextures)
 		: Texture3D(textureTarget, numTextures) {
 	samplerType_ = "sampler2DArray";
 }
 
-Texture2DArrayDepth::Texture2DArrayDepth(GLuint numTextures)
+Texture2DArrayDepth::Texture2DArrayDepth(uint32_t numTextures)
 		: Texture2DArray(GL_TEXTURE_2D_ARRAY, numTextures) {
 	format_ = GL_DEPTH_COMPONENT;
 	internalFormat_ = GL_DEPTH_COMPONENT24;
@@ -872,7 +872,7 @@ Texture2DArrayDepth::Texture2DArrayDepth(GLuint numTextures)
 
 Texture2DArrayMultisample::Texture2DArrayMultisample(
 		GLsizei numSamples,
-		GLuint numTextures,
+		uint32_t numTextures,
 		GLboolean fixedSampleLocations)
 		: Texture2DArray(GL_TEXTURE_2D_MULTISAMPLE_ARRAY, numTextures) {
 	samplerType_ = "sampler2DMSArray";
@@ -882,7 +882,7 @@ Texture2DArrayMultisample::Texture2DArrayMultisample(
 
 Texture2DArrayMultisampleDepth::Texture2DArrayMultisampleDepth(
 		GLsizei numSamples,
-		GLuint numTextures,
+		uint32_t numTextures,
 		GLboolean fixedSampleLocations)
 		: Texture2DArray(GL_TEXTURE_2D_MULTISAMPLE_ARRAY, numTextures) {
 	samplerType_ = "sampler2DMSArray";
@@ -890,7 +890,7 @@ Texture2DArrayMultisampleDepth::Texture2DArrayMultisampleDepth(
 	fixedSampleLocations_ = fixedSampleLocations;
 }
 
-TextureCube::TextureCube(GLuint numTextures)
+TextureCube::TextureCube(uint32_t numTextures)
 		: Texture2D(GL_TEXTURE_CUBE_MAP, numTextures) {
 	samplerType_ = "samplerCube";
 	dim_ = 3;
@@ -899,7 +899,7 @@ TextureCube::TextureCube(GLuint numTextures)
 	updateSubImage_ = &TextureCube::updateSubImage3D;
 }
 
-TextureCubeDepth::TextureCubeDepth(GLuint numTextures)
+TextureCubeDepth::TextureCubeDepth(uint32_t numTextures)
 		: TextureCube(numTextures) {
 	format_ = GL_DEPTH_COMPONENT;
 	internalFormat_ = GL_DEPTH_COMPONENT24;

--- a/regen/textures/texture.h
+++ b/regen/textures/texture.h
@@ -12,7 +12,7 @@
 
 namespace regen {
 	class Texture;
-	/** minification/magnifiction */
+	/** minification/magnification */
 	typedef Vec2i TextureFilter;
 	/** min/max LoD. */
 	typedef Vec2f TextureLoD;

--- a/regen/textures/texture.h
+++ b/regen/textures/texture.h
@@ -553,7 +553,7 @@ namespace regen {
 		/**
 		 * @param numTextures number of texture images.
 		 */
-		explicit Texture1D(GLuint numTextures = 1);
+		explicit Texture1D(uint32_t numTextures = 1);
 	};
 
 	/**
@@ -570,7 +570,7 @@ namespace regen {
 		 */
 		explicit Texture2D(
 				GLenum textureTarget = GL_TEXTURE_2D,
-				GLuint numTextures = 1);
+				uint32_t numTextures = 1);
 	};
 
 	/**
@@ -581,7 +581,7 @@ namespace regen {
 	 */
 	class TextureMips2D : public Texture2D {
 	public:
-		explicit TextureMips2D(GLuint numMips = 4);
+		explicit TextureMips2D(uint32_t numMips = 4);
 
 		std::vector<Texture *> &mipTextures() { return mipTextures_; }
 
@@ -606,7 +606,7 @@ namespace regen {
 		/**
 		 * @param numTextures number of texture images.
 		 */
-		explicit TextureRectangle(GLuint numTextures = 1);
+		explicit TextureRectangle(uint32_t numTextures = 1);
 	};
 
 	/**
@@ -619,7 +619,7 @@ namespace regen {
 		 */
 		explicit Texture2DDepth(
 				GLenum textureTarget = GL_TEXTURE_2D,
-				GLuint numTextures = 1);
+				uint32_t numTextures = 1);
 	};
 
 	/**
@@ -637,7 +637,7 @@ namespace regen {
 		 */
 		explicit Texture2DMultisample(
 				GLsizei numSamples,
-				GLuint numTextures = 1,
+				uint32_t numTextures = 1,
 				GLboolean fixedLocations = GL_TRUE);
 	};
 
@@ -667,12 +667,12 @@ namespace regen {
 		 */
 		explicit Texture3D(
 				GLenum textureTarget = GL_TEXTURE_3D,
-				GLuint numTextures = 1);
+				uint32_t numTextures = 1);
 
 		/**
 		 * @param depth the texture depth.
 		 */
-		void set_depth(GLuint depth);
+		void set_depth(uint32_t depth);
 	};
 
 	/**
@@ -683,7 +683,7 @@ namespace regen {
 		/**
 		 * @param numTextures number of texture images.
 		 */
-		explicit Texture3DDepth(GLuint numTextures = 1);
+		explicit Texture3DDepth(uint32_t numTextures = 1);
 	};
 
 	/**
@@ -696,7 +696,7 @@ namespace regen {
 		 */
 		explicit Texture2DArray(
 				GLenum textureTarget = GL_TEXTURE_2D_ARRAY,
-				GLuint numTextures = 1);
+				uint32_t numTextures = 1);
 	};
 
 	class Texture2DArrayDepth : public Texture2DArray {
@@ -704,7 +704,7 @@ namespace regen {
 		/**
 		 * @param numTextures number of texture images.
 		 */
-		explicit Texture2DArrayDepth(GLuint numTextures = 1);
+		explicit Texture2DArrayDepth(uint32_t numTextures = 1);
 	};
 
 	/**
@@ -719,7 +719,7 @@ namespace regen {
 		 */
 		explicit Texture2DArrayMultisample(
 				int32_t numSamples,
-				GLuint numTextures = 1,
+				uint32_t numTextures = 1,
 				GLboolean fixedLocations = GL_FALSE);
 	};
 
@@ -735,7 +735,7 @@ namespace regen {
 		 */
 		explicit Texture2DArrayMultisampleDepth(
 				int32_t numSamples,
-				GLuint numTextures = 1,
+				uint32_t numTextures = 1,
 				GLboolean fixedLocations = GL_FALSE);
 	};
 
@@ -762,7 +762,7 @@ namespace regen {
 		/**
 		 * @param numTextures number of texture images.
 		 */
-		explicit TextureCube(GLuint numTextures = 1);
+		explicit TextureCube(uint32_t numTextures = 1);
 	};
 
 	/**
@@ -774,7 +774,7 @@ namespace regen {
 		/**
 		 * @param numTextures number of texture images.
 		 */
-		explicit TextureCubeDepth(GLuint numTextures = 1);
+		explicit TextureCubeDepth(uint32_t numTextures = 1);
 	};
 } // namespace
 #endif /* REGEN_TEXTURE_H_ */

--- a/regen/utility/state-stacks.h
+++ b/regen/utility/state-stacks.h
@@ -177,7 +177,7 @@ namespace regen {
 	}
 
 	template<typename StackType, typename ValueType>
-	static void applyFilledStampedi(StackType *s, GLuint i, const ValueType &v) {
+	static void applyFilledStampedi(StackType *s, uint32_t i, const ValueType &v) {
 		if (v != s->headi_[i]->v) { s->applyi_(i, v); }
 	}
 
@@ -188,13 +188,13 @@ namespace regen {
 	}
 
 	template<typename StackType, typename ValueType>
-	static void applyInitStampedi(StackType *s, GLuint i, const ValueType &v) {
+	static void applyInitStampedi(StackType *s, uint32_t i, const ValueType &v) {
 		s->applyi_(i, v);
 		s->doApplyi_[i] = &applyFilledStampedi;
 	}
 
 	template<typename T>
-	void regen_lockedIndexed(GLuint i, const T &v) {}
+	void regen_lockedIndexed(uint32_t i, const T &v) {}
 
 	/**
 	 * \brief State stack with indexed apply function.
@@ -213,14 +213,14 @@ namespace regen {
 		/**
 		 * Function to apply the value to a single index.
 		 */
-		typedef void (*ApplyValueIndexed)(GLuint i, const ValueType &v);
+		typedef void (*ApplyValueIndexed)(uint32_t i, const ValueType &v);
 
 		/**
 		 * @param numIndices number of indices
 		 * @param apply apply a stack value to all indices.
 		 * @param applyi apply a stack value to a single index.
 		 */
-		IndexedStateStack(GLuint numIndices, ApplyValue apply, ApplyValueIndexed applyi)
+		IndexedStateStack(uint32_t numIndices, ApplyValue apply, ApplyValueIndexed applyi)
 				: numIndices_(numIndices),
 				  head_(new Node(zeroValue_)),
 				  apply_(apply),
@@ -236,7 +236,7 @@ namespace regen {
 			headi_ = new Node *[numIndices];
 			doApplyi_ = new DoApplyValueIndexed[numIndices];
 			isEmptyi_ = new GLboolean[numIndices];
-			for (GLuint i = 0; i < numIndices_; ++i) {
+			for (uint32_t i = 0; i < numIndices_; ++i) {
 				doApplyi_[i] = &applyInitStampedi;
 				headi_[i] = new Node(zeroValue_);
 				isEmptyi_[i] = GL_TRUE;
@@ -252,7 +252,7 @@ namespace regen {
 				isEmptyi_ = nullptr;
 			}
 			if (headi_) {
-				for (GLuint i = 0; i < numIndices_; ++i) { deleteNodes(headi_[i]); }
+				for (uint32_t i = 0; i < numIndices_; ++i) { deleteNodes(headi_[i]); }
 				delete[]headi_;
 				headi_ = nullptr;
 			}
@@ -270,7 +270,7 @@ namespace regen {
 		/**
 		 * @return the current state value or the value created by default constructor.
 		 */
-		const auto& value(GLuint index) const {
+		const auto& value(uint32_t index) const {
 			return headi_[index]->v;
 		}
 
@@ -318,7 +318,7 @@ namespace regen {
 		 * @param index the index.
 		 * @param v the value.
 		 */
-		void push(GLuint index, const ValueType &v) {
+		void push(uint32_t index, const ValueType &v) {
 			Node *headi = headi_[index];
 
 			if (counter_.x > counter_.y) {
@@ -373,7 +373,7 @@ namespace regen {
 		 * @param index the value index.
 		 * @param v the value.
 		 */
-		void apply(GLuint index, const ValueType &v) {
+		void apply(uint32_t index, const ValueType &v) {
 			if (headi_[index]->v != v) {
 				applyi_(index, v);
 				headi_[index]->v = v;
@@ -399,7 +399,7 @@ namespace regen {
 			if (counter_.y > 0) {
 				// Indexed states only applied with stamp>lastEqStamp
 				// Loop over all indexed stacks and compare stamps of top element.
-				for (GLuint i = 0; i < numIndices_; ++i) {
+				for (uint32_t i = 0; i < numIndices_; ++i) {
 					if (isEmptyi_[i]) { continue; }
 					Node *headi = headi_[i];
 
@@ -415,7 +415,7 @@ namespace regen {
 		 * Pop out last value at given index.
 		 * @param index the value index.
 		 */
-		void pop(GLuint index) {
+		void pop(uint32_t index) {
 			Node *headi = headi_[index];
 			GLboolean valueChanged;
 
@@ -501,7 +501,7 @@ namespace regen {
 		}
 
 		// Number of indices.
-		GLuint numIndices_;
+		uint32_t numIndices_;
 		// A stack containing stamped values applied to all indices.
 		Node *head_;
 		// A stack array containing stamped values applied to individual indices.
@@ -530,7 +530,7 @@ namespace regen {
 
 		typedef void (*DoApplyValue)(IndexedStateStack *, const ValueType &);
 
-		typedef void (*DoApplyValueIndexed)(IndexedStateStack *, GLuint, const ValueType &);
+		typedef void (*DoApplyValueIndexed)(IndexedStateStack *, uint32_t, const ValueType &);
 
 		// use function pointer to avoid some if statements
 		DoApplyValue doApply_;
@@ -543,10 +543,10 @@ namespace regen {
 				(IndexedStateStack *, const ValueType &);
 
 		friend void applyInitStampedi<IndexedStateStack, ValueType>
-				(IndexedStateStack *, GLuint, const ValueType &);
+				(IndexedStateStack *, uint32_t, const ValueType &);
 
 		friend void applyFilledStampedi<IndexedStateStack, ValueType>
-				(IndexedStateStack *, GLuint, const ValueType &);
+				(IndexedStateStack *, uint32_t, const ValueType &);
 	};
 } // namespace
 

--- a/regen/utility/threading.h
+++ b/regen/utility/threading.h
@@ -184,6 +184,13 @@ namespace regen {
 		}
 
 		/**
+		 * @return The number of worker threads in the pool.
+		 */
+		uint32_t numThreads() const {
+			return numThreads_;
+		}
+
+		/**
 		 * Stops all worker threads in the pool.
 		 */
 		void stopThreads() {


### PR DESCRIPTION
This PR refactors the bone tree traversal system for skeletal animation, replacing a recursive tree traversal with a more cache-efficient iteration-based approach. It also standardizes type usage by replacing OpenGL-specific types (GLuint, etc.) with standard uint32_t throughout the codebase, and introduces multithreading support for bone tree updates.

**Key Changes:**
- Refactored bone tree data structures to use flat arrays instead of tree pointers for better cache coherence
- Replaced GLuint and similar OpenGL types with uint32_t for consistency
- Added multithreading support via a shared JobPool for parallel bone tree updates across instances
- Modified Bones class API to accept BoneTree and bone node references directly