### PR TITLE
Revised boid simulation CPU path

### DIFF
--- a/applications/glut/glut-application.cpp
+++ b/applications/glut/glut-application.cpp
@@ -87,7 +87,7 @@ GLUTApplication::GLUTApplication(
 
   lastButtonTime_ = lastMotionTime_;
 
-  for(GLint i=0; i<NUM_KEYS; ++i) { keyState_[i] = false; }
+  for(int i=0; i<NUM_KEYS; ++i) { keyState_[i] = false; }
 
   glutInit(&argc, argv);
 }

--- a/applications/glut/glut-application.h
+++ b/applications/glut/glut-application.h
@@ -44,14 +44,14 @@ protected:
   uint32_t glutWidth_;
   uint32_t displayMode_;
 
-  GLboolean applicationRunning_;
+  bool applicationRunning_;
 
-  GLboolean reshaped_;
+  bool reshaped_;
 
-  GLboolean keyState_[NUM_KEYS];
-  GLboolean ctrlPressed_;
-  GLboolean altPressed_;
-  GLboolean shiftPressed_;
+  bool keyState_[NUM_KEYS];
+  bool ctrlPressed_;
+  bool altPressed_;
+  bool shiftPressed_;
 
   boost::posix_time::ptime lastButtonTime_;
 

--- a/applications/mesh-viewer/mesh-viewer-widget.cpp
+++ b/applications/mesh-viewer/mesh-viewer-widget.cpp
@@ -385,7 +385,7 @@ void MeshViewerWidget::selectMesh(int32_t meshIndex, uint32_t lodIndex) {
 
 static ref_ptr<Camera> createUserCamera(const Vec2i &viewport) {
 	auto cam = ref_ptr<Camera>::alloc(1);
-	float aspect = (GLfloat) viewport.x / (GLfloat) viewport.y;
+	float aspect = (float) viewport.x / (float) viewport.y;
 	cam->set_isAudioListener(false);
 	cam->setPosition(0, Vec3f(0.0f, 0.0f, -3.0f));
 	cam->setDirection(0, Vec3f(0.0f, 0.0f, 1.0f));

--- a/applications/mesh-viewer/mesh-viewer-widget.cpp
+++ b/applications/mesh-viewer/mesh-viewer-widget.cpp
@@ -59,7 +59,7 @@ QWidget *createParameterWidget(QtApplication *app, QWidget *parent,
 }
 
 static void hideLayout(QLayout *layout) {
-	for (GLint i = 0; i < layout->count(); ++i) {
+	for (int i = 0; i < layout->count(); ++i) {
 		QLayoutItem *item = layout->itemAt(i);
 		if (item->widget()) { item->widget()->hide(); }
 		if (item->layout()) { hideLayout(item->layout()); }
@@ -67,7 +67,7 @@ static void hideLayout(QLayout *layout) {
 }
 
 static void showLayout(QLayout *layout) {
-	for (GLint i = 0; i < layout->count(); ++i) {
+	for (int i = 0; i < layout->count(); ++i) {
 		QLayoutItem *item = layout->itemAt(i);
 		if (item->widget()) { item->widget()->show(); }
 		if (item->layout()) { showLayout(item->layout()); }

--- a/applications/mesh-viewer/mesh-viewer-widget.cpp
+++ b/applications/mesh-viewer/mesh-viewer-widget.cpp
@@ -45,7 +45,7 @@ public:
 
 	~RotateAnimation() override = default;
 
-	void animate(double dt) override { widget_->transformMesh(dt); }
+	void cpuUpdate(double dt) override { widget_->transformMesh(dt); }
 	MeshViewerWidget *widget_;
 };
 
@@ -345,7 +345,7 @@ void MeshViewerWidget::loadAnimation(const ref_ptr<Mesh> &mesh, uint32_t index) 
 		mesh->joinStates(bonesState);
 	}
 
-	ref_ptr<EventHandler> animStopped = ref_ptr<RandomAnimationRangeUpdater2>::alloc(nodeAnim);
+	ref_ptr<EventHandler> animStopped = ref_ptr<RandomAnimationRangeUpdater>::alloc(nodeAnim);
 	nodeAnim->connect(Animation::ANIMATION_STOPPED, animStopped);
 	{
 		EventData evData;

--- a/applications/mesh-viewer/mesh-viewer-widget.cpp
+++ b/applications/mesh-viewer/mesh-viewer-widget.cpp
@@ -413,7 +413,7 @@ void MeshViewerWidget::createCameraController() {
 }
 
 void MeshViewerWidget::gl_loadScene() {
-	AnimationManager::get().pause(GL_TRUE);
+	AnimationManager::get().pause(true);
 	AnimationManager::get().setRootState(app_->renderTree()->state());
 
 	// create render target

--- a/applications/mesh-viewer/mesh-viewer-widget.cpp
+++ b/applications/mesh-viewer/mesh-viewer-widget.cpp
@@ -45,7 +45,7 @@ public:
 
 	~RotateAnimation() override = default;
 
-	void animate(GLdouble dt) override { widget_->transformMesh(dt); }
+	void animate(double dt) override { widget_->transformMesh(dt); }
 	MeshViewerWidget *widget_;
 };
 
@@ -502,7 +502,7 @@ void MeshViewerWidget::gl_loadScene() {
 	createCameraController();
 }
 
-void MeshViewerWidget::transformMesh(GLdouble dt) {
+void MeshViewerWidget::transformMesh(double dt) {
 	// rotate the mesh around the Y axis
 	meshOrientation_ += dt * 0.001f;
 	if (meshOrientation_ > M_PI * 2.0f) {

--- a/applications/mesh-viewer/mesh-viewer-widget.h
+++ b/applications/mesh-viewer/mesh-viewer-widget.h
@@ -23,7 +23,7 @@ Q_OBJECT
 public:
 	explicit MeshViewerWidget(QtApplication *app);
 
-	void transformMesh(GLdouble dt);
+	void transformMesh(double dt);
 
 public slots:
 

--- a/applications/mesh-viewer/mesh-viewer-widget.h
+++ b/applications/mesh-viewer/mesh-viewer-widget.h
@@ -60,8 +60,8 @@ protected:
 	QVBoxLayout *fullscreenLayout_;
 	Ui_mainWindow ui_;
 
-	GLboolean controlsShown_;
-	GLboolean wereControlsShown_;
+	bool controlsShown_;
+	bool wereControlsShown_;
 	QList<int> splitterSizes_;
 
 	ref_ptr<StateNode> sceneRoot_;

--- a/applications/noise-gui/noise-widget.cpp
+++ b/applications/noise-gui/noise-widget.cpp
@@ -195,10 +195,10 @@ void NoiseWidget::addProperty(
 
 void NoiseWidget::addProperty_i(
 			std::string_view name,
-			GLint min,
-			GLint max,
-			GLint value,
-			const std::function<void(GLint)> &setter) {
+			int min,
+			int max,
+			int value,
+			const std::function<void(int)> &setter) {
 	auto *slider = new QSlider(Qt::Horizontal);
 	int sliderMin = 0;
 	int sliderMax = REGEN_QT_SLIDER_MAX;
@@ -212,7 +212,7 @@ void NoiseWidget::addProperty_i(
 	ui_.parameterTable->setItem(itemRow, 1, new QTableWidgetItem(QString::number(value)));
 	ui_.parameterTable->setCellWidget(itemRow, 2, slider);
 	slider->connect(slider, &QSlider::valueChanged, [this,setter,min,max,itemRow](int value) {
-		auto val = static_cast<GLint>(
+		auto val = static_cast<int>(
 			((static_cast<GLdouble>(value) / REGEN_QT_SLIDER_MAX_d) *
 			 static_cast<GLdouble>(max - min)) + min);
 		setter(val);
@@ -242,7 +242,7 @@ void NoiseWidget::updateTable(const ref_ptr<NoiseGenerator> &generator) {
 	auto perlin = dynamic_cast<noise::module::Perlin *>(handle);
 	if (perlin) {
 		addProperty_i("Seed", NOISE_SEED_MIN, NOISE_SEED_MAX, perlin->GetSeed(),
-			[perlin](GLint value) { perlin->SetSeed(value); });
+			[perlin](int value) { perlin->SetSeed(value); });
 		addProperty("Frequency", NOISE_FREQUENCY_MIN, NOISE_FREQUENCY_MAX, perlin->GetFrequency(),
 			[perlin](GLdouble value) { perlin->SetFrequency(value); });
 		addProperty("Persistence", NOISE_PERSISTENCE_MIN, NOISE_PERSISTENCE_MAX, perlin->GetPersistence(),
@@ -250,40 +250,40 @@ void NoiseWidget::updateTable(const ref_ptr<NoiseGenerator> &generator) {
 		addProperty("Lacunarity", NOISE_LACUNARITY_MIN, NOISE_LACUNARITY_MAX, perlin->GetLacunarity(),
 			[perlin](GLdouble value) { perlin->SetLacunarity(value); });
 		addProperty_i("Octave Count", NOISE_OCTAVES_MIN, NOISE_OCTAVES_MAX, perlin->GetOctaveCount(),
-			[perlin](GLint value) { perlin->SetOctaveCount(value); });
+			[perlin](int value) { perlin->SetOctaveCount(value); });
 		return;
 	}
 
 	auto billow = dynamic_cast<noise::module::Billow *>(handle);
 	if (billow) {
 		addProperty_i("Seed", NOISE_SEED_MIN, NOISE_SEED_MAX, billow->GetSeed(),
-			[billow](GLint value) { billow->SetSeed(value); });
+			[billow](int value) { billow->SetSeed(value); });
 		addProperty("Frequency", NOISE_FREQUENCY_MIN, NOISE_FREQUENCY_MAX, billow->GetFrequency(),
 			[billow](GLdouble value) { billow->SetFrequency(value); });
 		addProperty("Lacunarity", NOISE_LACUNARITY_MIN, NOISE_LACUNARITY_MAX, billow->GetLacunarity(),
 			[billow](GLdouble value) { billow->SetLacunarity(value); });
 		addProperty_i("Octave Count", NOISE_OCTAVES_MIN, NOISE_OCTAVES_MAX, billow->GetOctaveCount(),
-			[billow](GLint value) { billow->SetOctaveCount(value); });
+			[billow](int value) { billow->SetOctaveCount(value); });
 		return;
 	}
 
 	auto turbulence = dynamic_cast<noise::module::Turbulence *>(handle);
 	if (turbulence) {
 		addProperty_i("Seed", NOISE_SEED_MIN, NOISE_SEED_MAX, turbulence->GetSeed(),
-			[turbulence](GLint value) { turbulence->SetSeed(value); });
+			[turbulence](int value) { turbulence->SetSeed(value); });
 		addProperty("Frequency", NOISE_FREQUENCY_MIN, NOISE_FREQUENCY_MAX, turbulence->GetFrequency(),
 			[turbulence](GLdouble value) { turbulence->SetFrequency(value); });
 		addProperty("Power", 0.0, 10.0, turbulence->GetPower(),
 			[turbulence](GLdouble value) { turbulence->SetPower(value); });
 		addProperty_i("Roughness", 1, 10, turbulence->GetRoughnessCount(),
-			[turbulence](GLint value) { turbulence->SetRoughness(value); });
+			[turbulence](int value) { turbulence->SetRoughness(value); });
 		return;
 	}
 
 	auto voronoi = dynamic_cast<noise::module::Voronoi *>(handle);
 	if (voronoi) {
 		addProperty_i("Seed", NOISE_SEED_MIN, NOISE_SEED_MAX, voronoi->GetSeed(),
-			[voronoi](GLint value) { voronoi->SetSeed(value); });
+			[voronoi](int value) { voronoi->SetSeed(value); });
 		addProperty("Frequency", NOISE_FREQUENCY_MIN, NOISE_FREQUENCY_MAX, voronoi->GetFrequency(),
 			[voronoi](GLdouble value) { voronoi->SetFrequency(value); });
 		addProperty("Displacement", 0.0, 100.0, voronoi->GetDisplacement(),
@@ -321,13 +321,13 @@ void NoiseWidget::updateTable(const ref_ptr<NoiseGenerator> &generator) {
 	auto riggedMultifractal = dynamic_cast<noise::module::RidgedMulti *>(handle);
 	if (riggedMultifractal) {
 		addProperty_i("Seed", NOISE_SEED_MIN, NOISE_SEED_MAX, riggedMultifractal->GetSeed(),
-			[riggedMultifractal](GLint value) { riggedMultifractal->SetSeed(value); });
+			[riggedMultifractal](int value) { riggedMultifractal->SetSeed(value); });
 		addProperty("Frequency", NOISE_FREQUENCY_MIN, NOISE_FREQUENCY_MAX, riggedMultifractal->GetFrequency(),
 			[riggedMultifractal](GLdouble value) { riggedMultifractal->SetFrequency(value); });
 		addProperty("Lacunarity", NOISE_LACUNARITY_MIN, NOISE_LACUNARITY_MAX, riggedMultifractal->GetLacunarity(),
 			[riggedMultifractal](GLdouble value) { riggedMultifractal->SetLacunarity(value); });
 		addProperty_i("Octave Count", NOISE_OCTAVES_MIN, NOISE_OCTAVES_MAX, riggedMultifractal->GetOctaveCount(),
-			[riggedMultifractal](GLint value) { riggedMultifractal->SetOctaveCount(value); });
+			[riggedMultifractal](int value) { riggedMultifractal->SetOctaveCount(value); });
 		return;
 	}
 
@@ -555,7 +555,7 @@ void NoiseWidget::addNoiseModule() {
 }
 
 void NoiseWidget::loadPerlin() {
-	GLint randomSeed = 36433;
+	int randomSeed = 36433;
 	auto gen = NoiseGenerator::preset_perlin(randomSeed);
 	updateTexture();
 	updateNoiseGenerators(gen);
@@ -563,7 +563,7 @@ void NoiseWidget::loadPerlin() {
 }
 
 void NoiseWidget::loadClouds() {
-	GLint randomSeed = 754643;
+	int randomSeed = 754643;
 	auto gen = NoiseGenerator::preset_clouds(randomSeed);
 	updateTexture();
 	updateNoiseGenerators(gen);
@@ -571,7 +571,7 @@ void NoiseWidget::loadClouds() {
 }
 
 void NoiseWidget::loadGranite() {
-			GLint randomSeed = 45245;
+			int randomSeed = 45245;
 	auto gen = NoiseGenerator::preset_granite(randomSeed);
 	updateTexture();
 	updateNoiseGenerators(gen);
@@ -579,7 +579,7 @@ void NoiseWidget::loadGranite() {
 }
 
 void NoiseWidget::loadWood() {
-	GLint randomSeed = 9674;
+	int randomSeed = 9674;
 	auto gen = NoiseGenerator::preset_wood(randomSeed);
 	updateTexture();
 	updateNoiseGenerators(gen);

--- a/applications/noise-gui/noise-widget.cpp
+++ b/applications/noise-gui/noise-widget.cpp
@@ -120,9 +120,9 @@ void NoiseWidget::updateTexture() {
 	updateTexture_ = true;
 }
 
-void NoiseWidget::animate(double dt) {}
+void NoiseWidget::cpuUpdate(double dt) {}
 
-void NoiseWidget::glAnimate(RenderState *rs, double dt) {
+void NoiseWidget::gpuUpdate(RenderState *rs, double dt) {
 	if (!updateTexture_ || !texture_.get()) return;
 
 	auto noiseModuleName = ui_.textureSelectionBox->itemText(

--- a/applications/noise-gui/noise-widget.cpp
+++ b/applications/noise-gui/noise-widget.cpp
@@ -134,9 +134,7 @@ void NoiseWidget::gpuUpdate(RenderState *rs, double dt) {
 		return;
 	}
 
-	lock();
 	texture_->setNoiseGenerator(generator);
-	unlock();
 	updateTexture_ = false;
 }
 

--- a/applications/noise-gui/noise-widget.cpp
+++ b/applications/noise-gui/noise-widget.cpp
@@ -25,7 +25,7 @@ using namespace std;
 
 NoiseWidget::NoiseWidget(QtApplication *app)
 		: QMainWindow(),
-		  Animation(GL_TRUE, GL_TRUE),
+		  Animation(true, true),
 		  app_(app) {
 	setMouseTracking(true);
 
@@ -60,7 +60,7 @@ protected:
 };
 
 void NoiseWidget::gl_loadScene() {
-	AnimationManager::get().pause(GL_TRUE);
+	AnimationManager::get().pause(true);
 	AnimationManager::get().setRootState(app_->renderTree()->state());
 
 	// create render target
@@ -93,7 +93,7 @@ void NoiseWidget::gl_loadScene() {
 	sceneRoot->state()->joinStates(ref_ptr<BlitToScreen>::alloc(
 			fbo, app_->screen(),
 			GL_COLOR_ATTACHMENT0,
-			GL_TRUE));
+			true));
 	GL_ERROR_LOG();
 
 	// resize fbo with window
@@ -117,7 +117,7 @@ void NoiseWidget::updateSize() {
 }
 
 void NoiseWidget::updateTexture() {
-	updateTexture_ = GL_TRUE;
+	updateTexture_ = true;
 }
 
 void NoiseWidget::animate(double dt) {}
@@ -137,7 +137,7 @@ void NoiseWidget::glAnimate(RenderState *rs, double dt) {
 	lock();
 	texture_->setNoiseGenerator(generator);
 	unlock();
-	updateTexture_ = GL_FALSE;
+	updateTexture_ = false;
 }
 
 void NoiseWidget::updateNoiseGenerators(const ref_ptr<NoiseGenerator> &generator) {

--- a/applications/noise-gui/noise-widget.cpp
+++ b/applications/noise-gui/noise-widget.cpp
@@ -43,7 +43,7 @@ NoiseWidget::NoiseWidget(QtApplication *app)
 // Resizes Framebuffer texture when the window size changed
 class FBOResizer : public EventHandler {
 public:
-	FBOResizer(const ref_ptr<FBOState> &fbo, GLfloat wScale, GLfloat hScale)
+	FBOResizer(const ref_ptr<FBOState> &fbo, float wScale, float hScale)
 			: EventHandler(), fboState_(fbo), wScale_(wScale), hScale_(hScale) {}
 
 	~FBOResizer() override = default;
@@ -56,7 +56,7 @@ public:
 
 protected:
 	ref_ptr<FBOState> fboState_;
-	GLfloat wScale_, hScale_;
+	float wScale_, hScale_;
 };
 
 void NoiseWidget::gl_loadScene() {

--- a/applications/noise-gui/noise-widget.cpp
+++ b/applications/noise-gui/noise-widget.cpp
@@ -120,9 +120,9 @@ void NoiseWidget::updateTexture() {
 	updateTexture_ = GL_TRUE;
 }
 
-void NoiseWidget::animate(GLdouble dt) {}
+void NoiseWidget::animate(double dt) {}
 
-void NoiseWidget::glAnimate(RenderState *rs, GLdouble dt) {
+void NoiseWidget::glAnimate(RenderState *rs, double dt) {
 	if (!updateTexture_ || !texture_.get()) return;
 
 	auto noiseModuleName = ui_.textureSelectionBox->itemText(
@@ -170,10 +170,10 @@ void NoiseWidget::updateNoiseGenerators(const ref_ptr<NoiseGenerator> &generator
 
 void NoiseWidget::addProperty(
 			std::string_view name,
-			GLdouble min,
-			GLdouble max,
-			GLdouble value,
-			const std::function<void(GLdouble)> &setter) {
+			double min,
+			double max,
+			double value,
+			const std::function<void(double)> &setter) {
 	auto *slider = new QSlider(Qt::Horizontal);
 	int sliderMin = 0;
 	int sliderMax = REGEN_QT_SLIDER_MAX;
@@ -186,7 +186,7 @@ void NoiseWidget::addProperty(
 	ui_.parameterTable->setItem(itemRow, 1, new QTableWidgetItem(QString::number(value)));
 	ui_.parameterTable->setCellWidget(itemRow, 2, slider);
 	slider->connect(slider, &QSlider::valueChanged, [this,setter,min,max,itemRow](int value) {
-		GLdouble val = (static_cast<GLdouble>(value) / REGEN_QT_SLIDER_MAX_d) * ((max - min) + min);
+		double val = (static_cast<double>(value) / REGEN_QT_SLIDER_MAX_d) * ((max - min) + min);
 		setter(val);
 		ui_.parameterTable->item(itemRow, 1)->setText(QString::number(val));
 		//updateTexture();
@@ -203,7 +203,7 @@ void NoiseWidget::addProperty_i(
 	int sliderMin = 0;
 	int sliderMax = REGEN_QT_SLIDER_MAX;
 	int sliderValue = static_cast<int>(
-			(static_cast<GLdouble>(value) / static_cast<GLdouble>(max-min)) * static_cast<GLdouble>(sliderMax - sliderMin));
+			(static_cast<double>(value) / static_cast<double>(max-min)) * static_cast<double>(sliderMax - sliderMin));
 	int itemRow = ui_.parameterTable->rowCount();
 	slider->setRange(sliderMin, sliderMax);
 	slider->setValue(sliderValue);
@@ -213,8 +213,8 @@ void NoiseWidget::addProperty_i(
 	ui_.parameterTable->setCellWidget(itemRow, 2, slider);
 	slider->connect(slider, &QSlider::valueChanged, [this,setter,min,max,itemRow](int value) {
 		auto val = static_cast<int>(
-			((static_cast<GLdouble>(value) / REGEN_QT_SLIDER_MAX_d) *
-			 static_cast<GLdouble>(max - min)) + min);
+			((static_cast<double>(value) / REGEN_QT_SLIDER_MAX_d) *
+			 static_cast<double>(max - min)) + min);
 		setter(val);
 		ui_.parameterTable->item(itemRow, 1)->setText(QString::number(val));
 		//updateTexture();
@@ -244,11 +244,11 @@ void NoiseWidget::updateTable(const ref_ptr<NoiseGenerator> &generator) {
 		addProperty_i("Seed", NOISE_SEED_MIN, NOISE_SEED_MAX, perlin->GetSeed(),
 			[perlin](int value) { perlin->SetSeed(value); });
 		addProperty("Frequency", NOISE_FREQUENCY_MIN, NOISE_FREQUENCY_MAX, perlin->GetFrequency(),
-			[perlin](GLdouble value) { perlin->SetFrequency(value); });
+			[perlin](double value) { perlin->SetFrequency(value); });
 		addProperty("Persistence", NOISE_PERSISTENCE_MIN, NOISE_PERSISTENCE_MAX, perlin->GetPersistence(),
-			[perlin](GLdouble value) { perlin->SetPersistence(value); });
+			[perlin](double value) { perlin->SetPersistence(value); });
 		addProperty("Lacunarity", NOISE_LACUNARITY_MIN, NOISE_LACUNARITY_MAX, perlin->GetLacunarity(),
-			[perlin](GLdouble value) { perlin->SetLacunarity(value); });
+			[perlin](double value) { perlin->SetLacunarity(value); });
 		addProperty_i("Octave Count", NOISE_OCTAVES_MIN, NOISE_OCTAVES_MAX, perlin->GetOctaveCount(),
 			[perlin](int value) { perlin->SetOctaveCount(value); });
 		return;
@@ -259,9 +259,9 @@ void NoiseWidget::updateTable(const ref_ptr<NoiseGenerator> &generator) {
 		addProperty_i("Seed", NOISE_SEED_MIN, NOISE_SEED_MAX, billow->GetSeed(),
 			[billow](int value) { billow->SetSeed(value); });
 		addProperty("Frequency", NOISE_FREQUENCY_MIN, NOISE_FREQUENCY_MAX, billow->GetFrequency(),
-			[billow](GLdouble value) { billow->SetFrequency(value); });
+			[billow](double value) { billow->SetFrequency(value); });
 		addProperty("Lacunarity", NOISE_LACUNARITY_MIN, NOISE_LACUNARITY_MAX, billow->GetLacunarity(),
-			[billow](GLdouble value) { billow->SetLacunarity(value); });
+			[billow](double value) { billow->SetLacunarity(value); });
 		addProperty_i("Octave Count", NOISE_OCTAVES_MIN, NOISE_OCTAVES_MAX, billow->GetOctaveCount(),
 			[billow](int value) { billow->SetOctaveCount(value); });
 		return;
@@ -272,9 +272,9 @@ void NoiseWidget::updateTable(const ref_ptr<NoiseGenerator> &generator) {
 		addProperty_i("Seed", NOISE_SEED_MIN, NOISE_SEED_MAX, turbulence->GetSeed(),
 			[turbulence](int value) { turbulence->SetSeed(value); });
 		addProperty("Frequency", NOISE_FREQUENCY_MIN, NOISE_FREQUENCY_MAX, turbulence->GetFrequency(),
-			[turbulence](GLdouble value) { turbulence->SetFrequency(value); });
+			[turbulence](double value) { turbulence->SetFrequency(value); });
 		addProperty("Power", 0.0, 10.0, turbulence->GetPower(),
-			[turbulence](GLdouble value) { turbulence->SetPower(value); });
+			[turbulence](double value) { turbulence->SetPower(value); });
 		addProperty_i("Roughness", 1, 10, turbulence->GetRoughnessCount(),
 			[turbulence](int value) { turbulence->SetRoughness(value); });
 		return;
@@ -285,36 +285,36 @@ void NoiseWidget::updateTable(const ref_ptr<NoiseGenerator> &generator) {
 		addProperty_i("Seed", NOISE_SEED_MIN, NOISE_SEED_MAX, voronoi->GetSeed(),
 			[voronoi](int value) { voronoi->SetSeed(value); });
 		addProperty("Frequency", NOISE_FREQUENCY_MIN, NOISE_FREQUENCY_MAX, voronoi->GetFrequency(),
-			[voronoi](GLdouble value) { voronoi->SetFrequency(value); });
+			[voronoi](double value) { voronoi->SetFrequency(value); });
 		addProperty("Displacement", 0.0, 100.0, voronoi->GetDisplacement(),
-			[voronoi](GLdouble value) { voronoi->SetDisplacement(value); });
+			[voronoi](double value) { voronoi->SetDisplacement(value); });
 		return;
 	}
 
 	auto cylinders = dynamic_cast<noise::module::Cylinders *>(handle);
 	if (cylinders) {
 		addProperty("Frequency", NOISE_FREQUENCY_MIN, NOISE_FREQUENCY_MAX, cylinders->GetFrequency(),
-			[cylinders](GLdouble value) { cylinders->SetFrequency(value); });
+			[cylinders](double value) { cylinders->SetFrequency(value); });
 		return;
 	}
 
 	auto scaleBias = dynamic_cast<noise::module::ScaleBias *>(handle);
 	if (scaleBias) {
 		addProperty("Scale", -100.0, 100.0, scaleBias->GetScale(),
-			[scaleBias](GLdouble value) { scaleBias->SetScale(value); });
+			[scaleBias](double value) { scaleBias->SetScale(value); });
 		addProperty("Bias", -100.0, 100.0, scaleBias->GetBias(),
-			[scaleBias](GLdouble value) { scaleBias->SetBias(value); });
+			[scaleBias](double value) { scaleBias->SetBias(value); });
 		return;
 	}
 
 	auto scalePoint = dynamic_cast<noise::module::ScalePoint *>(handle);
 	if (scalePoint) {
 		addProperty("X Scale", 0.0, 100.0, scalePoint->GetXScale(),
-			[scalePoint](GLdouble value) { scalePoint->SetXScale(value); });
+			[scalePoint](double value) { scalePoint->SetXScale(value); });
 		addProperty("Y Scale", 0.0, 100.0, scalePoint->GetYScale(),
-			[scalePoint](GLdouble value) { scalePoint->SetYScale(value); });
+			[scalePoint](double value) { scalePoint->SetYScale(value); });
 		addProperty("Z Scale", 0.0, 100.0, scalePoint->GetZScale(),
-			[scalePoint](GLdouble value) { scalePoint->SetZScale(value); });
+			[scalePoint](double value) { scalePoint->SetZScale(value); });
 		return;
 	}
 
@@ -323,9 +323,9 @@ void NoiseWidget::updateTable(const ref_ptr<NoiseGenerator> &generator) {
 		addProperty_i("Seed", NOISE_SEED_MIN, NOISE_SEED_MAX, riggedMultifractal->GetSeed(),
 			[riggedMultifractal](int value) { riggedMultifractal->SetSeed(value); });
 		addProperty("Frequency", NOISE_FREQUENCY_MIN, NOISE_FREQUENCY_MAX, riggedMultifractal->GetFrequency(),
-			[riggedMultifractal](GLdouble value) { riggedMultifractal->SetFrequency(value); });
+			[riggedMultifractal](double value) { riggedMultifractal->SetFrequency(value); });
 		addProperty("Lacunarity", NOISE_LACUNARITY_MIN, NOISE_LACUNARITY_MAX, riggedMultifractal->GetLacunarity(),
-			[riggedMultifractal](GLdouble value) { riggedMultifractal->SetLacunarity(value); });
+			[riggedMultifractal](double value) { riggedMultifractal->SetLacunarity(value); });
 		addProperty_i("Octave Count", NOISE_OCTAVES_MIN, NOISE_OCTAVES_MAX, riggedMultifractal->GetOctaveCount(),
 			[riggedMultifractal](int value) { riggedMultifractal->SetOctaveCount(value); });
 		return;
@@ -354,33 +354,33 @@ void NoiseWidget::updateTable(const ref_ptr<NoiseGenerator> &generator) {
 	auto select = dynamic_cast<noise::module::Select *>(handle);
 	if (select) {
 		addProperty("Lower Bound", -1.0, 1.0, select->GetLowerBound(),
-			[select](GLdouble value) { select->SetBounds(value, select->GetUpperBound()); });
+			[select](double value) { select->SetBounds(value, select->GetUpperBound()); });
 		addProperty("Upper Bound", -1.0, 1.0, select->GetUpperBound(),
-			[select](GLdouble value) { select->SetBounds(select->GetLowerBound(), value); });
+			[select](double value) { select->SetBounds(select->GetLowerBound(), value); });
 		addProperty("Edge Falloff", 0.0, 1.0, select->GetEdgeFalloff(),
-			[select](GLdouble value) { select->SetEdgeFalloff(value); });
+			[select](double value) { select->SetEdgeFalloff(value); });
 		return;
 	}
 
 	auto translatePoint = dynamic_cast<noise::module::TranslatePoint *>(handle);
 	if (translatePoint) {
 		addProperty("X Translation", -100.0, 100.0, translatePoint->GetXTranslation(),
-			[translatePoint](GLdouble value) { translatePoint->SetXTranslation(value); });
+			[translatePoint](double value) { translatePoint->SetXTranslation(value); });
 		addProperty("Y Translation", -100.0, 100.0, translatePoint->GetYTranslation(),
-			[translatePoint](GLdouble value) { translatePoint->SetYTranslation(value); });
+			[translatePoint](double value) { translatePoint->SetYTranslation(value); });
 		addProperty("Z Translation", -100.0, 100.0, translatePoint->GetZTranslation(),
-			[translatePoint](GLdouble value) { translatePoint->SetZTranslation(value); });
+			[translatePoint](double value) { translatePoint->SetZTranslation(value); });
 		return;
 	}
 
 	auto rotatePoint = dynamic_cast<noise::module::RotatePoint *>(handle);
 	if (rotatePoint) {
 		addProperty("X Angle", 0.0, 360.0, rotatePoint->GetXAngle(),
-			[rotatePoint](GLdouble value) { rotatePoint->SetXAngle(value); });
+			[rotatePoint](double value) { rotatePoint->SetXAngle(value); });
 		addProperty("Y Angle", 0.0, 360.0, rotatePoint->GetYAngle(),
-			[rotatePoint](GLdouble value) { rotatePoint->SetYAngle(value); });
+			[rotatePoint](double value) { rotatePoint->SetYAngle(value); });
 		addProperty("Z Angle", 0.0, 360.0, rotatePoint->GetZAngle(),
-			[rotatePoint](GLdouble value) { rotatePoint->SetZAngle(value); });
+			[rotatePoint](double value) { rotatePoint->SetZAngle(value); });
 		return;
 	}
 }

--- a/applications/noise-gui/noise-widget.h
+++ b/applications/noise-gui/noise-widget.h
@@ -95,10 +95,10 @@ protected:
 
 	void addProperty_i(
 			std::string_view name,
-			GLint min,
-			GLint max,
-			GLint value,
-			const std::function<void(GLint)> &setter);
+			int min,
+			int max,
+			int value,
+			const std::function<void(int)> &setter);
 };
 
 #endif /* NOISE_WIDGET_H_ */

--- a/applications/noise-gui/noise-widget.h
+++ b/applications/noise-gui/noise-widget.h
@@ -26,9 +26,9 @@ public:
 	// Override
 	void call(EventObject *ev, EventData *data);
 
-	void animate(double dt);
+	void cpuUpdate(double dt);
 
-	void glAnimate(RenderState *rs, double dt);
+	void gpuUpdate(RenderState *rs, double dt);
 
 public slots:
 

--- a/applications/noise-gui/noise-widget.h
+++ b/applications/noise-gui/noise-widget.h
@@ -26,9 +26,9 @@ public:
 	// Override
 	void call(EventObject *ev, EventData *data);
 
-	void animate(GLdouble dt);
+	void animate(double dt);
 
-	void glAnimate(RenderState *rs, GLdouble dt);
+	void glAnimate(RenderState *rs, double dt);
 
 public slots:
 
@@ -88,10 +88,10 @@ protected:
 
 	void addProperty(
 			std::string_view name,
-			GLdouble min,
-			GLdouble max,
-			GLdouble value,
-			const std::function<void(GLdouble)> &setter);
+			double min,
+			double max,
+			double value,
+			const std::function<void(double)> &setter);
 
 	void addProperty_i(
 			std::string_view name,

--- a/applications/noise-gui/noise-widget.h
+++ b/applications/noise-gui/noise-widget.h
@@ -62,7 +62,7 @@ protected:
 	QtApplication *app_;
 	Ui_mainWindow ui_;
 	ref_ptr<NoiseTexture2D> texture_;
-	GLboolean updateTexture_ = GL_TRUE;
+	bool updateTexture_ = true;
 
 	std::map<std::string, ref_ptr<NoiseGenerator>> noiseGenerators_;
 

--- a/applications/qt/ColorWidget.cpp
+++ b/applications/qt/ColorWidget.cpp
@@ -26,10 +26,10 @@ QColor ColorWidget::initializeColor() {
 	uint32_t count = input_->valsPerElement();
 	QColor color;
 	if (input_->baseType() == GL_FLOAT) {
-		GLfloat r = ((GLfloat *) value)[0];
-		GLfloat g = ((GLfloat *) value)[1];
-		GLfloat b = ((GLfloat *) value)[2];
-		GLfloat a = (count == 4) ? ((GLfloat *) value)[3] : 1.0f;
+		float r = ((float *) value)[0];
+		float g = ((float *) value)[1];
+		float b = ((float *) value)[2];
+		float a = (count == 4) ? ((float *) value)[3] : 1.0f;
 		mapped.unmap();
 		color.setRgbF(r, g, b, a);
 	} else {
@@ -56,11 +56,11 @@ void ColorWidget::updateColor(const QColor &color) {
 	uint32_t count = input_->valsPerElement();
 	byte *changedData = new byte[input_->elementSize()];
 	if (input_->baseType() == GL_FLOAT) {
-		((GLfloat *) changedData)[0] = color.redF();
-		((GLfloat *) changedData)[1] = color.greenF();
-		((GLfloat *) changedData)[2] = color.blueF();
+		((float *) changedData)[0] = color.redF();
+		((float *) changedData)[1] = color.greenF();
+		((float *) changedData)[2] = color.blueF();
 		if (count == 4) {
-			((GLfloat *) changedData)[3] = color.alphaF();
+			((float *) changedData)[3] = color.alphaF();
 		}
 	}
 	input_->writeVertex(0, changedData);
@@ -82,10 +82,10 @@ void ColorWidget::pickColor() {
 	const byte *value = mapped.r;
 	QColor initialColor;
 	if (input_->baseType() == GL_FLOAT) {
-		GLfloat r = ((GLfloat *) value)[0];
-		GLfloat g = ((GLfloat *) value)[1];
-		GLfloat b = ((GLfloat *) value)[2];
-		GLfloat a = (count == 4) ? ((GLfloat *) value)[3] : 1.0f;
+		float r = ((float *) value)[0];
+		float g = ((float *) value)[1];
+		float b = ((float *) value)[2];
+		float a = (count == 4) ? ((float *) value)[3] : 1.0f;
 		mapped.unmap();
 		initialColor.setRgbF(r, g, b, a);
 	} else {
@@ -125,7 +125,7 @@ void ColorWidget::alphaChanged() {
 	auto mapped = input_->mapClientDataRaw(BUFFER_GPU_READ);
 	const byte *value = mapped.r;
 	if (input_->baseType() == GL_FLOAT) {
-		((GLfloat *) value)[3] = static_cast<GLfloat>(sliderValue) / 1000.0f;
+		((float *) value)[3] = static_cast<float>(sliderValue) / 1000.0f;
 	} else {
 		REGEN_WARN("Unsupported data type for color input.");
 		return;

--- a/applications/qt/VectorWidget.cpp
+++ b/applications/qt/VectorWidget.cpp
@@ -8,7 +8,7 @@ static GLfloat readInputValue(const ref_ptr<ShaderInput> &input, const byte *val
 			return ((GLfloat *) value)[i];
 		}
 		case GL_INT: {
-			return static_cast<GLfloat>((((GLint *) value)[i]));
+			return static_cast<GLfloat>((((int *) value)[i]));
 		}
 		case GL_UNSIGNED_INT: {
 			return static_cast<GLfloat>((((uint32_t *) value)[i]));
@@ -140,7 +140,7 @@ void VectorWidget::valueUpdated() {
 			changedData = createData<GLfloat>(input_, valueWidgets, valueTexts, count);
 			break;
 		case GL_INT:
-			changedData = createData<GLint>(input_, valueWidgets, valueTexts, count);
+			changedData = createData<int>(input_, valueWidgets, valueTexts, count);
 			break;
 		case GL_UNSIGNED_INT:
 			changedData = createData<uint32_t>(input_, valueWidgets, valueTexts, count);

--- a/applications/qt/VectorWidget.cpp
+++ b/applications/qt/VectorWidget.cpp
@@ -2,16 +2,16 @@
 
 using namespace regen;
 
-static GLfloat readInputValue(const ref_ptr<ShaderInput> &input, const byte *value, uint32_t i) {
+static float readInputValue(const ref_ptr<ShaderInput> &input, const byte *value, uint32_t i) {
 	switch (input->baseType()) {
 		case GL_FLOAT: {
-			return ((GLfloat *) value)[i];
+			return ((float *) value)[i];
 		}
 		case GL_INT: {
-			return static_cast<GLfloat>((((int *) value)[i]));
+			return static_cast<float>((((int *) value)[i]));
 		}
 		case GL_UNSIGNED_INT: {
-			return static_cast<GLfloat>((((uint32_t *) value)[i]));
+			return static_cast<float>((((uint32_t *) value)[i]));
 		}
 		default:
 			REGEN_WARN("Unknown data type " << input->baseType());
@@ -55,7 +55,7 @@ VectorWidget::VectorWidget(const RegenWidgetData &data, QWidget *parent)
 			valueWidgets[i]->setMinimum(static_cast<int>(limits->first * 1000.0f));
 			valueWidgets[i]->setMaximum(static_cast<int>(limits->second * 1000.0f));
 		} else {
-			GLfloat x = readInputValue(input_, value, i);
+			float x = readInputValue(input_, value, i);
 			valueWidgets[i]->setMinimum(0);
 			valueWidgets[i]->setMaximum(static_cast<int>(std::max(1.0, fabs(x) * 2.0) * 1000.0f));
 		}
@@ -63,7 +63,7 @@ VectorWidget::VectorWidget(const RegenWidgetData &data, QWidget *parent)
 
 	// show and set active components
 	for (i = 0; i < count; ++i) {
-		GLfloat x = readInputValue(input_, value, i);
+		float x = readInputValue(input_, value, i);
 		valueWidgets[i]->setValue(static_cast<int>(x * 1000.0f));
 		valueTexts[i]->setText(QString::number(x));
 
@@ -137,7 +137,7 @@ void VectorWidget::valueUpdated() {
 	byte *changedData = nullptr;
 	switch (input_->baseType()) {
 		case GL_FLOAT:
-			changedData = createData<GLfloat>(input_, valueWidgets, valueTexts, count);
+			changedData = createData<float>(input_, valueWidgets, valueTexts, count);
 			break;
 		case GL_INT:
 			changedData = createData<int>(input_, valueWidgets, valueTexts, count);

--- a/applications/qt/qt-application.cpp
+++ b/applications/qt/qt-application.cpp
@@ -83,7 +83,7 @@ int QtApplication::mainLoop() {
 	}
 	((SceneWidget*)glWidget_)->stopRendering();
 #endif
-	AnimationManager::get().close();
+	AnimationManager::get().shutdown();
 	BufferObject::destroyMemoryPools();
 	Font::closeLibrary();
 

--- a/applications/qt/qt-application.cpp
+++ b/applications/qt/qt-application.cpp
@@ -31,7 +31,7 @@ QtApplication::QtApplication(
 		const QSurfaceFormat &glFormat,
 		uint32_t width, uint32_t height,
 		QWidget *parent)
-		: Scene(argc, argv), isMainloopRunning_(GL_FALSE), exitCode_(0) {
+		: Scene(argc, argv), isMainloopRunning_(false), exitCode_(0) {
 	QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 	app_ = new QApplication(appArgCount, (char **) appArgs);
 
@@ -64,12 +64,12 @@ void QtApplication::show() {
 
 void QtApplication::exitMainLoop(int errorCode) {
 	exitCode_ = errorCode;
-	isMainloopRunning_ = GL_FALSE;
+	isMainloopRunning_ = false;
 }
 
 int QtApplication::mainLoop() {
 	AnimationManager::get().resume();
-	isMainloopRunning_ = GL_TRUE;
+	isMainloopRunning_ = true;
 
 	toplevelWidget()->installEventFilter(glWidget_);
 

--- a/applications/qt/qt-application.cpp
+++ b/applications/qt/qt-application.cpp
@@ -68,6 +68,9 @@ void QtApplication::exitMainLoop(int errorCode) {
 }
 
 int QtApplication::mainLoop() {
+	// Make sure the window is exposed before starting rendering
+	app_->processEvents();
+
 	AnimationManager::get().resume();
 	isMainloopRunning_ = true;
 

--- a/applications/qt/scene-widget.cpp
+++ b/applications/qt/scene-widget.cpp
@@ -282,8 +282,8 @@ void SceneWidget::wheelEvent(QWheelEvent *event) {
 	int button = event->angleDelta().y() > 0 ? Scene::MOUSE_WHEEL_UP : Scene::MOUSE_WHEEL_DOWN;
 	Scene::ButtonEvent ev{};
 	ev.button = button;
-	ev.isDoubleClick = GL_FALSE;
-	ev.pressed = GL_FALSE;
+	ev.isDoubleClick = false;
+	ev.pressed = false;
 	ev.x = static_cast<int>(x);
 	ev.y = static_cast<int>(y);
 	app_->mouseButton(ev);

--- a/applications/qt/scene-widget.cpp
+++ b/applications/qt/scene-widget.cpp
@@ -51,7 +51,7 @@ namespace regen {
 	};
 }
 
-static GLint qtToOgleButton(Qt::MouseButton button) {
+static int qtToOgleButton(Qt::MouseButton button) {
 	switch (button) {
 		case Qt::LeftButton:
 			return Scene::MOUSE_BUTTON_LEFT;
@@ -123,7 +123,7 @@ QSurfaceFormat SceneWidget::defaultFormat() {
 	return format;
 }
 
-void SceneWidget::setUpdateInterval(GLint interval) {
+void SceneWidget::setUpdateInterval(int interval) {
 	updateInterval_ = interval;
 }
 
@@ -236,8 +236,8 @@ void SceneWidget::GLThread::run() {
 }
 
 void SceneWidget::do_mouseClick(QMouseEvent *event, bool isPressed, bool isDoubleClick) {
-	GLint x = event->x(), y = event->y();
-	GLint button = qtToOgleButton(event->button());
+	int x = event->x(), y = event->y();
+	int button = qtToOgleButton(event->button());
 	if (button == -1) { return; }
 	Scene::ButtonEvent ev{};
 	ev.button = button;
@@ -303,8 +303,8 @@ void SceneWidget::keyPressEvent(QKeyEvent *event) {
 	auto mousePos = app_->mousePosition()->getVertex(0);
 	Scene::KeyEvent ev{};
 	ev.key = event->key();
-	ev.x = (GLint) mousePos.r.x;
-	ev.y = (GLint) mousePos.r.y;
+	ev.x = (int) mousePos.r.x;
+	ev.y = (int) mousePos.r.y;
 	app_->keyDown(ev);
 	event->accept();
 }

--- a/applications/qt/scene-widget.h
+++ b/applications/qt/scene-widget.h
@@ -39,7 +39,7 @@ namespace regen {
 		/**
 		 * @param interval update interval in milliseconds.
 		 */
-		void setUpdateInterval(GLint interval);
+		void setUpdateInterval(int interval);
 
 		// override
 		void mousePressEvent(QMouseEvent *) override;

--- a/applications/qt/shader-input-widget.cpp
+++ b/applications/qt/shader-input-widget.cpp
@@ -21,7 +21,7 @@ using namespace regen;
 ShaderInputWidget::ShaderInputWidget(QtApplication *app, QWidget *parent)
 		: QWidget(parent), app_(app),
 		  selectedItem_(nullptr),
-		  ignoreValueChanges_(GL_FALSE) {
+		  ignoreValueChanges_(false) {
 	ui_.setupUi(this);
 	QList<int> sizes;
 	sizes << 25 << 75;
@@ -159,7 +159,7 @@ bool ShaderInputWidget::handleNode(
 }
 
 void ShaderInputWidget::activateValue(QTreeWidgetItem *selected, QTreeWidgetItem *_) {
-	ignoreValueChanges_ = GL_TRUE;
+	ignoreValueChanges_ = true;
 	selectedItem_ = selected;
 
 	while (ui_.parameterLayout->count() > 0) {
@@ -182,7 +182,7 @@ void ShaderInputWidget::activateValue(QTreeWidgetItem *selected, QTreeWidgetItem
 		REGEN_WARN("No item found for selected node.");
 	}
 
-	ignoreValueChanges_ = GL_FALSE;
+	ignoreValueChanges_ = false;
 }
 
 bool ShaderInputWidget::handleState(

--- a/applications/qt/shader-input-widget.cpp
+++ b/applications/qt/shader-input-widget.cpp
@@ -81,13 +81,13 @@ void ShaderInputWidget::setNode(const ref_ptr<StateNode> &node) {
 	animWidget->setExpanded(true);
 	int index = 0;
 	std::set<Animation *> allAnimations;
-	for (auto &anim: AnimationManager::get().synchronizedAnimations()) {
+	for (auto &anim: AnimationManager::get().cpuAnimations()) {
 		allAnimations.insert(anim);
 	}
-	for (auto &anim: AnimationManager::get().unsynchronizedAnimations()) {
+	for (auto &anim: AnimationManager::get().gpuAnimations()) {
 		allAnimations.insert(anim);
 	}
-	for (auto &anim: AnimationManager::get().graphicsAnimations()) {
+	for (auto &anim: AnimationManager::get().unsyncedAnimations()) {
 		allAnimations.insert(anim);
 	}
 	for (auto &anim: allAnimations) {

--- a/applications/qt/shader-input-widget.h
+++ b/applications/qt/shader-input-widget.h
@@ -34,7 +34,7 @@ namespace regen {
 		QtApplication *app_;
 		Ui_shaderInputEditor ui_;
 		QTreeWidgetItem *selectedItem_;
-		GLboolean ignoreValueChanges_;
+		bool ignoreValueChanges_;
 
 		std::map<ShaderInput *, byte *> initialValue_;
 		std::map<ShaderInput *, uint32_t> initialValueStamp_;

--- a/applications/scene-display/animation-events.h
+++ b/applications/scene-display/animation-events.h
@@ -10,66 +10,22 @@ inline BoneTree::AnimationHandle setAnimationRangeActive(
 			uint32_t instanceIdx,
 			const AnimationRange &animRange) {
 	if (animRange.trackName.empty()) {
-		REGEN_INFO("Starting animation range '" << animRange.name
-			<< "' on track index " << animRange.trackIndex
-			<< " for instance " << instanceIdx << ".");
 		return anim->startBoneAnimation(instanceIdx, animRange.trackIndex, animRange.range);
 	} else {
 		int32_t trackIndex = anim->getTrackIndex(animRange.trackName);
 		if (trackIndex < 0) {
-			REGEN_WARN("Unable to find track name '" << animRange.trackName
-				<< "' for animation range '" << animRange.name << "'.");
 			return -1;
 		}
 		return anim->startBoneAnimation(instanceIdx, trackIndex, animRange.range);
 	}
 }
 
+
 class RandomAnimationRangeUpdater : public EventHandler {
 public:
-	RandomAnimationRangeUpdater(const ref_ptr<BoneAnimationItem> &animItem)
-			: EventHandler(), animItem_(animItem) {
-		// Load the track index for each range.
-		for (auto &range: animItem_->ranges) {
-			if (!range.trackName.empty()) {
-				range.trackIndex = animItem_->boneTree->getTrackIndex(range.trackName);
-			}
-		}
-	}
+	explicit RandomAnimationRangeUpdater(const ref_ptr<BoneTree> &anim) : EventHandler(), anim_(anim) {}
 
 	~RandomAnimationRangeUpdater() override = default;
-
-	void call(EventObject *ev, EventData *data) override {
-		BoneTree::BoneEvent *evData = (BoneTree::BoneEvent *) data;
-		int index = rand() % animItem_->ranges.size();
-		setAnimationRangeActive(animItem_->boneTree, evData->instanceIdx, animItem_->ranges[index]);
-	}
-
-protected:
-	ref_ptr<BoneAnimationItem> animItem_{};
-};
-
-class FixedAnimationRangeUpdater : public EventHandler {
-public:
-	FixedAnimationRangeUpdater(const ref_ptr<BoneTree> &anim, const AnimationRange &animRange)
-			: EventHandler(), anim_(anim), animRange_(animRange) {}
-
-	~FixedAnimationRangeUpdater() override = default;
-	void call(EventObject *ev, EventData *data) override {
-		BoneTree::BoneEvent *evData = (BoneTree::BoneEvent *) data;
-		setAnimationRangeActive(anim_, evData->instanceIdx, animRange_);
-	}
-protected:
-	ref_ptr<BoneTree> anim_;
-	AnimationRange animRange_;
-};
-
-
-class RandomAnimationRangeUpdater2 : public EventHandler {
-public:
-	explicit RandomAnimationRangeUpdater2(const ref_ptr<BoneTree> &anim) : EventHandler(), anim_(anim) {}
-
-	~RandomAnimationRangeUpdater2() override = default;
 
 	void call(EventObject *ev, EventData *data) override {
 		BoneTree::BoneEvent *evData = (BoneTree::BoneEvent *) data;

--- a/applications/scene-display/examples/canyon.xml
+++ b/applications/scene-display/examples/canyon.xml
@@ -595,6 +595,8 @@
              swizzle-g="RED" swizzle-b="RED"/>
 
     <!-- water surface mesh used for depth rendering and post-processing effects -->
+    <!-- FIXME: This does not work well when camera is facing downwards,
+                effectively looking behind its position in xz plane. Also the case in other scenes. -->
     <mesh id="water-mesh" type="rectangle" lod="0" center="1"
           use-normal="0" use-texco="0" use-tangent="0"
           rotation="0.0,0.0,3.1415"

--- a/applications/scene-display/examples/terrain.xml
+++ b/applications/scene-display/examples/terrain.xml
@@ -230,8 +230,6 @@
              swizzle-g="RED" swizzle-b="RED"/>
 
     <!-- water surface mesh used for depth rendering and post-processing effects -->
-    <!-- FIXME: This does not work well when camera is facing downwards,
-                effectively looking behind its position in xz plane. Also the case in other scenes. -->
     <mesh id="water-mesh" type="rectangle" lod="0" center="1"
           use-normal="0" use-texco="0" use-tangent="0"
           rotation="0.0,0.0,3.1415"

--- a/applications/scene-display/fps-widget.h
+++ b/applications/scene-display/fps-widget.h
@@ -19,7 +19,7 @@ public:
 		setAnimationName("fps-widget");
 	}
 
-	void glAnimate(RenderState *rs, double dt) {
+	void gpuUpdate(RenderState *rs, double dt) {
 		frameCounter_ += 1;
 		sumDtMiliseconds_ += dt;
 

--- a/applications/scene-display/fps-widget.h
+++ b/applications/scene-display/fps-widget.h
@@ -24,7 +24,7 @@ public:
 		sumDtMiliseconds_ += dt;
 
 		if (sumDtMiliseconds_ > 1000.0) {
-			fps_ = (GLint) (frameCounter_ * 1000.0 / sumDtMiliseconds_);
+			fps_ = (int) (frameCounter_ * 1000.0 / sumDtMiliseconds_);
 			sumDtMiliseconds_ = 0;
 			frameCounter_ = 0;
 
@@ -37,7 +37,7 @@ public:
 private:
 	ref_ptr<TextureMappedText> widget_{};
 	uint32_t frameCounter_{};
-	GLint fps_{};
+	int fps_{};
 	GLdouble sumDtMiliseconds_;
 };
 

--- a/applications/scene-display/fps-widget.h
+++ b/applications/scene-display/fps-widget.h
@@ -19,7 +19,7 @@ public:
 		setAnimationName("fps-widget");
 	}
 
-	void glAnimate(RenderState *rs, GLdouble dt) {
+	void glAnimate(RenderState *rs, double dt) {
 		frameCounter_ += 1;
 		sumDtMiliseconds_ += dt;
 
@@ -38,7 +38,7 @@ private:
 	ref_ptr<TextureMappedText> widget_{};
 	uint32_t frameCounter_{};
 	int fps_{};
-	GLdouble sumDtMiliseconds_;
+	double sumDtMiliseconds_;
 };
 
 #endif /* SCENE_DISPLAY_FPS_WIDGET_H_ */

--- a/applications/scene-display/scene-display-widget.cpp
+++ b/applications/scene-display/scene-display-widget.cpp
@@ -47,7 +47,7 @@ public:
 		  widget_(widget), sceneFile_(sceneFile) {
 	}
 
-	void glAnimate(RenderState *rs, double dt) override {
+	void gpuUpdate(RenderState *rs, double dt) override {
 		widget_->loadSceneGraphicsThread(sceneFile_);
 	}
 
@@ -65,7 +65,7 @@ public:
 		: Animation(false, true), widget_(widget) {
 	}
 
-	void animate(double dt) override { widget_->updateGameTimeWidget(); }
+	void cpuUpdate(double dt) override { widget_->updateGameTimeWidget(); }
 
 protected:
 	SceneDisplayWidget *widget_;
@@ -107,7 +107,7 @@ public:
 		}
 	}
 
-	void glAnimate(RenderState *rs, double dt) override {
+	void gpuUpdate(RenderState *rs, double dt) override {
 		while (!interactionQueue_.empty()) {
 			boost::lock_guard<boost::mutex> lock(animationLock_);
 			auto interaction = interactionQueue_.front();
@@ -259,7 +259,7 @@ void SceneDisplayWidget::toggleOnCameraTransform() {
 		// update the camera position
 		userController_->setTransform(userCamera_->position(0), userCamera_->direction(0));
 		userController_->startAnimation();
-		userController_->animate(0.0);
+		userController_->cpuUpdate(0.0);
 	}
 }
 
@@ -331,7 +331,7 @@ void SceneDisplayWidget::playAnchor() {
 		anchorAnim_->push_back(anchor, dt * anchorTimeScale_);
 		lastPos = anchor->position();
 	}
-	anchorAnim_->animate(0.0);
+	anchorAnim_->cpuUpdate(0.0);
 	anchorAnim_->startAnimation();
 }
 
@@ -859,31 +859,6 @@ static ref_ptr<WorldModel> loadWorldModel(
 	return worldModel;
 }
 
-/**
-if (animationNode->getValue("mode") == string("random")) {
-		if (animItem->animation.get()) {
-			ref_ptr<EventHandler> animStopped = ref_ptr<RandomAnimationRangeUpdater>::alloc(animItem);
-			animItem->animation->connect(Animation::ANIMATION_STOPPED, animStopped);
-			eventHandler.push_back(animStopped);
-
-			EventData evData;
-			evData.eventID = Animation::ANIMATION_STOPPED;
-			animStopped->call(animItem->animation.get(), &evData);
-		}
-	} else if (animationNode->getValue("mode") == "fixed") {
-		if (animItem->animation.get()) {
-			auto &fixedRange = animItem->ranges[0];
-			ref_ptr<EventHandler> animStopped = ref_ptr<FixedAnimationRangeUpdater>::alloc(animItem->animation, fixedRange);
-			animItem->animation->connect(Animation::ANIMATION_STOPPED, animStopped);
-			eventHandler.push_back(animStopped);
-
-			EventData evData;
-			evData.eventID = Animation::ANIMATION_STOPPED;
-			animStopped->call(animItem->animation.get(), &evData);
-		}
-	}
- */
-
 static void handleMouseConfiguration(
 	QtApplication *app_,
 	scene::SceneLoader &sceneParser,
@@ -990,6 +965,9 @@ void SceneDisplayWidget::loadSceneGraphicsThread(const string &sceneFile) {
 	                     sceneParser.getEventHandler().begin(),
 	                     sceneParser.getEventHandler().end());
 	spatialIndices_ = sceneParser.getResources()->getIndices();
+	for (auto &x: spatialIndices_) {
+		spatialIndexList_.push_back(x.second);
+	}
 
 	// Process the configuration node
 	for (const auto &x: configurationNode->getChildren()) {
@@ -1084,7 +1062,7 @@ void SceneDisplayWidget::loadSceneGraphicsThread(const string &sceneFile) {
 	animations_.emplace_back(timeWidgetAnimation_);
 	loadAnim_ = ref_ptr<Animation>();
 	lightStates_ = sceneParser.getResources()->getLights();
-	AnimationManager::get().setSpatialIndices(spatialIndices_);
+	AnimationManager::get().setSpatialIndices(spatialIndexList_);
 	AnimationManager::get().resetTime();
 
 	AnimationManager::get().resume();

--- a/applications/scene-display/scene-display-widget.cpp
+++ b/applications/scene-display/scene-display-widget.cpp
@@ -203,7 +203,7 @@ void SceneDisplayWidget::writeConfig() {
 void SceneDisplayWidget::nextView() {
 	if (viewNodes_.empty()) return;
 	ViewNode &active0 = *activeView_;
-	active0.node->set_isHidden(GL_TRUE);
+	active0.node->set_isHidden(true);
 
 	activeView_++;
 	if (activeView_ == viewNodes_.end()) {
@@ -211,7 +211,7 @@ void SceneDisplayWidget::nextView() {
 	}
 
 	ViewNode &active1 = *activeView_;
-	active1.node->set_isHidden(GL_FALSE);
+	active1.node->set_isHidden(false);
 	app_->toplevelWidget()->setWindowTitle(QString(active1.name.c_str()));
 
 	if (videoRecorder_.get()) {
@@ -227,7 +227,7 @@ void SceneDisplayWidget::nextView() {
 void SceneDisplayWidget::previousView() {
 	if (viewNodes_.empty()) return;
 	ViewNode &active0 = *activeView_;
-	active0.node->set_isHidden(GL_TRUE);
+	active0.node->set_isHidden(true);
 
 	if (activeView_ == viewNodes_.begin()) {
 		activeView_ = viewNodes_.end();
@@ -235,7 +235,7 @@ void SceneDisplayWidget::previousView() {
 	activeView_--;
 
 	ViewNode &active1 = *activeView_;
-	active1.node->set_isHidden(GL_FALSE);
+	active1.node->set_isHidden(false);
 	app_->toplevelWidget()->setWindowTitle(QString(active1.name.c_str()));
 
 	if (videoRecorder_.get()) {
@@ -278,7 +278,7 @@ void SceneDisplayWidget::activateAnchor() {
 	double dt = getAnchorTime(anchor->position(), camPos);
 
 	anchorAnim_ = ref_ptr<KeyFrameController>::alloc(userCamera_);
-	anchorAnim_->setRepeat(GL_FALSE);
+	anchorAnim_->setRepeat(false);
 	anchorAnim_->setEaseInOutIntensity(anchorEaseInOutIntensity_);
 	anchorAnim_->setPauseBetweenFrames(anchorPauseTime_);
 	anchorAnim_->push_back(cameraAnchor, 0.0);
@@ -318,8 +318,8 @@ void SceneDisplayWidget::playAnchor() {
 	toggleOffCameraTransform();
 
 	anchorAnim_ = ref_ptr<KeyFrameController>::alloc(userCamera_);
-	anchorAnim_->setRepeat(GL_TRUE);
-	//anchorAnim_->setSkipFirstFrameOnLoop(GL_TRUE);
+	anchorAnim_->setRepeat(true);
+	//anchorAnim_->setSkipFirstFrameOnLoop(true);
 	anchorAnim_->setEaseInOutIntensity(anchorEaseInOutIntensity_);
 	anchorAnim_->setPauseBetweenFrames(anchorPauseTime_);
 	auto camPos = userCamera_->position(0);
@@ -478,12 +478,12 @@ void SceneDisplayWidget::toggleInfo(bool isOn) {
 	if (isOn) {
 		auto guiNode = app_->renderTree()->findNodeWithName("GUI-Pass");
 		if (guiNode) {
-			guiNode->set_isHidden(GL_FALSE);
+			guiNode->set_isHidden(false);
 		}
 	} else {
 		auto guiNode = app_->renderTree()->findNodeWithName("GUI-Pass");
 		if (guiNode) {
-			guiNode->set_isHidden(GL_TRUE);
+			guiNode->set_isHidden(true);
 		}
 	}
 }
@@ -927,7 +927,7 @@ static void handleMouseConfiguration(
 void SceneDisplayWidget::loadSceneGraphicsThread(const string &sceneFile) {
 	REGEN_INFO("Loading XML scene at " << sceneFile << ".");
 
-	AnimationManager::get().pause(GL_TRUE);
+	AnimationManager::get().pause(true);
 	AnimationManager::get().clear();
 	AnimationManager::get().setRootState(app_->renderTree()->state());
 	TextureBinder::reset();
@@ -1037,7 +1037,7 @@ void SceneDisplayWidget::loadSceneGraphicsThread(const string &sceneFile) {
 		activeView_ = viewNodes_.end();
 		activeView_--;
 		ViewNode &active = *activeView_;
-		active.node->set_isHidden(GL_FALSE);
+		active.node->set_isHidden(false);
 		app_->toplevelWidget()->setWindowTitle(QString(active.name.c_str()));
 	}
 

--- a/applications/scene-display/scene-display-widget.cpp
+++ b/applications/scene-display/scene-display-widget.cpp
@@ -47,7 +47,7 @@ public:
 		  widget_(widget), sceneFile_(sceneFile) {
 	}
 
-	void glAnimate(RenderState *rs, GLdouble dt) override {
+	void glAnimate(RenderState *rs, double dt) override {
 		widget_->loadSceneGraphicsThread(sceneFile_);
 	}
 
@@ -65,7 +65,7 @@ public:
 		: Animation(false, true), widget_(widget) {
 	}
 
-	void animate(GLdouble dt) override { widget_->updateGameTimeWidget(); }
+	void animate(double dt) override { widget_->updateGameTimeWidget(); }
 
 protected:
 	SceneDisplayWidget *widget_;
@@ -107,7 +107,7 @@ public:
 		}
 	}
 
-	void glAnimate(RenderState *rs, GLdouble dt) override {
+	void glAnimate(RenderState *rs, double dt) override {
 		while (!interactionQueue_.empty()) {
 			boost::lock_guard<boost::mutex> lock(animationLock_);
 			auto interaction = interactionQueue_.front();
@@ -706,13 +706,13 @@ void SceneDisplayWidget::handleControllerConfiguration(
 		}
 		ref_ptr<KeyFrameController> keyFramesCamera = ref_ptr<KeyFrameController>::alloc(cam);
 		if (node->hasAttribute("ease-in-out")) {
-			keyFramesCamera->setEaseInOutIntensity(node->getValue<GLdouble>("ease-in-out", 1.0));
+			keyFramesCamera->setEaseInOutIntensity(node->getValue<double>("ease-in-out", 1.0));
 		}
 		for (const auto &x: node->getChildren("key-frame")) {
 			keyFramesCamera->push_back(
 				x->getValue<Vec3f>("pos", Vec3f(0.0f, 0.0f, 1.0f)),
 				x->getValue<Vec3f>("dir", Vec3f(0.0f, 0.0f, -1.0f)),
-				x->getValue<GLdouble>("dt", 0.0)
+				x->getValue<double>("dt", 0.0)
 			);
 		}
 		keyFramesCamera->startAnimation();

--- a/applications/scene-display/scene-display-widget.cpp
+++ b/applications/scene-display/scene-display-widget.cpp
@@ -643,16 +643,16 @@ void SceneDisplayWidget::handleControllerConfiguration(
 
 		auto cameraEventHandler =
 			ref_ptr<QtCameraEventHandler>::alloc(userController_, camKeyMappings);
-		cameraEventHandler->set_sensitivity(node->getValue<GLfloat>("sensitivity", 0.005f));
+		cameraEventHandler->set_sensitivity(node->getValue<float>("sensitivity", 0.005f));
 		app_->connect(Scene::KEY_EVENT, cameraEventHandler);
 		app_->connect(Scene::BUTTON_EVENT, cameraEventHandler);
 		app_->connect(Scene::MOUSE_MOTION_EVENT, cameraEventHandler);
 		eventHandler_.emplace_back(cameraEventHandler);
 
 		// Handle anchor points
-		anchorEaseInOutIntensity_ = node->getValue<GLfloat>("ease-in-out", 1.0);
-		anchorPauseTime_ = node->getValue<GLfloat>("anchor-pause-time", 0.5);
-		anchorTimeScale_ = node->getValue<GLfloat>("anchor-time-scale", 1.0);
+		anchorEaseInOutIntensity_ = node->getValue<float>("ease-in-out", 1.0);
+		anchorPauseTime_ = node->getValue<float>("anchor-pause-time", 0.5);
+		anchorTimeScale_ = node->getValue<float>("anchor-time-scale", 1.0);
 		for (const auto &x: node->getChildren("anchor")) {
 			if (x->hasAttribute("transform")) {
 				auto transform = scene.getResources()->getTransform(&scene, x->getValue("transform"));

--- a/applications/scene-display/scene-display-widget.h
+++ b/applications/scene-display/scene-display-widget.h
@@ -104,11 +104,13 @@ protected:
 	double anchorPauseTime_;
 	double anchorTimeScale_;
 
+	std::map<std::string, ref_ptr<SpatialIndex>> spatialIndices_;
+	std::vector<ref_ptr<SpatialIndex>> spatialIndexList_;
+
 	QDialog *inputDialog_;
 	ShaderInputWidget *inputWidget_;
 	QtApplication *app_;
 	ref_ptr<BulletPhysics> physics_;
-	std::map<std::string, ref_ptr<SpatialIndex>> spatialIndices_;
 	Ui_sceneViewer ui_;
 	std::string activeFile_;
 	ViewNodeList viewNodes_;

--- a/applications/scene-display/scene-display-widget.h
+++ b/applications/scene-display/scene-display-widget.h
@@ -100,9 +100,9 @@ protected:
 	ref_ptr<KeyFrameController> anchorAnim_;
 	std::vector<ref_ptr<CameraAnchor>> anchors_;
 	uint32_t anchorIndex_;
-	GLdouble anchorEaseInOutIntensity_;
-	GLdouble anchorPauseTime_;
-	GLdouble anchorTimeScale_;
+	double anchorEaseInOutIntensity_;
+	double anchorPauseTime_;
+	double anchorTimeScale_;
 
 	QDialog *inputDialog_;
 	ShaderInputWidget *inputWidget_;

--- a/applications/scene-display/view-node.h
+++ b/applications/scene-display/view-node.h
@@ -22,7 +22,7 @@ public:
 		ref_ptr<State> state = ref_ptr<State>::alloc();
 		ref_ptr<StateNode> newNode = ref_ptr<StateNode>::alloc(state);
 		newNode->set_name(input.getName());
-		newNode->set_isHidden(GL_TRUE);
+		newNode->set_isHidden(true);
 		parent->addChild(newNode);
 		parser->putNode(input.getName(), newNode);
 		handleChildren(parser, input, newNode);

--- a/applications/video-player/video-player-widget.cpp
+++ b/applications/video-player/video-player-widget.cpp
@@ -50,7 +50,7 @@ static QString formatTime(GLfloat elapsedSeconds) {
 }
 
 static void hideLayout(QLayout *layout) {
-	for (GLint i = 0; i < layout->count(); ++i) {
+	for (int i = 0; i < layout->count(); ++i) {
 		QLayoutItem *item = layout->itemAt(i);
 		if (item->widget()) { item->widget()->hide(); }
 		if (item->layout()) { hideLayout(item->layout()); }
@@ -58,7 +58,7 @@ static void hideLayout(QLayout *layout) {
 }
 
 static void showLayout(QLayout *layout) {
-	for (GLint i = 0; i < layout->count(); ++i) {
+	for (int i = 0; i < layout->count(); ++i) {
 		QLayoutItem *item = layout->itemAt(i);
 		if (item->widget()) { item->widget()->show(); }
 		if (item->layout()) { showLayout(item->layout()); }
@@ -341,13 +341,13 @@ void VideoPlayerWidget::updateSize() {
 	if (!vid_.get()) return;
 	GLfloat widgetRatio = ui_.blackBackground->width() / (GLfloat) ui_.blackBackground->height();
 	GLfloat videoRatio = vid_->width() / (GLfloat) vid_->height();
-	GLint w, h;
+	int w, h;
 	if (widgetRatio > videoRatio) {
-		w = (GLint) (ui_.blackBackground->height() * videoRatio);
+		w = (int) (ui_.blackBackground->height() * videoRatio);
 		h = ui_.blackBackground->height();
 	} else {
 		w = ui_.blackBackground->width();
-		h = (GLint) (ui_.blackBackground->width() / videoRatio);
+		h = (int) (ui_.blackBackground->width() / videoRatio);
 	}
 	if (w % 2 != 0) { w -= 1; }
 	if (h % 2 != 0) { h -= 1; }

--- a/applications/video-player/video-player-widget.cpp
+++ b/applications/video-player/video-player-widget.cpp
@@ -38,7 +38,7 @@ extern "C" {
 
 using namespace std;
 
-static QString formatTime(GLfloat elapsedSeconds) {
+static QString formatTime(float elapsedSeconds) {
 	uint32_t seconds = (uint32_t) elapsedSeconds;
 	uint32_t minutes = seconds / 60;
 	seconds = seconds % 60;
@@ -130,7 +130,7 @@ VideoPlayerWidget::VideoPlayerWidget(QtApplication *app)
 // Resizes Framebuffer texture when the window size changed
 class FBOResizer : public EventHandler {
 public:
-	FBOResizer(const ref_ptr<FBOState> &fbo, GLfloat wScale, GLfloat hScale)
+	FBOResizer(const ref_ptr<FBOState> &fbo, float wScale, float hScale)
 			: EventHandler(), fboState_(fbo), wScale_(wScale), hScale_(hScale) {}
 
 	~FBOResizer() override = default;
@@ -143,7 +143,7 @@ public:
 
 protected:
 	ref_ptr<FBOState> fboState_;
-	GLfloat wScale_, hScale_;
+	float wScale_, hScale_;
 };
 
 void setBlitToScreen(Scene *app, const ref_ptr<FBO> &fbo, GLenum attachment) {
@@ -251,7 +251,7 @@ void VideoPlayerWidget::changeVolume(int val) {
 }
 
 void VideoPlayerWidget::updateElapsedTime() {
-	GLfloat elapsed = vid_->elapsedSeconds();
+	float elapsed = vid_->elapsedSeconds();
 	ui_.progressLabel->setText(formatTime(elapsed));
 	ui_.progressSlider->blockSignals(true);
 	ui_.progressSlider->setValue((int) (
@@ -339,8 +339,8 @@ void VideoPlayerWidget::addLocalPath(const string &filePath) {
 
 void VideoPlayerWidget::updateSize() {
 	if (!vid_.get()) return;
-	GLfloat widgetRatio = ui_.blackBackground->width() / (GLfloat) ui_.blackBackground->height();
-	GLfloat videoRatio = vid_->width() / (GLfloat) vid_->height();
+	float widgetRatio = ui_.blackBackground->width() / (float) ui_.blackBackground->height();
+	float videoRatio = vid_->width() / (float) vid_->height();
 	int w, h;
 	if (widgetRatio > videoRatio) {
 		w = (int) (ui_.blackBackground->height() * videoRatio);

--- a/applications/video-player/video-player-widget.cpp
+++ b/applications/video-player/video-player-widget.cpp
@@ -83,7 +83,7 @@ public:
 	explicit VideoInitAnimation(VideoPlayerWidget *widget)
 			: Animation(true, false), widget_(widget) {}
 
-	void glAnimate(RenderState *rs, double dt) override { widget_->gl_loadScene(); }
+	void gpuUpdate(RenderState *rs, double dt) override { widget_->gl_loadScene(); }
 
 	VideoPlayerWidget *widget_;
 };

--- a/applications/video-player/video-player-widget.cpp
+++ b/applications/video-player/video-player-widget.cpp
@@ -65,12 +65,12 @@ static void showLayout(QLayout *layout) {
 	}
 }
 
-static GLboolean isRegularFile(const string &f) {
+static bool isRegularFile(const string &f) {
 	boost::filesystem::path p(f);
 	return boost::filesystem::is_regular_file(p);
 }
 
-static GLboolean isDirectory(const string &f) {
+static bool isDirectory(const string &f) {
 	boost::filesystem::path p(f);
 	return boost::filesystem::is_directory(p);
 }
@@ -94,10 +94,10 @@ VideoPlayerWidget::VideoPlayerWidget(QtApplication *app)
 		  gain_(1.0f),
 		  elapsedTimer_(this),
 		  activePlaylistRow_(nullptr),
-		  wereControlsShown_(GL_FALSE) {
+		  wereControlsShown_(false) {
 	setMouseTracking(true);
 	setAcceptDrops(true);
-	controlsShown_ = GL_TRUE;
+	controlsShown_ = true;
 
 	ui_.setupUi(this);
 	app_->glWidget()->setEnabled(false);
@@ -157,17 +157,17 @@ ref_ptr<Mesh> createVideoWidget(
 		const ref_ptr<StateNode> &root) {
 	Rectangle::Config quadConfig;
 	quadConfig.levelOfDetails = {0};
-	quadConfig.isTexcoRequired = GL_TRUE;
-	quadConfig.isNormalRequired = GL_FALSE;
-	quadConfig.isTangentRequired = GL_FALSE;
-	quadConfig.centerAtOrigin = GL_TRUE;
+	quadConfig.isTexcoRequired = true;
+	quadConfig.isNormalRequired = false;
+	quadConfig.isTangentRequired = false;
+	quadConfig.centerAtOrigin = true;
 	quadConfig.rotation = Vec3f(0.5 * M_PI, 0.0 * M_PI, 0.0 * M_PI);
 	quadConfig.posScale = Vec3f::one();
 	quadConfig.texcoScale = Vec2f(-1.0f, 1.0f);
 	quadConfig.levelOfDetails = {0};
-	quadConfig.isTexcoRequired = GL_TRUE;
-	quadConfig.isNormalRequired = GL_FALSE;
-	quadConfig.centerAtOrigin = GL_TRUE;
+	quadConfig.isTexcoRequired = true;
+	quadConfig.isNormalRequired = false;
+	quadConfig.centerAtOrigin = true;
 	auto mesh = regen::Rectangle::create(quadConfig);
 
 	ref_ptr<TextureState> texState = ref_ptr<TextureState>::alloc(videoTexture);
@@ -190,7 +190,7 @@ ref_ptr<Mesh> createVideoWidget(
 }
 
 void VideoPlayerWidget::gl_loadScene() {
-	AnimationManager::get().pause(GL_TRUE);
+	AnimationManager::get().pause(true);
 
 	vid_ = ref_ptr<VideoTexture>::alloc();
 	demuxer_ = vid_->demuxer();

--- a/applications/video-player/video-player-widget.cpp
+++ b/applications/video-player/video-player-widget.cpp
@@ -83,7 +83,7 @@ public:
 	explicit VideoInitAnimation(VideoPlayerWidget *widget)
 			: Animation(true, false), widget_(widget) {}
 
-	void glAnimate(RenderState *rs, GLdouble dt) override { widget_->gl_loadScene(); }
+	void glAnimate(RenderState *rs, double dt) override { widget_->gl_loadScene(); }
 
 	VideoPlayerWidget *widget_;
 };
@@ -292,7 +292,7 @@ int VideoPlayerWidget::addPlaylistItem(const string &filePath) {
 	if (avformat_find_stream_info(formatCtx, nullptr) < 0) {
 		return -1;
 	}
-	GLdouble numSeconds = formatCtx->duration / (GLdouble) AV_TIME_BASE;
+	double numSeconds = formatCtx->duration / (double) AV_TIME_BASE;
 	__CLOSE_INPUT__(formatCtx);
 
 	std::string filename = boost::filesystem::path(filePath).stem().string();

--- a/applications/video-player/video-player-widget.h
+++ b/applications/video-player/video-player-widget.h
@@ -80,7 +80,7 @@ protected:
 	Ui_mainWindow ui_;
 	ref_ptr<VideoTexture> vid_;
 	ref_ptr<Demuxer> demuxer_;
-	GLfloat gain_;
+	float gain_;
 	QTimer elapsedTimer_;
 	QTableWidgetItem *activePlaylistRow_;
 

--- a/applications/video-player/video-player-widget.h
+++ b/applications/video-player/video-player-widget.h
@@ -84,8 +84,8 @@ protected:
 	QTimer elapsedTimer_;
 	QTableWidgetItem *activePlaylistRow_;
 
-	GLboolean controlsShown_;
-	GLboolean wereControlsShown_;
+	bool controlsShown_;
+	bool wereControlsShown_;
 	QList<int> splitterSizes_;
 
 	ref_ptr<Animation> initAnim_;

--- a/doc/doxygen.h
+++ b/doc/doxygen.h
@@ -148,11 +148,11 @@ public:
   MyAnimation()
   : Animation(GL_TRUE,GL_TRUE)
   {}
-  void animate(GLdouble dt)
+  void animate(double dt)
   {
     doSomethingInAnimThread();
   }
-  void glAnimate(RenderState *rs, GLdouble dt)
+  void glAnimate(RenderState *rs, double dt)
   {
     doSomethingInRenderThread();
   }

--- a/doc/doxygen.h
+++ b/doc/doxygen.h
@@ -26,7 +26,7 @@ using namespace regen;
 // Get the singleton and activate the MULTISAMPLE state
 // aka. use multiple fragment samples in computing the final color of a pixel.
 // Possibly glEnable(GL_MULTISAMPLE) will be called with this push
-RenderState()::get()->toggles().push(RenderState::MULTISAMPLE, GL_TRUE);
+RenderState()::get()->toggles().push(RenderState::MULTISAMPLE, true);
 doSomethingWithMultiSampling();
 // Pop value, reset to previous value of MULTISAMPLE state
 RenderState()::get()->toggles().pop();
@@ -146,7 +146,7 @@ class MyAnimation : public Animation
 {
 public:
   MyAnimation()
-  : Animation(GL_TRUE,GL_TRUE)
+  : Animation(true,true)
   {}
   void animate(double dt)
   {

--- a/regen/animation/animation-manager.cpp
+++ b/regen/animation/animation-manager.cpp
@@ -255,7 +255,7 @@ void AnimationManager::run() {
 				boost::posix_time::microsec_clock::local_time());
 
 		if (!pauseFlag_) {
-			double dt = ((GLdouble) (time_ - lastTime_).total_microseconds()) / 1000.0;
+			double dt = ((double) (time_ - lastTime_).total_microseconds()) / 1000.0;
 			// wait for remove/add to return
 			while (removeInProgress_) usleepRegen(1000);
 			while (addInProgress_) usleepRegen(1000);

--- a/regen/animation/animation-manager.cpp
+++ b/regen/animation/animation-manager.cpp
@@ -8,9 +8,6 @@
 
 using namespace regen;
 
-// Microseconds to sleep per loop in idle mode.
-#define IDLE_SLEEP 100000
-
 AnimationManager &AnimationManager::get() {
 	static AnimationManager manager;
 	return manager;
@@ -24,24 +21,46 @@ static void setStagingCopyFlag() {
 	StagingSystem::instance().setIsCopyInProgress();
 }
 
+template <bool DesiredFlagState>
+static void waitOnFlag(const std::atomic_flag &flag) {
+	for (int i = 0; flag.test(std::memory_order_acquire) != DesiredFlagState; ++i) {
+		if (i < 16) { CPU_PAUSE(); }
+		else if (i < 256) { std::this_thread::yield(); }
+		else { std::this_thread::sleep_for(std::chrono::microseconds(1)); }
+	}
+}
+
+template <typename CounterType, CounterType DesiredCount>
+static void waitOnCounter(const std::atomic<CounterType> &count) {
+	for (int i = 0; count.load(std::memory_order_acquire) != DesiredCount; ++i) {
+		if (i < 16) { CPU_PAUSE(); }
+		else if (i < 256) { std::this_thread::yield(); }
+		else { std::this_thread::sleep_for(std::chrono::microseconds(1)); }
+	}
+}
+
+
 AnimationManager::AnimationManager()
-		: frameBarrier_(2, setStagingCopyFlag),
-		  animInProgress_(false),
-		  glInProgress_(false),
-		  removeInProgress_(false),
-		  addInProgress_(false),
-		  animChangedDuringLoop_(false),
-		  glChangedDuringLoop_(false),
-		  closeFlag_(false),
-		  pauseFlag_(true) {
+		: frameBarrier_(2, setStagingCopyFlag) {
 	resetTime();
-	thread_ = boost::thread(&AnimationManager::run, this);
+	cpu_isUpdateActive_.clear(std::memory_order_release);
+	gpu_isUpdateActive_.clear(std::memory_order_release);
+	cpuUpdateThread_ = boost::thread(&AnimationManager::cpuUpdate, this);
 }
 
 AnimationManager::~AnimationManager() {
-	closeFlag_ = true;
+	// toggle atomic close flag to true
+	closeFlag_.test_and_set(std::memory_order_release);
+	// indicate arrival at the barrier and drop this thread
 	frameBarrier_.arrive_and_drop();
-	thread_.join();
+	cpuUpdateThread_.join();
+	// Finally also join the dedicated threads
+	if (unsynced_numActiveUpdates_.load(std::memory_order_acquire) > 0) {
+		waitOnCounter<int,0>(unsynced_numActiveUpdates_);
+	}
+	for (auto &thread : unsyncedThreads_) {
+		thread.join();
+	}
 }
 
 void AnimationManager::resetTime() {
@@ -52,13 +71,13 @@ void AnimationManager::resetTime() {
 
 void AnimationManager::setRootState(const ref_ptr<State> &rootState) {
 	std::set<Animation *> allAnimations;
-	for (auto &anim : synchronizedAnimations_) {
-		allAnimations.insert(anim);
-	}
-	for (auto &anim : unsynchronizedAnimations_) {
+	for (auto &anim : cpuAnimations_) {
 		allAnimations.insert(anim);
 	}
 	for (auto &anim : gpuAnimations_) {
+		allAnimations.insert(anim);
+	}
+	for (auto &anim : unsyncedAnimations_) {
 		allAnimations.insert(anim);
 	}
 
@@ -76,253 +95,198 @@ void AnimationManager::setRootState(const ref_ptr<State> &rootState) {
 }
 
 void AnimationManager::addAnimation(Animation *animation) {
-	// Don't add while removing
-	while (removeInProgress_) usleepRegen(1000);
-
-	addThreadID_ = boost::this_thread::get_id();
-	addInProgress_ = true;
-
 	if (animation->isGPUAnimation()) {
-		if (glInProgress_ && addThreadID_ == glThreadID_) {
-			// Called from glAnimate().
-			glChangedDuringLoop_ = true;
-			gpuAnimations_.insert(animation);
-		} else {
-			// Wait for the current loop to finish.
-			if (glInProgress_) {
-				addInProgress_ = false;
-				while (glInProgress_) usleepRegen(1000);
-				addInProgress_ = true;
-			}
-			// save to remove from set
-			// FIXME: there is a race condition here if add/remove are called from different
-			//        non GL threads they could insert/remove simultaneously
-			gpuAnimations_.insert(animation);
-		}
+		gpu_commandQueue_.push({ ADD, animation });
 	}
 
-	if (animation->isCPUAnimation()) {
-		if (animation->isSynchronized()) {
-			if (animInProgress_ && addThreadID_ == animationThreadID_) {
-				// Called from animate().
-				animChangedDuringLoop_ = true;
-				synchronizedAnimations_.emplace_back(animation);
-			} else {
-				// Wait for the current loop to finish.
-				while (animInProgress_) usleepRegen(1000);
-				// save to remove from set
-				synchronizedAnimations_.emplace_back(animation);
-			}
-		} else {
-			// start a new dedicated thread
-			boost::unique_lock<boost::mutex> lock(unsynchronizedMut_);
-			unsynchronizedAnimations_.emplace_back(animation);
-			unsynchronizedThreads_.emplace_back([this, animation]()
-				{ runUnsynchronized(animation); });
-		}
+	if (animation->isCPUAnimation() && animation->isSynchronized()) {
+		cpu_commandQueue_.push({ ADD, animation });
+	} else if (animation->isCPUAnimation()) {
+		// start a new dedicated thread
+		boost::unique_lock lock(unsyncedListLock_);
+		unsyncedAnimations_.emplace_back(animation);
+		unsyncedThreads_.emplace_back([this, animation]() {
+			unsyncedUpdate(animation);
+		});
 	}
-
-	addInProgress_ = false;
 }
 
 void AnimationManager::removeAnimation(Animation *animation) {
-	// Don't remove while adding
-	while (addInProgress_) usleepRegen(1000);
-
-	removeThreadID_ = boost::this_thread::get_id();
-	removeInProgress_ = true;
+	// Make sure we won't run this animation anymore
+	animation->stopAnimation();
 
 	if (animation->isGPUAnimation()) {
-		if (glInProgress_ && removeThreadID_ == glThreadID_) {
-			// Called from glAnimate().
-			glChangedDuringLoop_ = true;
-			gpuAnimations_.erase(animation);
-		} else {
-			// Wait for the current loop to finish.
-			if (glInProgress_) {
-				removeInProgress_ = false;
-				while (glInProgress_) usleepRegen(1000);
-				removeInProgress_ = true;
-			}
-			// save to remove from set
-			gpuAnimations_.erase(animation);
-		}
+		gpu_commandQueue_.push({ REMOVE, animation });
 	}
 
-	if (animation->isCPUAnimation()) {
-		if (animation->isSynchronized()) {
-			if (animInProgress_ && removeThreadID_ == animationThreadID_) {
-				// Called from animate().
-				animChangedDuringLoop_ = true;
-			} else {
-				// Wait for the current loop to finish.
-				while (animInProgress_) usleepRegen(1000);
-				// save to remove from set
-			}
-			// remove from list
-			auto it = synchronizedAnimations_.begin();
-			while (it != synchronizedAnimations_.end()) {
-				if (*it == animation) {
-					synchronizedAnimations_.erase(it);
-					break;
-				}
-				++it;
-			}
-		}
-		else {
-			// remove from list
-			boost::unique_lock<boost::mutex> lock(unsynchronizedMut_);
-			animation->isRunning_ = false;
-			for (size_t i = 0; i < unsynchronizedAnimations_.size(); i++) {
-				if (unsynchronizedAnimations_[i] == animation) {
-					unsynchronizedThreads_[i].join();
-					unsynchronizedAnimations_.erase(unsynchronizedAnimations_.begin() + i);
-					unsynchronizedThreads_.erase(unsynchronizedThreads_.begin() + i);
-					break;
-				}
-			}
-		}
-	}
-
-	removeInProgress_ = false;
-}
-
-void AnimationManager::updateSynchronized_GPU(double dt) {
-	if (pauseFlag_) { return; }
-	glThreadID_ = boost::this_thread::get_id();
-
-	// wait for remove/remove to return
-	while (removeInProgress_) usleepRegen(1000);
-	while (addInProgress_) usleepRegen(1000);
-
-	// Set processing flags, so that other threads can wait
-	// for the completion of this loop
-	glInProgress_ = true;
-	std::set<Animation *> processed;
-	bool animationsRemaining = true;
-	while (animationsRemaining && !pauseFlag_) {
-		animationsRemaining = false;
-		for (auto it = gpuAnimations_.begin(); it != gpuAnimations_.end(); ++it) {
-			Animation *anim = *it;
-			processed.insert(anim);
-			if (anim->isRunning()) {
-				auto animState = anim->animationState();
-				animState->enable(RenderState::get());
-				anim->glAnimate(RenderState::get(), dt);
-				animState->disable(RenderState::get());
-				// Animation was removed in glAnimate call.
-				// We have to restart the loop because iterator is invalid.
-				if (glChangedDuringLoop_) {
-					glChangedDuringLoop_ = false;
-					animationsRemaining = true;
-					break;
-				}
-			}
-		}
-	}
-	glInProgress_ = false;
-}
-
-void AnimationManager::updateSynchronized_CPU(double dt) {
-	if (synchronizedAnimations_.empty()) return;
-
-	bool areAnimationsRemaining = true;
-	std::set<Animation *> processed;
-	while (areAnimationsRemaining) {
-		areAnimationsRemaining = false;
-		for (auto anim: synchronizedAnimations_) {
-			processed.insert(anim);
-			if (anim->isRunning()) {
-				anim->animate(dt);
-				// Animation was removed in animate call.
-				// We have to restart the loop because iterator is invalid.
-				if (animChangedDuringLoop_) {
-					animChangedDuringLoop_ = false;
-					areAnimationsRemaining = true;
-					break;
-				}
+	if (animation->isCPUAnimation() && animation->isSynchronized()) {
+		cpu_commandQueue_.push({ REMOVE, animation });
+	} else if (animation->isCPUAnimation()) {
+		// remove from list
+		boost::unique_lock lock(unsyncedListLock_);
+		for (size_t i = 0; i < unsyncedAnimations_.size(); i++) {
+			if (unsyncedAnimations_[i] == animation) {
+				unsyncedThreads_[i].join();
+				unsyncedAnimations_.erase(unsyncedAnimations_.begin() + i);
+				unsyncedThreads_.erase(unsyncedThreads_.begin() + i);
+				break;
 			}
 		}
 	}
 }
 
-void AnimationManager::run() {
-	animationThreadID_ = boost::this_thread::get_id();
-	resetTime();
-
-	while (!closeFlag_) {
-		time_ = boost::posix_time::ptime(
-				boost::posix_time::microsec_clock::local_time());
-
-		if (!pauseFlag_) {
-			double dt = ((double) (time_ - lastTime_).total_microseconds()) / 1000.0;
-			// wait for remove/add to return
-			while (removeInProgress_) usleepRegen(1000);
-			while (addInProgress_) usleepRegen(1000);
-			animInProgress_ = true;
-
-			// Advance each CPU animation.
-			// Main point is writing shader data that will be added to
-			// staging next frame.
-			updateSynchronized_CPU(dt);
-			// Update visibility using spatial indices.
-			// Note: this might be computationally heavy!
-			for (auto &index : spatialIndices_) {
-				index.second->update(static_cast<float>(dt));
-			}
-#ifdef REGEN_STAGING_ANIMATION_THREAD_SWAPS_CLIENT
-			// make client buffers we just wrote available for the next frame in the staging system.
-			swapClientData();
-#endif
-
-			animInProgress_ = false;
-		}
-		lastTime_ = time_;
-		frameBarrier_.arrive_and_wait();
+void AnimationManager::waitForAnimations() const {
+	// Block until all "isUpdateActive" flags are cleared in all *other* threads.
+	const auto thisThreadID = boost::this_thread::get_id();
+	if (thisThreadID != cpu_threadID_ && cpu_isUpdateActive_.test(std::memory_order_acquire)) {
+		waitOnFlag<false>(cpu_isUpdateActive_);
+	}
+	if (thisThreadID != gpu_threadID_ && gpu_isUpdateActive_.test(std::memory_order_acquire)) {
+		waitOnFlag<false>(gpu_isUpdateActive_);
+	}
+	if (unsynced_numActiveUpdates_.load(std::memory_order_acquire) > 0) {
+		waitOnCounter<int,0>(unsynced_numActiveUpdates_);
 	}
 }
 
-void AnimationManager::close(bool blocking) {
-	closeFlag_ = true;
-	if (blocking) {
-		boost::thread::id callingThread = boost::this_thread::get_id();
-		if (callingThread != animationThreadID_)
-			while (animInProgress_) usleepRegen(1000);
-		if (callingThread != glThreadID_)
-			while (glInProgress_) usleepRegen(1000);
-	}
+void AnimationManager::shutdown(bool blocking) {
+	// toggle atomic close flag to true
+	closeFlag_.test_and_set(std::memory_order_release);
+	if (blocking) waitForAnimations();
 }
 
 void AnimationManager::pause(bool blocking) {
-	pauseFlag_ = true;
-	if (blocking) {
-		boost::thread::id callingThread = boost::this_thread::get_id();
-		if (callingThread != animationThreadID_)
-			while (animInProgress_) usleepRegen(1000);
-		if (callingThread != glThreadID_)
-			while (glInProgress_) usleepRegen(1000);
-	}
+	// toggle atomic pause flag to true
+	pauseFlag_.test_and_set(std::memory_order_release);
+	if (blocking) waitForAnimations();
 }
 
 void AnimationManager::clear() {
-	synchronizedAnimations_.clear();
-	unsynchronizedAnimations_.clear();
+	// note: assuming, pause(true) was called before, no animation is running now
+	boost::unique_lock lock(unsyncedListLock_);
+	cpuAnimations_.clear();
 	gpuAnimations_.clear();
+	unsyncedAnimations_.clear();
 	spatialIndices_.clear();
 }
 
 void AnimationManager::resume(bool runOnce) {
 	if(runOnce) {
-		for (auto anim : synchronizedAnimations_) {
+		for (auto anim : cpuAnimations_) {
 			if (anim->isRunning()) {
-				anim->animate(0.0);
+				anim->cpuUpdate(0.0);
 			}
 		}
 	}
-	pauseFlag_ = false;
+	// toggle atomic pause flag to false
+	pauseFlag_.clear(std::memory_order_release);
 }
 
-void AnimationManager::runUnsynchronized(Animation *animation) const {
+void AnimationManager::gpuUpdateStep(double dt) {
+	RenderState *rs = RenderState::get();
+	// Remember the GPU thread ID
+	gpu_threadID_ = boost::this_thread::get_id();
+
+	// Set processing flags, so that other threads can wait for the completion of this loop
+	gpu_isUpdateActive_.test_and_set(std::memory_order_acquire);
+
+	// Avoid race condition with close waiting for gpu_isUpdateActive_ to clear
+	if (closeFlag_.test(std::memory_order_acquire) || pauseFlag_.test(std::memory_order_acquire)) {
+		gpu_isUpdateActive_.clear(std::memory_order_release);
+		return;
+	}
+
+	// Advance each active GPU animation.
+	for (const auto &anim : gpuAnimations_) {
+		if (!anim->isRunning()) { continue; }
+		auto animState = anim->animationState();
+		animState->enable(rs);
+		anim->gpuUpdate(rs, dt);
+		animState->disable(rs);
+	}
+
+	// Clear processing flags
+	gpu_isUpdateActive_.clear(std::memory_order_release);
+
+	// Perform pending add/remove operations
+	while (!gpu_commandQueue_.empty()) {
+		Command &cmd = gpu_commandQueue_.front();
+		switch (cmd.type) {
+			case ADD:
+				gpuAnimations_.push_back(cmd.animation);
+				break;
+			case REMOVE:
+				gpuAnimations_.erase(std::ranges::remove(
+					gpuAnimations_, cmd.animation).begin(), gpuAnimations_.end());
+				break;
+		}
+		gpu_commandQueue_.pop();
+	}
+}
+
+void AnimationManager::cpuUpdateStep() {
+	// Compute dt in milliseconds
+	double dt = static_cast<double>(
+		(time_ - lastTime_).total_microseconds()) / 1000.0;
+
+	// Set processing flags, so that other threads can wait for the completion of this loop
+	cpu_isUpdateActive_.test_and_set(std::memory_order_acquire);
+
+	// Avoid race conditions with close/pause waiting for cpu_isUpdateActive_ to clear
+	if (closeFlag_.test(std::memory_order_acquire) || pauseFlag_.test(std::memory_order_acquire)) {
+		cpu_isUpdateActive_.clear(std::memory_order_release);
+		return;
+	}
+
+	// Advance each active CPU animation.
+	for (const auto &anim : cpuAnimations_) {
+		if (!anim->isRunning()) { continue; }
+		anim->cpuUpdate(dt);
+	}
+
+	// Update visibility using spatial indices.
+	// Note: this might be computationally heavy!
+	for (auto &index : spatialIndices_) {
+		index->update(static_cast<float>(dt));
+	}
+
+#ifdef REGEN_STAGING_ANIMATION_THREAD_SWAPS_CLIENT
+	// make client buffers we just wrote available for the next frame in the staging system.
+	swapClientData();
+#endif
+
+	// Clear processing flags
+	cpu_isUpdateActive_.clear(std::memory_order_release);
+
+	// Perform pending add/remove operations
+	while (!cpu_commandQueue_.empty()) {
+		Command &cmd = cpu_commandQueue_.front();
+		switch (cmd.type) {
+			case ADD:
+				cpuAnimations_.push_back(cmd.animation);
+				break;
+			case REMOVE:
+				cpuAnimations_.erase(std::ranges::remove(
+					cpuAnimations_, cmd.animation).begin(), cpuAnimations_.end());
+				break;
+		}
+		cpu_commandQueue_.pop();
+	}
+}
+
+void AnimationManager::cpuUpdate() {
+	cpu_threadID_ = boost::this_thread::get_id();
+	resetTime();
+
+	while (closeFlag_.test(std::memory_order_acquire) == false) {
+		time_ = boost::posix_time::ptime(boost::posix_time::microsec_clock::local_time());
+		cpuUpdateStep();
+		lastTime_ = time_;
+		frameBarrier_.arrive_and_wait();
+	}
+}
+
+void AnimationManager::unsyncedUpdate(Animation *animation) {
 	using Clock = std::chrono::steady_clock;
 	using ms = std::chrono::duration<double, std::milli>;
 
@@ -331,10 +295,20 @@ void AnimationManager::runUnsynchronized(Animation *animation) const {
 	const auto frameDuration = std::chrono::duration_cast<Clock::duration>(d_frameDuration);
 	auto nextFrame = Clock::now();
 
-	while (!closeFlag_ && animation->isRunning()) {
-		if (pauseFlag_) {
-			usleepRegen(IDLE_SLEEP);  // or sleep_for()
-			nextFrame += std::chrono::microseconds(IDLE_SLEEP);
+	while (closeFlag_.test(std::memory_order_acquire) == false && animation->isRunning()) {
+		// Increase update counter atomic
+		unsynced_numActiveUpdates_.fetch_add(1, std::memory_order_acquire);
+
+		// Avoid race condition on close
+		if (closeFlag_.test(std::memory_order_acquire)) {
+			unsynced_numActiveUpdates_.fetch_sub(1, std::memory_order_release);
+			break;
+		}
+
+		// Spin until we can continue
+		if (pauseFlag_.test(std::memory_order_acquire)) {
+			unsynced_numActiveUpdates_.fetch_sub(1, std::memory_order_release);
+			waitOnFlag<false>(pauseFlag_);
 			continue;
 		}
 
@@ -342,7 +316,10 @@ void AnimationManager::runUnsynchronized(Animation *animation) const {
 		double dt = std::chrono::duration<double, std::milli>(frameStart - nextFrame + frameDuration).count();
 
 		// Run the animation logic
-		animation->animate(dt);
+		animation->cpuUpdate(dt);
+
+		// decrease update counter atomic
+		unsynced_numActiveUpdates_.fetch_sub(1, std::memory_order_release);
 
 		// Schedule next frame
 		nextFrame += frameDuration;
@@ -357,17 +334,13 @@ void AnimationManager::runUnsynchronized(Animation *animation) const {
 	}
 }
 
-void AnimationManager::flushGraphics() {
-	frameBarrier_.arrive_and_wait();
-}
-
 void AnimationManager::swapClientData() {
-	if (closeFlag_) return;
+	if (closeFlag_.test(std::memory_order_acquire)) return;
 	auto &staging = StagingSystem::instance();
 	// Wait for the staging system to finish copying client data for this frame.
-	while (staging.isCopyInProgress()) {
+	while (staging.isCopyInProgress() &&
+		!closeFlag_.test(std::memory_order_acquire)) {
 		CPU_PAUSE();
-		if (closeFlag_) return;
 	}
 	staging.swapClientData();
 }

--- a/regen/animation/animation-manager.cpp
+++ b/regen/animation/animation-manager.cpp
@@ -75,10 +75,6 @@ void AnimationManager::setRootState(const ref_ptr<State> &rootState) {
 	}
 }
 
-void AnimationManager::setSpatialIndices(const std::map<std::string, ref_ptr<SpatialIndex>> &indices) {
-	spatialIndices_ = indices;
-}
-
 void AnimationManager::addAnimation(Animation *animation) {
 	// Don't add while removing
 	while (removeInProgress_) usleepRegen(1000);
@@ -191,7 +187,7 @@ void AnimationManager::removeAnimation(Animation *animation) {
 	removeInProgress_ = false;
 }
 
-void AnimationManager::updateGraphics(RenderState *_, GLdouble dt) {
+void AnimationManager::updateSynchronized_GPU(double dt) {
 	if (pauseFlag_) { return; }
 	glThreadID_ = boost::this_thread::get_id();
 
@@ -227,57 +223,7 @@ void AnimationManager::updateGraphics(RenderState *_, GLdouble dt) {
 	glInProgress_ = false;
 }
 
-void AnimationManager::flushGraphics() {
-	frameBarrier_.arrive_and_wait();
-}
-
-void AnimationManager::runUnsynchronized(Animation *animation) const {
-	using Clock = std::chrono::steady_clock;
-	using ms = std::chrono::duration<double, std::milli>;
-
-	const double targetMs = 1000.0 / animation->desiredFrameRate();
-	const auto d_frameDuration = ms(targetMs);
-	const auto frameDuration = std::chrono::duration_cast<Clock::duration>(d_frameDuration);
-	auto nextFrame = Clock::now();
-
-	while (!closeFlag_ && animation->isRunning()) {
-		if (pauseFlag_) {
-			usleepRegen(IDLE_SLEEP);  // or sleep_for()
-			nextFrame += std::chrono::microseconds(IDLE_SLEEP);
-			continue;
-		}
-
-		auto frameStart = Clock::now();
-		double dt = std::chrono::duration<double, std::milli>(frameStart - nextFrame + frameDuration).count();
-
-		// Run the animation logic
-		animation->animate(dt);
-
-		// Schedule next frame
-		nextFrame += frameDuration;
-
-		auto now = Clock::now();
-		if (now < nextFrame) {
-			std::this_thread::sleep_until(nextFrame);
-		} else {
-			// Missed the frame deadline: resync
-			nextFrame = now;
-		}
-	}
-}
-
-void AnimationManager::swapClientData() {
-	if (closeFlag_) return;
-	auto &staging = StagingSystem::instance();
-	// Wait for the staging system to finish copying client data for this frame.
-	while (staging.isCopyInProgress()) {
-		CPU_PAUSE();
-		if (closeFlag_) return;
-	}
-	staging.swapClientData();
-}
-
-void AnimationManager::updateAnimations_cpu(double dt) {
+void AnimationManager::updateSynchronized_CPU(double dt) {
 	if (synchronizedAnimations_.empty()) return;
 
 	bool areAnimationsRemaining = true;
@@ -318,7 +264,7 @@ void AnimationManager::run() {
 			// Advance each CPU animation.
 			// Main point is writing shader data that will be added to
 			// staging next frame.
-			updateAnimations_cpu(dt);
+			updateSynchronized_CPU(dt);
 			// Update visibility using spatial indices.
 			// Note: this might be computationally heavy!
 			for (auto &index : spatialIndices_) {
@@ -374,4 +320,54 @@ void AnimationManager::resume(bool runOnce) {
 		}
 	}
 	pauseFlag_ = false;
+}
+
+void AnimationManager::runUnsynchronized(Animation *animation) const {
+	using Clock = std::chrono::steady_clock;
+	using ms = std::chrono::duration<double, std::milli>;
+
+	const double targetMs = 1000.0 / animation->desiredFrameRate();
+	const auto d_frameDuration = ms(targetMs);
+	const auto frameDuration = std::chrono::duration_cast<Clock::duration>(d_frameDuration);
+	auto nextFrame = Clock::now();
+
+	while (!closeFlag_ && animation->isRunning()) {
+		if (pauseFlag_) {
+			usleepRegen(IDLE_SLEEP);  // or sleep_for()
+			nextFrame += std::chrono::microseconds(IDLE_SLEEP);
+			continue;
+		}
+
+		auto frameStart = Clock::now();
+		double dt = std::chrono::duration<double, std::milli>(frameStart - nextFrame + frameDuration).count();
+
+		// Run the animation logic
+		animation->animate(dt);
+
+		// Schedule next frame
+		nextFrame += frameDuration;
+
+		auto now = Clock::now();
+		if (now < nextFrame) {
+			std::this_thread::sleep_until(nextFrame);
+		} else {
+			// Missed the frame deadline: resync
+			nextFrame = now;
+		}
+	}
+}
+
+void AnimationManager::flushGraphics() {
+	frameBarrier_.arrive_and_wait();
+}
+
+void AnimationManager::swapClientData() {
+	if (closeFlag_) return;
+	auto &staging = StagingSystem::instance();
+	// Wait for the staging system to finish copying client data for this frame.
+	while (staging.isCopyInProgress()) {
+		CPU_PAUSE();
+		if (closeFlag_) return;
+	}
+	staging.swapClientData();
 }

--- a/regen/animation/animation-manager.h
+++ b/regen/animation/animation-manager.h
@@ -1,11 +1,7 @@
 #ifndef REGEN_ANIMATION_MANAGER_H_
 #define REGEN_ANIMATION_MANAGER_H_
 
-#include <list>
-#include <set>
 #include <barrier>
-
-#include <regen/utility/threading.h>
 #include <regen/animation/animation.h>
 #include "regen/shapes/spatial-index.h"
 
@@ -21,7 +17,87 @@ namespace regen {
 		static AnimationManager &get();
 
 		/**
-		 * Adds an animation.
+		 * Command types for adding/removing animations.
+		 */
+		enum CommandType : uint8_t {
+			ADD,
+			REMOVE
+		};
+
+		/**
+		 * Animation command structure.
+		 */
+		struct Command {
+			CommandType type;
+			Animation *animation;
+		};
+
+		AnimationManager();
+
+		~AnimationManager();
+
+		/**
+		 * Set the root state.
+		 * @param rootState the root state.
+		 */
+		void setRootState(const ref_ptr<State> &rootState);
+
+		/**
+		 * @return the root state.
+		 */
+		const ref_ptr<State> &rootState() const { return rootState_; }
+
+		/**
+		 * Set the spatial indices.
+		 * @param indices the spatial indices.
+		 */
+		void setSpatialIndices(const std::vector<ref_ptr<SpatialIndex>> &indices) { spatialIndices_ = indices; }
+
+		/**
+		 * @return the set of animations.
+		 */
+		const std::vector<Animation*>& cpuAnimations() { return cpuAnimations_; }
+
+		/**
+		 * @return the set of glAnimations.
+		 */
+		const std::vector<Animation*>& gpuAnimations() { return gpuAnimations_; }
+
+		/**
+		 * @return the set of unsynchronized animations.
+		 */
+		const std::vector<Animation*>& unsyncedAnimations() { return unsyncedAnimations_; }
+
+		/**
+		 * Shutdown the animation manager.
+		 * @param blocking if true, wait for completion of any active animations.
+		 */
+		void shutdown(bool blocking = false);
+
+		/**
+		 * Pauses all animations.
+		 * @param blocking if true, wait for completion of any active animations.
+		 */
+		void pause(bool blocking = false);
+
+		/**
+		 * Remove all animations from the manager.
+		 */
+		void clear();
+
+		/**
+		 * Resumes previously paused animations.
+		 * @param runOnce if true, run one update step immediately upon resuming.
+		 */
+		void resume(bool runOnce = true);
+
+		/**
+		 * Reset the time of the animation manager.
+		 */
+		void resetTime();
+
+		/**
+		 * Adds an animation to the manager.
 		 * @param animation a Animation instance.
 		 */
 		void addAnimation(Animation *animation);
@@ -33,113 +109,69 @@ namespace regen {
 		void removeAnimation(Animation *animation);
 
 		/**
-		 * Invoke glAnimate() on added glAnimations.
-		 * @param dt_ms time difference to last call in milliseconds.
+		 * Performs a single GPU update step.
+		 * This should be called from the GPU thread each frame.
+		 * @param dt_ms time delta in milliseconds since last update.
 		 */
-		void updateSynchronized_GPU(double dt_ms);
-
-		/**
-		 * Close animation thread.
-		 */
-		void close(bool blocking = false);
-
-		/**
-		 * Pause glAnimations.
-		 * Can be resumed by call to resume().
-		 */
-		void pause(bool blocking = false);
-
-		/**
-		 * Clear all animations.
-		 */
-		void clear();
-
-		/**
-		 * Resumes previously paused glAnimations.
-		 */
-		void resume(bool runOnce = true);
-
-		/**
-		 * Reset the time of the animation manager.
-		 */
-		void resetTime();
-
-		/**
-		 * @return the set of glAnimations.
-		 */
-		auto& graphicsAnimations() { return gpuAnimations_; }
-
-		/**
-		 * @return the set of animations.
-		 */
-		auto& synchronizedAnimations() { return synchronizedAnimations_; }
-
-		/**
-		 * @return the set of unsynchronized animations.
-		 */
-		auto& unsynchronizedAnimations() { return unsynchronizedAnimations_; }
-
-		/**
-		 * Set the root state.
-		 * @param rootState the root state.
-		 */
-		void setRootState(const ref_ptr<State> &rootState);
-
-		/**
-		 * @return the root state.
-		 */
-		auto &rootState() const { return rootState_; }
-
-		/**
-		 * Set the spatial indices.
-		 * @param indices the spatial indices.
-		 */
-		void setSpatialIndices(const std::map<std::string, ref_ptr<SpatialIndex>> &indices) { spatialIndices_ = indices; }
+		void gpuUpdateStep(double dt_ms);
 
 	private:
+		// Time tracking
 		boost::posix_time::ptime time_;
 		boost::posix_time::ptime lastTime_;
-		std::vector<Animation *> synchronizedAnimations_;
-		std::vector<Animation *> unsynchronizedAnimations_;
-		std::vector<boost::thread> unsynchronizedThreads_;
-		std::set<Animation *> gpuAnimations_;
+
+		// GPU and CPU update threads
+		boost::thread cpuUpdateThread_;
+		boost::thread::id gpu_threadID_;
+		boost::thread::id cpu_threadID_;
+
+		// The root state for all animations
 		ref_ptr<State> rootState_;
-		std::map<std::string, ref_ptr<SpatialIndex>> spatialIndices_;
+		// Spatial indices for visibility updates
+		std::vector<ref_ptr<SpatialIndex>> spatialIndices_;
 
-		boost::thread::id animationThreadID_;
-		boost::thread::id glThreadID_;
-		boost::thread::id removeThreadID_;
-		boost::thread::id addThreadID_;
-		boost::thread thread_;
-		boost::mutex threadLock_;
+		// Synchronized GPU/CPU threads
+		std::vector<Animation *> cpuAnimations_; // only touch in CPU thread
+		std::vector<Animation *> gpuAnimations_; // only touch in GPU thread
+		// Unsynchronized threads that run independently
+		std::vector<Animation *> unsyncedAnimations_;
+		std::vector<boost::thread> unsyncedThreads_;
 
+		// Barrier to synchronize CPU and GPU threads at the end of each frame
 		using BarrierCompletionFun = std::function<void()>;
 		std::barrier<BarrierCompletionFun> frameBarrier_;
-		boost::mutex unsynchronizedMut_;
+		// This lock is only used for adding/removing unsynced animations,
+		// since there is no hot loop over the unsyncedAnimations_ list, this is acceptable.
+		boost::mutex unsyncedListLock_;
 
-		bool animInProgress_;
-		bool glInProgress_;
-		bool removeInProgress_;
-		bool addInProgress_;
-		bool animChangedDuringLoop_;
-		bool glChangedDuringLoop_;
-		bool closeFlag_;
-		bool pauseFlag_;
+		// The close flag is only toggled to true when system shuts down
+		std::atomic_flag closeFlag_ = { false };
+		// The pause flag is toggled to true when animations are paused, eg.
+		// when a new scene is loaded
+		std::atomic_flag pauseFlag_ = { false };
+		// Flags to indicate if an update is active, one for each thread.
+		// Unsynced animations currently have their dedicated threads, so each has its own flag.
+		std::atomic_flag cpu_isUpdateActive_ = { false };
+		std::atomic_flag gpu_isUpdateActive_ = { false };
+		std::atomic<int> unsynced_numActiveUpdates_{0};
 
-		AnimationManager();
+		// Command queues for adding/removing animations
+		ThreadSafeQueue<Command> gpu_commandQueue_;
+		ThreadSafeQueue<Command> cpu_commandQueue_;
 
-		~AnimationManager();
+		void flushGraphics() { frameBarrier_.arrive_and_wait(); }
 
-		void flushGraphics();
-		friend class Scene;
+		void cpuUpdate();
 
-		void run();
+		void cpuUpdateStep();
 
-		void runUnsynchronized(Animation *animation) const;
+		void unsyncedUpdate(Animation *animation);
 
-		void updateSynchronized_CPU(double dt);
+		void waitForAnimations() const;
 
 		void swapClientData();
+
+		friend class Scene;
 	};
 } // namespace
 

--- a/regen/animation/animation-manager.h
+++ b/regen/animation/animation-manager.h
@@ -34,10 +34,9 @@ namespace regen {
 
 		/**
 		 * Invoke glAnimate() on added glAnimations.
-		 * @param rs the render state.
-		 * @param dt time difference to last call in milliseconds.
+		 * @param dt_ms time difference to last call in milliseconds.
 		 */
-		void updateGraphics(RenderState *rs, GLdouble dt);
+		void updateSynchronized_GPU(double dt_ms);
 
 		/**
 		 * Close animation thread.
@@ -95,7 +94,7 @@ namespace regen {
 		 * Set the spatial indices.
 		 * @param indices the spatial indices.
 		 */
-		void setSpatialIndices(const std::map<std::string, ref_ptr<SpatialIndex>> &indices);
+		void setSpatialIndices(const std::map<std::string, ref_ptr<SpatialIndex>> &indices) { spatialIndices_ = indices; }
 
 	private:
 		boost::posix_time::ptime time_;
@@ -138,7 +137,7 @@ namespace regen {
 
 		void runUnsynchronized(Animation *animation) const;
 
-		void updateAnimations_cpu(double dt);
+		void updateSynchronized_CPU(double dt);
 
 		void swapClientData();
 	};

--- a/regen/animation/animation.cpp
+++ b/regen/animation/animation.cpp
@@ -53,13 +53,13 @@ void Animation::doStopAnimation() {
 	AnimationManager::get().removeAnimation(this);
 }
 
-GLboolean Animation::try_lock() { return mutex_.try_lock(); }
+bool Animation::try_lock() { return mutex_.try_lock(); }
 
 void Animation::lock() { mutex_.lock(); }
 
 void Animation::unlock() { mutex_.unlock(); }
 
-GLboolean Animation::try_lock_gl() { return mutex_gl_.try_lock(); }
+bool Animation::try_lock_gl() { return mutex_gl_.try_lock(); }
 
 void Animation::lock_gl() { mutex_gl_.lock(); }
 

--- a/regen/animation/animation.cpp
+++ b/regen/animation/animation.cpp
@@ -1,20 +1,15 @@
 #include <regen/animation/animation-manager.h>
-#include <regen/utility/threading.h>
-#include <regen/utility/logging.h>
-#include <regen/config.h>
 
 #include "animation.h"
 
 using namespace regen;
 
-uint32_t Animation::ANIMATION_STARTED = EventObject::registerEvent("animationStarted");
 uint32_t Animation::ANIMATION_STOPPED = EventObject::registerEvent("animationStopped");
 
 Animation::Animation(bool isGPUAnimation, bool isCPUAnimation)
 		: EventObject(),
 		  isGPUAnimation_(isGPUAnimation),
-		  isCPUAnimation_(isCPUAnimation),
-		  isRunning_(false) {
+		  isCPUAnimation_(isCPUAnimation) {
 	animationState_ = ref_ptr<State>::alloc();
 	if (AnimationManager::get().rootState().get()) {
 		animationState_->joinStates(AnimationManager::get().rootState());
@@ -22,51 +17,23 @@ Animation::Animation(bool isGPUAnimation, bool isCPUAnimation)
 }
 
 Animation::~Animation() {
-	if (!try_lock()) {
-		REGEN_WARN("Destroying Animation during it's locked.");
-	} else {
-		unlock();
-	}
-	if (!try_lock_gl()) {
-		REGEN_WARN("Destroying GL Animation during it's locked.");
-	} else {
-		unlock_gl();
-	}
-	doStopAnimation();
+	isRunning_.clear(std::memory_order_release);
+	unQueueEmit(ANIMATION_STOPPED);
+	AnimationManager::get().removeAnimation(this);
 }
 
 void Animation::startAnimation() {
-	if (isRunning_) return;
-	isRunning_ = true;
-
+	if (isRunning()) return;
+	isRunning_.test_and_set(std::memory_order_acquire);
 	unQueueEmit(ANIMATION_STOPPED);
-	queueEmit(ANIMATION_STARTED);
 	AnimationManager::get().addAnimation(this);
 }
 
 void Animation::doStopAnimation() {
-	if (!isRunning_) return;
-
-	isRunning_ = false;
-	unQueueEmit(ANIMATION_STARTED);
+	if (!isRunning()) return;
+	isRunning_.clear(std::memory_order_release);
 	queueEmit(ANIMATION_STOPPED);
 	AnimationManager::get().removeAnimation(this);
-}
-
-bool Animation::try_lock() { return mutex_.try_lock(); }
-
-void Animation::lock() { mutex_.lock(); }
-
-void Animation::unlock() { mutex_.unlock(); }
-
-bool Animation::try_lock_gl() { return mutex_gl_.try_lock(); }
-
-void Animation::lock_gl() { mutex_gl_.lock(); }
-
-void Animation::unlock_gl() { mutex_gl_.unlock(); }
-
-void Animation::wait(uint32_t milliseconds) {
-	usleepRegen(1000 * milliseconds);
 }
 
 void Animation::joinAnimationState(const ref_ptr<State> &state) {

--- a/regen/animation/animation.h
+++ b/regen/animation/animation.h
@@ -74,7 +74,7 @@ namespace regen {
 		 * Set the synchronized flag.
 		 * @param synchronized the synchronized flag.
 		 */
-		void setSynchronized(GLboolean v) { isSynchronized_ = v; }
+		void setSynchronized(bool v) { isSynchronized_ = v; }
 
 		/**
 		 * Activate this animation.
@@ -90,13 +90,13 @@ namespace regen {
 		 * Mutex lock for data access.
 		 * @return false if not successful.
 		 */
-		GLboolean try_lock();
+		bool try_lock();
 
 		/**
 		 * Mutex lock for data access.
 		 * @return false if not successful.
 		 */
-		GLboolean try_lock_gl();
+		bool try_lock_gl();
 
 		/**
 		 * Mutex lock for data access.

--- a/regen/animation/animation.h
+++ b/regen/animation/animation.h
@@ -143,7 +143,7 @@ namespace regen {
 		 * This should be called each frame.
 		 * @param dt time difference to last call in milliseconds.
 		 */
-		virtual void animate(GLdouble dt) {}
+		virtual void animate(double dt) {}
 
 		/**
 		 * Upload animation data to GL.
@@ -152,7 +152,7 @@ namespace regen {
 		 * @param rs the render state.
 		 * @param dt time difference to last call in milliseconds.
 		 */
-		virtual void glAnimate(RenderState *rs, GLdouble dt) {}
+		virtual void glAnimate(RenderState *rs, double dt) {}
 
 		/**
 		 * @return the root state.

--- a/regen/animation/animation.h
+++ b/regen/animation/animation.h
@@ -1,12 +1,8 @@
-#ifndef GL_ANIMATION_H_
-#define GL_ANIMATION_H_
-
-#include <GL/glew.h>
-#include <boost/thread/mutex.hpp>
+#ifndef REGEN_ANIMATION_H_
+#define REGEN_ANIMATION_H_
 
 #include <regen/utility/event-object.h>
 #include <regen/gl-types/render-state.h>
-#include "regen/shader/shader.h"
 #include <regen/states/state.h>
 
 namespace regen {
@@ -16,22 +12,15 @@ namespace regen {
 	class Animation : public EventObject {
 	public:
 		/**
-		 * The animation state switched to active.
-		 */
-		static uint32_t ANIMATION_STARTED;
-		/**
 		 * The animation state switched to inactive.
 		 */
 		static uint32_t ANIMATION_STOPPED;
 
 		/**
 		 * Create an animation.
-		 * Note that the animation removes itself from the AnimationManager
-		 * in the destructor.
-		 * @param a user readable name, must not be unique.
-		 * @param useGLAnimation execute with render context.
-		 * @param useAnimation execute without render context in separate thread.
-		 * @param autoStart is true the animation adds itself to the AnimationManager.
+		 * Note that the animation removes itself from the AnimationManager in the destructor.
+		 * @param isGPUAnimation execute with render context.
+		 * @param isCPUAnimation execute without render context in separate thread.
 		 */
 		Animation(bool isGPUAnimation, bool isCPUAnimation);
 
@@ -40,9 +29,40 @@ namespace regen {
 		Animation(const Animation &) = delete;
 
 		/**
+		 * @return true if the animation implements glAnimate().
+		 */
+		bool isGPUAnimation() const { return isGPUAnimation_; }
+
+		/**
+		 * @return true if the animation implements animate().
+		 */
+		bool isCPUAnimation() const { return isCPUAnimation_; }
+
+		/**
+		 * @return true if this animation is synchronized.
+		 */
+		bool isSynchronized() const { return isSynchronized_; }
+
+		/**
+		 * Set the synchronized flag.
+		 * @param v the synchronized flag.
+		 */
+		void setSynchronized(bool v) { isSynchronized_ = v; }
+
+		/**
+		 * @return the desired frame rate.
+		 */
+		float desiredFrameRate() const { return desiredFrameRate_; }
+
+		/**
+		 * @return true if this animation is active.
+		 */
+		bool isRunning() const { return isRunning_.test(std::memory_order_acquire); }
+
+		/**
 		 * @return the name of the animation.
 		 */
-		auto &animationName() const { return animationName_; }
+		const std::string &animationName() const { return animationName_; }
 
 		/**
 		 * Set the name of the animation.
@@ -56,25 +76,21 @@ namespace regen {
 		bool hasAnimationName() const { return !animationName_.empty(); }
 
 		/**
-		 * @return true if this animation is active.
+		 * @return the root state.
 		 */
-		auto isRunning() const { return isRunning_; }
+		const ref_ptr<State>& animationState() const { return animationState_; }
 
 		/**
-		 * @return true if this animation is synchronized.
+		 * Set the root state.
+		 * @param state the root state.
 		 */
-		auto isSynchronized() const { return isSynchronized_; }
+		void joinAnimationState(const ref_ptr<State> &state);
 
 		/**
-		 * @return the desired frame rate.
+		 * Remove the root state.
+		 * @param state the root state.
 		 */
-		auto desiredFrameRate() const { return desiredFrameRate_; }
-
-		/**
-		 * Set the synchronized flag.
-		 * @param synchronized the synchronized flag.
-		 */
-		void setSynchronized(bool v) { isSynchronized_ = v; }
+		void disjoinAnimationState(const ref_ptr<State> &state);
 
 		/**
 		 * Activate this animation.
@@ -87,63 +103,11 @@ namespace regen {
 		virtual void stopAnimation() { doStopAnimation(); }
 
 		/**
-		 * Mutex lock for data access.
-		 * @return false if not successful.
-		 */
-		bool try_lock();
-
-		/**
-		 * Mutex lock for data access.
-		 * @return false if not successful.
-		 */
-		bool try_lock_gl();
-
-		/**
-		 * Mutex lock for data access.
-		 * Blocks until lock can be acquired.
-		 */
-		void lock();
-
-		/**
-		 * Mutex lock for data access.
-		 * Blocks until lock can be acquired.
-		 */
-		void lock_gl();
-
-		/**
-		 * Mutex lock for data access.
-		 * Unlocks a previously acquired lock.
-		 */
-		void unlock();
-
-		/**
-		 * Mutex lock for data access.
-		 * Unlocks a previously acquired lock.
-		 */
-		void unlock_gl();
-
-		/**
-		 * Waits for a while.
-		 * @param milliseconds number of ms to wait
-		 */
-		void wait(uint32_t milliseconds);
-
-		/**
-		 * @return true if the animation implements glAnimate().
-		 */
-		auto isGPUAnimation() const { return isGPUAnimation_; }
-
-		/**
-		 * @return true if the animation implements animate().
-		 */
-		auto isCPUAnimation() const { return isCPUAnimation_; }
-
-		/**
 		 * Make the next animation step.
 		 * This should be called each frame.
 		 * @param dt time difference to last call in milliseconds.
 		 */
-		virtual void animate(double dt) {}
+		virtual void cpuUpdate(double dt) {}
 
 		/**
 		 * Upload animation data to GL.
@@ -152,37 +116,18 @@ namespace regen {
 		 * @param rs the render state.
 		 * @param dt time difference to last call in milliseconds.
 		 */
-		virtual void glAnimate(RenderState *rs, double dt) {}
-
-		/**
-		 * @return the root state.
-		 */
-		auto& animationState() const { return animationState_; }
-
-		/**
-		 * Set the root state.
-		 * @param rootState the root state.
-		 */
-		void joinAnimationState(const ref_ptr<State> &state);
-
-		/**
-		 * Remove the root state.
-		 * @param rootState the root state.
-		 */
-		void disjoinAnimationState(const ref_ptr<State> &state);
+		virtual void gpuUpdate(RenderState *rs, double dt) {}
 
 	protected:
-		boost::mutex mutex_;
-		boost::mutex mutex_gl_;
+		const bool isGPUAnimation_;
+		const bool isCPUAnimation_;
 		std::string animationName_;
-		bool isGPUAnimation_;
-		bool isCPUAnimation_;
-		bool isRunning_;
+
 		bool isSynchronized_ = true;
 		float desiredFrameRate_ = 60.0f;
-		ref_ptr<State> animationState_;
 
-		void operator=(const Animation &) = delete;
+		std::atomic_flag isRunning_ = ATOMIC_FLAG_INIT;
+		ref_ptr<State> animationState_;
 
 		void doStopAnimation();
 
@@ -190,4 +135,4 @@ namespace regen {
 	};
 } // namespace
 
-#endif /* GL_ANIMATION_H_ */
+#endif /* REGEN_ANIMATION_H_ */

--- a/regen/animation/attribute-feedback.cpp
+++ b/regen/animation/attribute-feedback.cpp
@@ -58,7 +58,7 @@ void AttributeFeedbackAnimation::initializeResources() {
 	feedbackMesh_->updateVAO(shaderConfigurer.cfg(), shaderState_->shader());
 }
 
-void AttributeFeedbackAnimation::glAnimate(regen::RenderState *rs, double dt) {
+void AttributeFeedbackAnimation::gpuUpdate(regen::RenderState *rs, double dt) {
 	animationNode_->traverse(rs);
 }
 

--- a/regen/animation/attribute-feedback.cpp
+++ b/regen/animation/attribute-feedback.cpp
@@ -58,7 +58,7 @@ void AttributeFeedbackAnimation::initializeResources() {
 	feedbackMesh_->updateVAO(shaderConfigurer.cfg(), shaderState_->shader());
 }
 
-void AttributeFeedbackAnimation::glAnimate(regen::RenderState *rs, GLdouble dt) {
+void AttributeFeedbackAnimation::glAnimate(regen::RenderState *rs, double dt) {
 	animationNode_->traverse(rs);
 }
 

--- a/regen/animation/attribute-feedback.h
+++ b/regen/animation/attribute-feedback.h
@@ -27,7 +27,7 @@ namespace regen {
 		void initializeResources();
 
 		// Override
-		void glAnimate(regen::RenderState *rs, double dt) override;
+		void gpuUpdate(regen::RenderState *rs, double dt) override;
 
 		/**
 		 * Create a new animation node.

--- a/regen/animation/attribute-feedback.h
+++ b/regen/animation/attribute-feedback.h
@@ -27,7 +27,7 @@ namespace regen {
 		void initializeResources();
 
 		// Override
-		void glAnimate(regen::RenderState *rs, GLdouble dt) override;
+		void glAnimate(regen::RenderState *rs, double dt) override;
 
 		/**
 		 * Create a new animation node.

--- a/regen/animation/bone-tree.cpp
+++ b/regen/animation/bone-tree.cpp
@@ -287,21 +287,6 @@ void BoneTree::setTickRange(uint32_t instanceIdx, AnimationHandle animHandle, co
 }
 
 // Look for present frame number.
-// Search from last position if time is after the last time, else from beginning
-
-template<class T>
-static void findFrameAfterTick(double tick, uint32_t &frame, const std::vector<T> &keys) {
-	const uint32_t numKeys = keys.size();
-	double dt;
-	while (frame < numKeys - 1) {
-		dt = tick - keys[++frame].time;
-		if (dt < 0.00001) {
-			--frame;
-			return;
-		}
-	}
-}
-
 template<class T>
 static void findFrameBeforeTick(double &tick, uint32_t &frame, const std::vector<T> &keys) {
 	const uint32_t numKeys = keys.size();
@@ -338,6 +323,10 @@ void BoneTree::setTickRange(ActiveBoneRange &ar, const Vec2d &forcedTickRange) {
 	if (tickRange.x == ar.tickRange_.x && tickRange.y == ar.tickRange_.y) {
 		// nothing changed
 		return;
+	}
+	if (tickRange.x > tickRange.y) {
+		REGEN_WARN("Reverse playback not yet implemented for bone animations.");
+		tickRange.y = tickRange.x;
 	}
 	ar.tickRange_ = tickRange;
 
@@ -463,28 +452,9 @@ void BoneTree::animate(double dt_ms) {
 #endif
 }
 
-template<typename T,int I> static REGEN_FORCE_INLINE
-void findFrame(ActiveBoneRange &ar,
-		uint32_t i,
-		uint32_t &frame,
-		uint32_t &lastFrame,
-		const std::vector<Stamped<T>> &keys) {
-	lastFrame = ar.lastFramePosition_[i][I];
-	// Search from last position if time is after the last time, else from beginning
-	// This is a bit tricky if the animation runs backwards.
-	if (ar.tickRange_.x > ar.tickRange_.y) {
-		frame = (ar.timeInTicks_ <= ar.lastTime_ ? lastFrame : ar.startFramePosition_[i][I]);
-		findFrameBeforeTick(ar.timeInTicks_, frame, keys);
-	} else {
-		frame = (ar.timeInTicks_ >= ar.lastTime_ ? lastFrame : ar.startFramePosition_[i][I]);
-		findFrameAfterTick(ar.timeInTicks_, frame, keys);
-	}
-	ar.lastFramePosition_[i][I] = frame;
-}
-
 namespace regen {
 	template<typename T> static REGEN_FORCE_INLINE
-	float computeInterpolation(ActiveBoneRange &ar, const Stamped<T> &key, const Stamped<T> &nextKey) {
+	float computeBoneInterpolation(ActiveBoneRange &ar, const Stamped<T> &key, const Stamped<T> &nextKey) {
 		double timeDifference = nextKey.time - key.time;
 		if (timeDifference < 0.0) {
 			timeDifference += ar.duration_;
@@ -493,17 +463,17 @@ namespace regen {
 		return facOut > 0.0 ? facOut : 0.0f;
 	}
 
-	template <typename T> T interpolateTypedChannel(ActiveBoneRange&, const Stamped<T>&, const Stamped<T>&);
+	template <typename T> T boneInterpolateTyped(ActiveBoneRange&, const Stamped<T>&, const Stamped<T>&);
 
-	template<> Vec3f interpolateTypedChannel<Vec3f>(ActiveBoneRange &ar,
+	template<> Vec3f boneInterpolateTyped<Vec3f>(ActiveBoneRange &ar,
 				const Stamped<Vec3f> &key, const Stamped<Vec3f> &nextKey) {
-		const float fac = computeInterpolation<Vec3f>(ar, key, nextKey);
+		const float fac = computeBoneInterpolation<Vec3f>(ar, key, nextKey);
 		return key.value + (nextKey.value - key.value) * fac;
 	}
 
-	template<> Quaternion interpolateTypedChannel<Quaternion>(ActiveBoneRange &ar,
+	template<> Quaternion boneInterpolateTyped<Quaternion>(ActiveBoneRange &ar,
 				const Stamped<Quaternion> &key, const Stamped<Quaternion> &nextKey) {
-		float fac = computeInterpolation<Quaternion>(ar, key, nextKey);
+		float fac = computeBoneInterpolation<Quaternion>(ar, key, nextKey);
 		Quaternion value;
 		if constexpr(BONE_INTERPOLATE_QUATERNION_LINEAR) {
 			value.interpolateLinear(key.value, nextKey.value, fac);
@@ -512,26 +482,29 @@ namespace regen {
 		}
 		return value;
 	}
-}
 
-template <typename T, int I>
-static REGEN_FORCE_INLINE  T interpolateChannel(ActiveBoneRange &ar,
-			const AnimationChannel &channel, const std::vector<Stamped<T>> &keys, uint32_t i) {
-	const uint32_t keyCount = keys.size();
-	// Find present frame number.
-	uint32_t frame, lastFrame;
-	findFrame<T,I>(ar, i, frame, lastFrame, keys);
-	// Lookup nearest key
-	const Stamped<T> &key = keys[frame];
+	template <typename T, int I>
+	static REGEN_FORCE_INLINE  T boneInterpolate(ActiveBoneRange &ar,
+				const std::vector<Stamped<T>> &keys, uint32_t i) {
+		const uint32_t keyCount = keys.size();
+		const uint32_t lastFrame = ar.lastFramePosition_[i][I];
 
-	// interpolate between this frame's value and next frame's value
-	if (frame < lastFrame && channel.postState == AnimationChannelBehavior::DEFAULT) {
-		return keys[0].value;
-	} else if (frame < lastFrame && channel.postState == AnimationChannelBehavior::CONSTANT) {
-		return key.value;
-	} else [[likely]] {
-		auto &nextKey = keys[(frame + 1) % keyCount];
-		return interpolateTypedChannel<T>(ar, key, nextKey);
+		// Wrap around if needed, else start from last frame
+		// Note: ar.lastTime_ stores last time in ticks.
+		const uint32_t startFrame = (ar.timeInTicks_ >= ar.lastTime_ ?
+				lastFrame : ar.startFramePosition_[i][I]);
+		// Find present frame number.
+		uint32_t frame;
+		for (frame = startFrame; frame < keyCount - 1; frame++) {
+			if (ar.timeInTicks_ < keys[frame + 1].time) break;
+		}
+		// Store active frame for next time
+		ar.lastFramePosition_[i][I] = frame;
+
+		// interpolate between this frame's value and next frame's value
+		const Stamped<T> &key = keys[frame];
+		const Stamped<T> &nextKey = keys[(frame + 1) % keyCount];
+		return boneInterpolateTyped<T>(ar, key, nextKey);
 	}
 }
 
@@ -539,7 +512,6 @@ template <bool HasScaleKeys>
 void BoneTree::updateLocalTransforms(BoneTreeTraversal &td, uint32_t itemBase, InstanceData &instance) {
 	const auto numNodes = static_cast<uint32_t>(nodes_.size());
 	const auto numRanges = instance.numActiveRanges_;
-	//const uint32_t* __restrict numActive = numActive_.data() + itemBase;
 	const Mat4f* __restrict localTF = localTransform_.data();
 	Mat4f* __restrict blendedTF = blendedTransforms_.data() + itemBase;
 	int8_t* __restrict localDirty = td.localDirty.data();
@@ -550,14 +522,6 @@ void BoneTree::updateLocalTransforms(BoneTreeTraversal &td, uint32_t itemBase, I
 	Vec3f &accScale = td.accScale;
 
 	for (uint32_t nodeIdx = 0; nodeIdx < numNodes; nodeIdx++) {
-		// fast-check with numActive
-		/**
-		if (numActive[nodeIdx] == 0) {
-			blendedTF[nodeIdx] = localTF[nodeIdx];
-			continue;
-		}
-		**/
-
 		// Compute per-bone effective weights
 		float weightSum = 0.0f;
 		for (uint32_t rangeIdx : instance.activeRanges_) {
@@ -599,17 +563,18 @@ void BoneTree::updateLocalTransforms(BoneTreeTraversal &td, uint32_t itemBase, I
 			weight *= weightSum;
 
 			// Accumulate position
-			accPos += interpolateChannel<Vec3f,0>(range, channel, channel.positionKeys_, nodeIdx) * weight;
+			accPos += boneInterpolate<Vec3f,0>(range, channel.positionKeys_, nodeIdx) * weight;
 			// Accumulate rotation
-			Quaternion rotation = interpolateChannel<Quaternion,1>(range, channel, channel.rotationKeys_, nodeIdx);
+			Quaternion rotation = boneInterpolate<Quaternion,1>(range, channel.rotationKeys_, nodeIdx);
 			if (accRot.dot(rotation) < 0.0f) { rotation = -rotation; }
 			accRot += rotation * weight;
 			// Accumulate scaling
 			if constexpr (HasScaleKeys) {
-				accScale += interpolateChannel<Vec3f,2>(range, channel, channel.scalingKeys_, nodeIdx) * weight;
+				accScale += boneInterpolate<Vec3f,2>(range, channel.scalingKeys_, nodeIdx) * weight;
 			}
 		}
 
+		// Finally, write blended local transform
 		{
 			localDirty[nodeIdx] = true;
 			if (numRanges > 1) {
@@ -689,6 +654,9 @@ void BoneTree::updateBoneTree(uint32_t instanceBase, uint32_t numInstances, doub
 	const uint32_t instanceEnd = instanceBase + numInstances;
 	const auto numNodes = static_cast<uint32_t>(nodes_.size());
 
+	InstanceData* __restrict instanceData = instanceData_.data();
+	Track* __restrict animTracks = animTracks_.data();
+
 	thread_local BoneTreeTraversal td;
 	// make sure traversal data arrays are large enough
 	if (td.localDirty.size() < numNodes) {
@@ -698,7 +666,7 @@ void BoneTree::updateBoneTree(uint32_t instanceBase, uint32_t numInstances, doub
 
 	for (uint32_t instanceIdx = instanceBase; instanceIdx < instanceEnd; instanceIdx++) {
 		const uint32_t itemBase = instanceIdx * numNodes;
-		auto &instance = instanceData_[instanceIdx];
+		auto &instance = instanceData[instanceIdx];
 		const auto numRanges = instance.numActiveRanges_;
 
 		if (numRanges == 0) continue;
@@ -706,17 +674,12 @@ void BoneTree::updateBoneTree(uint32_t instanceBase, uint32_t numInstances, doub
 		// Pass 1: Advance time in active ranges
 		for (uint32_t rangeIdx : instance.activeRanges_) {
 			ActiveBoneRange &range = instance.ranges_[rangeIdx];
-			const Track &track = animTracks_[range.trackIdx_];
+			const Track &track = animTracks[range.trackIdx_];
 			range.elapsedTime_ += dt_ms;
 			range.lastTime_ = range.timeInTicks_;
-
 			// Map into anim's duration
 			range.timeInTicks_ = std::min(range.duration_,
 				range.elapsedTime_ * timeFactor_ * track.ticksPerSecond_);
-			// Time runs backwards when start tick is higher than stop tick
-			if (range.tickRange_.x > range.tickRange_.y) {
-				range.timeInTicks_ = -range.timeInTicks_;
-			}
 			range.timeInTicks_ += range.startTick_;
 		}
 

--- a/regen/animation/bone-tree.cpp
+++ b/regen/animation/bone-tree.cpp
@@ -401,7 +401,7 @@ static void boneSliceJob(void *arg) {
 	BoneSliceJob::run(arg);
 }
 
-void BoneTree::animate(double dt_ms) {
+void BoneTree::cpuUpdate(double dt_ms) {
 #ifdef BONE_TREE_DEBUG_TIME
 	static ElapsedTimeDebugger elapsedTime("NodeAnimation Update", 300);
 	elapsedTime.beginFrame();

--- a/regen/animation/bone-tree.h
+++ b/regen/animation/bone-tree.h
@@ -277,7 +277,7 @@ namespace regen {
 		double ticksPerSecond(uint32_t trackIdx) const;
 
 		// override
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 		/**
 		 * Find node with given name.

--- a/regen/animation/bones.cpp
+++ b/regen/animation/bones.cpp
@@ -57,7 +57,7 @@ Bones::Bones(const ref_ptr<BoneTree> &tree,
 	GL_ERROR_LOG();
 }
 
-void Bones::animate(GLdouble dt) {
+void Bones::animate(double dt) {
 	if (bufferSize_ <= 0) return;
 	auto mapped = boneMatrices_->mapClientData<Mat4f>(BUFFER_GPU_WRITE);
 	auto *boneMatrixData_ = mapped.w.data();

--- a/regen/animation/bones.cpp
+++ b/regen/animation/bones.cpp
@@ -57,7 +57,7 @@ Bones::Bones(const ref_ptr<BoneTree> &tree,
 	GL_ERROR_LOG();
 }
 
-void Bones::animate(double dt) {
+void Bones::cpuUpdate(double dt) {
 	if (bufferSize_ <= 0) return;
 	auto mapped = boneMatrices_->mapClientData<Mat4f>(BUFFER_GPU_WRITE);
 	auto *boneMatrixData_ = mapped.w.data();

--- a/regen/animation/bones.h
+++ b/regen/animation/bones.h
@@ -25,7 +25,7 @@ namespace regen {
 		auto numBoneWeights() const  { return numBoneWeights_->getVertex(0); }
 
 		// override
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 	protected:
 		ref_ptr<BoneTree> boneTree_;

--- a/regen/animation/bones.h
+++ b/regen/animation/bones.h
@@ -25,7 +25,7 @@ namespace regen {
 		auto numBoneWeights() const  { return numBoneWeights_->getVertex(0); }
 
 		// override
-		void animate(GLdouble dt) override;
+		void animate(double dt) override;
 
 	protected:
 		ref_ptr<BoneTree> boneTree_;

--- a/regen/animation/input-animation.h
+++ b/regen/animation/input-animation.h
@@ -44,7 +44,7 @@ namespace regen {
 		}
 
 		// Override
-		void animate(double dt) override {
+		void cpuUpdate(double dt) override {
 			if (it_ == frames_.end()) {
 				it_ = frames_.begin();
 				dt_ = 0.0;
@@ -57,7 +57,7 @@ namespace regen {
 				lastFrame_ = currentFrame;
 				double dt__ = dt_ - currentFrame.dt;
 				dt_ = 0.0;
-				animate(dt__);
+				cpuUpdate(dt__);
 			} else {
 				double t = currentFrame.dt > 0.0 ? dt_ / currentFrame.dt : 1.0;
 				val_ = math::mix(lastFrame_.val, currentFrame.val, t);

--- a/regen/animation/input-animation.h
+++ b/regen/animation/input-animation.h
@@ -11,7 +11,7 @@ namespace regen {
 	template<class T>
 	struct InputKeyFrame {
 		T val;
-		GLdouble dt;
+		double dt;
 	};
 
 	/**
@@ -33,7 +33,7 @@ namespace regen {
 			setAnimationName(REGEN_STRING("animation-" << in->name()));
 		}
 
-		void push_back(const T &value, GLdouble dt) {
+		void push_back(const T &value, double dt) {
 			InputKeyFrame<T> f;
 			f.val = value;
 			f.dt = dt;
@@ -44,7 +44,7 @@ namespace regen {
 		}
 
 		// Override
-		void animate(GLdouble dt) override {
+		void animate(double dt) override {
 			if (it_ == frames_.end()) {
 				it_ = frames_.begin();
 				dt_ = 0.0;
@@ -55,11 +55,11 @@ namespace regen {
 			if (dt_ >= currentFrame.dt) {
 				++it_;
 				lastFrame_ = currentFrame;
-				GLdouble dt__ = dt_ - currentFrame.dt;
+				double dt__ = dt_ - currentFrame.dt;
 				dt_ = 0.0;
 				animate(dt__);
 			} else {
-				GLdouble t = currentFrame.dt > 0.0 ? dt_ / currentFrame.dt : 1.0;
+				double t = currentFrame.dt > 0.0 ? dt_ / currentFrame.dt : 1.0;
 				val_ = math::mix(lastFrame_.val, currentFrame.val, t);
 				in_->setVertex(0, val_);
 			}
@@ -70,7 +70,7 @@ namespace regen {
 		std::list <InputKeyFrame<T>> frames_;
 		typename std::list<InputKeyFrame<T> >::iterator it_;
 		InputKeyFrame<T> lastFrame_;
-		GLdouble dt_;
+		double dt_;
 		T val_;
 	};
 }

--- a/regen/animation/mesh-animation.cpp
+++ b/regen/animation/mesh-animation.cpp
@@ -8,9 +8,9 @@ using namespace regen;
 
 void MeshAnimation::findFrameAfterTick(
 		GLdouble tick,
-		GLint &frame,
+		int &frame,
 		std::vector<KeyFrame> &keys) {
-	while (frame < (GLint) (keys.size() - 1)) {
+	while (frame < (int) (keys.size() - 1)) {
 		if (tick <= keys[frame].endTick) {
 			return;
 		}
@@ -242,8 +242,8 @@ void MeshAnimation::glAnimate(RenderState *rs, GLdouble dt) {
 
 	bool framesChanged = false;
 	// Look for present frame number.
-	GLint lastFrame = lastFramePosition_;
-	GLint frame = (timeInTicks >= lastTime_ ? lastFrame : startFramePosition_);
+	int lastFrame = lastFramePosition_;
+	int frame = (timeInTicks >= lastTime_ ? lastFrame : startFramePosition_);
 	findFrameAfterTick(timeInTicks, frame, frames_);
 	lastFramePosition_ = frame;
 
@@ -305,7 +305,7 @@ void MeshAnimation::glAnimate(RenderState *rs, GLdouble dt) {
 		if (hasMeshInterleavedAttributes_) {
 			rs->feedbackBufferRange().push(0, bufferRange_);
 		} else {
-			GLint index = inputs.size() - 1;
+			int index = inputs.size() - 1;
 			bufferRange_.offset_ = 0;
 			for (auto it = inputs.rbegin(); it != inputs.rend(); ++it) {
 				const ref_ptr<ShaderInput> &in = it->in_;
@@ -325,7 +325,7 @@ void MeshAnimation::glAnimate(RenderState *rs, GLdouble dt) {
 		if (hasMeshInterleavedAttributes_) {
 			rs->feedbackBufferRange().pop(0);
 		} else {
-			GLint index = inputs.size() - 1;
+			int index = inputs.size() - 1;
 			for (auto it = inputs.rbegin(); it != inputs.rend(); ++it) {
 				const ref_ptr<ShaderInput> &in = it->in_;
 				index -= 1;

--- a/regen/animation/mesh-animation.cpp
+++ b/regen/animation/mesh-animation.cpp
@@ -7,7 +7,7 @@
 using namespace regen;
 
 void MeshAnimation::findFrameAfterTick(
-		GLdouble tick,
+		double tick,
 		int &frame,
 		std::vector<KeyFrame> &keys) {
 	while (frame < (int) (keys.size() - 1)) {
@@ -19,7 +19,7 @@ void MeshAnimation::findFrameAfterTick(
 }
 
 void MeshAnimation::findFrameBeforeTick(
-		GLdouble &tick,
+		double &tick,
 		uint32_t &frame,
 		std::vector<KeyFrame> &keys) {
 	for (frame = keys.size() - 1; frame > 0;) {
@@ -202,7 +202,7 @@ void MeshAnimation::loadFrame(uint32_t frameIndex, GLboolean isPongFrame) {
 	}
 }
 
-void MeshAnimation::glAnimate(RenderState *rs, GLdouble dt) {
+void MeshAnimation::glAnimate(RenderState *rs, double dt) {
 	if (dt <= 0.00001) return;
 	if (rs->isTransformFeedbackAcive()) {
 		REGEN_WARN("Transform Feedback was active when the MeshAnimation was updated.");
@@ -227,8 +227,8 @@ void MeshAnimation::glAnimate(RenderState *rs, GLdouble dt) {
 	elapsedTime_ += dt;
 
 	// map into anim's duration
-	const GLdouble duration = tickRange_.y - tickRange_.x;
-	const GLdouble timeInTicks = elapsedTime_ * ticksPerSecond_ / 1000.0;
+	const double duration = tickRange_.y - tickRange_.x;
+	const double timeInTicks = elapsedTime_ * ticksPerSecond_ / 1000.0;
 	if (timeInTicks > duration) {
 		REGEN_DEBUG("Mesh animation stopped at tick " <<
 				timeInTicks << " (duration: " << duration << ", frame:" << nextFrame_ << ")");
@@ -352,7 +352,7 @@ void MeshAnimation::glAnimate(RenderState *rs, GLdouble dt) {
 
 void MeshAnimation::addFrame(
 		const std::list<ref_ptr<ShaderInput> > &attributes,
-		GLdouble timeInTicks) {
+		double timeInTicks) {
 	MeshAnimation::KeyFrame frame;
 
 	frame.timeInTicks = timeInTicks;
@@ -391,7 +391,7 @@ void MeshAnimation::addFrame(
 	frames_.push_back(frame);
 }
 
-void MeshAnimation::addMeshFrame(GLdouble timeInTicks) {
+void MeshAnimation::addMeshFrame(double timeInTicks) {
 	std::list<ref_ptr<ShaderInput> > meshAttributes;
 	for (auto &it : mesh_->inputs()) {
 		if (!it.in_->isVertexAttribute()) continue;
@@ -416,7 +416,7 @@ ref_ptr<ShaderInput> MeshAnimation::findLastAttribute(const std::string &name) {
 void MeshAnimation::addSphereAttributes(
 		float horizontalRadius,
 		float verticalRadius,
-		GLdouble timeInTicks,
+		double timeInTicks,
 		const Vec3f &offset) {
 	if (!mesh_->hasInput(ATTRIBUTE_NAME_POS)) {
 		REGEN_WARN("mesh has no input named '" << ATTRIBUTE_NAME_POS << "'");
@@ -460,7 +460,7 @@ void MeshAnimation::addSphereAttributes(
 		Vec3f v = posAtt->getVertex(i).r;
 		Vec3f direction = v - centroid;
 		Vec3f n;
-		GLdouble l = direction.length();
+		double l = direction.length();
 		if (l == 0) {
 			continue;
 		}
@@ -600,7 +600,7 @@ void MeshAnimation::addBoxAttributes(
 		float width,
 		float height,
 		float depth,
-		GLdouble timeInTicks,
+		double timeInTicks,
 		const Vec3f &offset) {
 	if (!mesh_->hasInput(ATTRIBUTE_NAME_POS)) {
 		REGEN_WARN("mesh has no input named '" << ATTRIBUTE_NAME_POS << "'");
@@ -612,7 +612,7 @@ void MeshAnimation::addBoxAttributes(
 	}
 
 	Vec3f boxSize(width, height, depth);
-	GLdouble radius = sqrt(0.5f);
+	double radius = sqrt(0.5f);
 
 	ref_ptr<ShaderInput3f> posAtt = ref_ptr<ShaderInput3f>::dynamicCast(mesh_->positions());
 	ref_ptr<ShaderInput3f> norAtt = ref_ptr<ShaderInput3f>::dynamicCast(mesh_->normals());
@@ -626,7 +626,7 @@ void MeshAnimation::addBoxAttributes(
 	for (uint32_t i = 0; i < boxPos->numVertices(); ++i) {
 		Vec3f v = posAtt->getVertex(i).r;
 		Vec3f n;
-		GLdouble l = v.length();
+		double l = v.length();
 		if (l == 0) {
 			continue;
 		}
@@ -638,10 +638,10 @@ void MeshAnimation::addBoxAttributes(
 
 #if 0
 		// check the coordinate values to choose the right face
-		GLdouble xAbs = abs(vCopy.x);
-		GLdouble yAbs = abs(vCopy.y);
-		GLdouble zAbs = abs(vCopy.z);
-		GLdouble factor;
+		double xAbs = abs(vCopy.x);
+		double yAbs = abs(vCopy.y);
+		double zAbs = abs(vCopy.z);
+		double factor;
 		// set the coordinate for the face to the cube size
 		if(xAbs > yAbs && xAbs > zAbs) { // left/right face
 		  factor = (v.x<0 ? -1 : 1);
@@ -660,9 +660,9 @@ void MeshAnimation::addBoxAttributes(
 		vCopy *= radius;
 
 		// check the coordinate values to choose the right face
-		GLdouble xAbs = abs(vCopy.x);
-		GLdouble yAbs = abs(vCopy.y);
-		GLdouble zAbs = abs(vCopy.z);
+		double xAbs = abs(vCopy.x);
+		double yAbs = abs(vCopy.y);
+		double zAbs = abs(vCopy.z);
 		float h, factor;
 		// set the coordinate for the face to the cube size
 		if (xAbs > yAbs && xAbs > zAbs) { // left/right face
@@ -684,7 +684,7 @@ void MeshAnimation::addBoxAttributes(
 		// delete component of face direction (-n*0.5f , 0.5f because thats the sphere radius)
 		vCopy += -r * (factor * 0.5f - h) / h - n * 0.5f;
 
-		GLdouble maxDim = std::max(std::max(abs(vCopy.x), abs(vCopy.y)), abs(vCopy.z));
+		double maxDim = std::max(std::max(abs(vCopy.x), abs(vCopy.y)), abs(vCopy.z));
 		// we divide by maxDim, so it is not allowed to be zero,
 		// this happens for vCopy with only a single component not zero.
 		if (maxDim != 0.0f) {
@@ -692,7 +692,7 @@ void MeshAnimation::addBoxAttributes(
 			// the length of the vector pointing on the square surface
 			// by the length of the vector pointing on the circle surface (equals circle radius).
 			// size2/maxDim calculates scale factor for d to point on the square surface
-			GLdouble distortionScale = ((vCopy * 0.5f / maxDim).length()) / 0.5f;
+			double distortionScale = ((vCopy * 0.5f / maxDim).length()) / 0.5f;
 			vCopy *= distortionScale;
 		}
 

--- a/regen/animation/mesh-animation.cpp
+++ b/regen/animation/mesh-animation.cpp
@@ -181,7 +181,7 @@ void MeshAnimation::setTickRange(const Vec2d &forcedTickRange) {
 	elapsedTime_ = 0.0;
 }
 
-void MeshAnimation::loadFrame(uint32_t frameIndex, GLboolean isPongFrame) {
+void MeshAnimation::loadFrame(uint32_t frameIndex, bool isPongFrame) {
 	MeshAnimation::KeyFrame &frame = frames_[frameIndex];
 
 	std::list<ref_ptr<ShaderInput> > atts;
@@ -395,7 +395,7 @@ void MeshAnimation::addMeshFrame(double timeInTicks) {
 	std::list<ref_ptr<ShaderInput> > meshAttributes;
 	for (auto &it : mesh_->inputs()) {
 		if (!it.in_->isVertexAttribute()) continue;
-		meshAttributes.push_back(ShaderInput::copy(it.in_, GL_TRUE));
+		meshAttributes.push_back(ShaderInput::copy(it.in_, true));
 	}
 	addFrame(meshAttributes, timeInTicks);
 }
@@ -406,7 +406,7 @@ ref_ptr<ShaderInput> MeshAnimation::findLastAttribute(const std::string &name) {
 		for (auto jt = f.attributes.begin(); jt != f.attributes.end(); ++jt) {
 			const ref_ptr<ShaderInput> &att = jt->input;
 			if (att->name() == name) {
-				return ShaderInput::copy(att, GL_TRUE);
+				return ShaderInput::copy(att, true);
 			}
 		}
 	}
@@ -618,9 +618,9 @@ void MeshAnimation::addBoxAttributes(
 	ref_ptr<ShaderInput3f> norAtt = ref_ptr<ShaderInput3f>::dynamicCast(mesh_->normals());
 	// allocate memory for the animation attributes
 	ref_ptr<ShaderInput3f> boxPos = ref_ptr<ShaderInput3f>::dynamicCast(
-			ShaderInput::copy(posAtt, GL_FALSE));
+			ShaderInput::copy(posAtt, false));
 	ref_ptr<ShaderInput3f> boxNor = ref_ptr<ShaderInput3f>::dynamicCast(
-			ShaderInput::copy(norAtt, GL_FALSE));
+			ShaderInput::copy(norAtt, false));
 
 	// set cube vertex data
 	for (uint32_t i = 0; i < boxPos->numVertices(); ++i) {

--- a/regen/animation/mesh-animation.cpp
+++ b/regen/animation/mesh-animation.cpp
@@ -145,11 +145,11 @@ MeshAnimation::MeshAnimation(
 	}
 }
 
-void MeshAnimation::setFriction(GLfloat friction) {
+void MeshAnimation::setFriction(float friction) {
 	frictionUniform_->setUniformData(friction);
 }
 
-void MeshAnimation::setFrequency(GLfloat frequency) {
+void MeshAnimation::setFrequency(float frequency) {
 	frequencyUniform_->setUniformData(frequency);
 }
 
@@ -414,8 +414,8 @@ ref_ptr<ShaderInput> MeshAnimation::findLastAttribute(const std::string &name) {
 }
 
 void MeshAnimation::addSphereAttributes(
-		GLfloat horizontalRadius,
-		GLfloat verticalRadius,
+		float horizontalRadius,
+		float verticalRadius,
 		GLdouble timeInTicks,
 		const Vec3f &offset) {
 	if (!mesh_->hasInput(ATTRIBUTE_NAME_POS)) {
@@ -426,7 +426,7 @@ void MeshAnimation::addSphereAttributes(
 		REGEN_WARN("mesh has no input named '" << ATTRIBUTE_NAME_NOR << "'");
 		return;
 	}
-	//GLfloat radiusScale = horizontalRadius / verticalRadius;
+	//float radiusScale = horizontalRadius / verticalRadius;
 	//Vec3f scale(radiusScale, 1.0, radiusScale);
 
 	ref_ptr<ShaderInput3f> posAtt = ref_ptr<ShaderInput3f>::dynamicCast(mesh_->positions());
@@ -597,9 +597,9 @@ static void cubizePoint(Vec3f& position)
 #endif
 
 void MeshAnimation::addBoxAttributes(
-		GLfloat width,
-		GLfloat height,
-		GLfloat depth,
+		float width,
+		float height,
+		float depth,
 		GLdouble timeInTicks,
 		const Vec3f &offset) {
 	if (!mesh_->hasInput(ATTRIBUTE_NAME_POS)) {
@@ -663,7 +663,7 @@ void MeshAnimation::addBoxAttributes(
 		GLdouble xAbs = abs(vCopy.x);
 		GLdouble yAbs = abs(vCopy.y);
 		GLdouble zAbs = abs(vCopy.z);
-		GLfloat h, factor;
+		float h, factor;
 		// set the coordinate for the face to the cube size
 		if (xAbs > yAbs && xAbs > zAbs) { // left/right face
 			factor = (v.x < 0.0f ? -1.0f : 1.0f);

--- a/regen/animation/mesh-animation.cpp
+++ b/regen/animation/mesh-animation.cpp
@@ -455,7 +455,7 @@ void MeshAnimation::addSphereAttributes(
 	// Note: this is a very simple sphere mapping, it is not perfect.
 	//       There might be artifacts caused by faces that are flipped.
 	//       Also make sure to use polygon offset to avoid shadow map fighting.
-	// TODO: it should be possible to do this with less artifacts by taking the faces into account.
+	// NOTE: It should be possible to do this with fewer artifacts by taking the faces into account.
 	for (uint32_t i = 0; i < spherePos->numVertices(); ++i) {
 		Vec3f v = posAtt->getVertex(i).r;
 		Vec3f direction = v - centroid;

--- a/regen/animation/mesh-animation.cpp
+++ b/regen/animation/mesh-animation.cpp
@@ -202,7 +202,7 @@ void MeshAnimation::loadFrame(uint32_t frameIndex, bool isPongFrame) {
 	}
 }
 
-void MeshAnimation::glAnimate(RenderState *rs, double dt) {
+void MeshAnimation::gpuUpdate(RenderState *rs, double dt) {
 	if (dt <= 0.00001) return;
 	if (rs->isTransformFeedbackAcive()) {
 		REGEN_WARN("Transform Feedback was active when the MeshAnimation was updated.");

--- a/regen/animation/mesh-animation.h
+++ b/regen/animation/mesh-animation.h
@@ -69,12 +69,12 @@ namespace regen {
 		/**
 		 * Set the friction of the animation.
 		 */
-		void setFriction(GLfloat friction);
+		void setFriction(float friction);
 
 		/**
 		 * Set the frequency of the animation.
 		 */
-		void setFrequency(GLfloat frequency);
+		void setFrequency(float frequency);
 
 		/**
 		 * Add a custom mesh frame.
@@ -98,8 +98,8 @@ namespace regen {
 		 * @param timeInTicks number of ticks for this morph.
 		 */
 		void addSphereAttributes(
-				GLfloat horizontalRadius,
-				GLfloat verticalRadius,
+				float horizontalRadius,
+				float verticalRadius,
 				GLdouble timeInTicks,
 				const Vec3f &offset = Vec3f(0.0f, 0.0f, 0.0f));
 
@@ -111,9 +111,9 @@ namespace regen {
 		 * @param timeInTicks number of ticks for this morph.
 		 */
 		void addBoxAttributes(
-				GLfloat width,
-				GLfloat height,
-				GLfloat depth,
+				float width,
+				float height,
+				float depth,
 				GLdouble timeInTicks,
 				const Vec3f &offset = Vec3f(0.0f, 0.0f, 0.0f));
 

--- a/regen/animation/mesh-animation.h
+++ b/regen/animation/mesh-animation.h
@@ -83,13 +83,13 @@ namespace regen {
 		 */
 		void addFrame(
 				const std::list<ref_ptr<ShaderInput> > &attributes,
-				GLdouble timeInTicks);
+				double timeInTicks);
 
 		/**
 		 * Add a frame for the original mesh attributes.
 		 * @param timeInTicks number of ticks for this morph.
 		 */
-		void addMeshFrame(GLdouble timeInTicks);
+		void addMeshFrame(double timeInTicks);
 
 		/**
 		 * Projects each vertex of the mesh to a sphere.
@@ -100,7 +100,7 @@ namespace regen {
 		void addSphereAttributes(
 				float horizontalRadius,
 				float verticalRadius,
-				GLdouble timeInTicks,
+				double timeInTicks,
 				const Vec3f &offset = Vec3f(0.0f, 0.0f, 0.0f));
 
 		/**
@@ -114,18 +114,18 @@ namespace regen {
 				float width,
 				float height,
 				float depth,
-				GLdouble timeInTicks,
+				double timeInTicks,
 				const Vec3f &offset = Vec3f(0.0f, 0.0f, 0.0f));
 
 		// override
-		void glAnimate(RenderState *rs, GLdouble dt) override;
+		void glAnimate(RenderState *rs, double dt) override;
 
 	protected:
 		struct KeyFrame {
 			std::list<InputLocation> attributes;
-			GLdouble timeInTicks;
-			GLdouble startTick;
-			GLdouble endTick;
+			double timeInTicks;
+			double startTick;
+			double endTick;
 			ref_ptr<BufferReference> ref;
 		};
 
@@ -153,9 +153,9 @@ namespace regen {
 		std::vector<KeyFrame> frames_;
 
 		// milliseconds from start of animation
-		GLdouble elapsedTime_;
-		GLdouble ticksPerSecond_;
-		GLdouble lastTime_;
+		double elapsedTime_;
+		double ticksPerSecond_;
+		double lastTime_;
 		Vec2d tickRange_;
 		uint32_t lastFramePosition_;
 		uint32_t startFramePosition_;
@@ -169,10 +169,10 @@ namespace regen {
 		ref_ptr<ShaderInput> findLastAttribute(const std::string &name);
 
 		static void findFrameAfterTick(
-				GLdouble tick, int &frame, std::vector<KeyFrame> &keys);
+				double tick, int &frame, std::vector<KeyFrame> &keys);
 
 		static void findFrameBeforeTick(
-				GLdouble &tick, uint32_t &frame, std::vector<KeyFrame> &keys);
+				double &tick, uint32_t &frame, std::vector<KeyFrame> &keys);
 	};
 } // namespace
 

--- a/regen/animation/mesh-animation.h
+++ b/regen/animation/mesh-animation.h
@@ -139,7 +139,7 @@ namespace regen {
 		ref_ptr<Mesh> mesh_;
 		uint32_t meshBufferOffset_;
 
-		GLint lastFrame_, nextFrame_;
+		int lastFrame_, nextFrame_;
 		uint32_t bufferSize_;
 
 		ref_ptr<VBO> feedbackBuffer_;
@@ -147,7 +147,7 @@ namespace regen {
 		BufferRange bufferRange_;
 
 		ref_ptr<VBO> animationBuffer_;
-		GLint pingFrame_, pongFrame_;
+		int pingFrame_, pongFrame_;
 		ref_ptr<BufferReference> pingIt_;
 		ref_ptr<BufferReference> pongIt_;
 		std::vector<KeyFrame> frames_;
@@ -169,7 +169,7 @@ namespace regen {
 		ref_ptr<ShaderInput> findLastAttribute(const std::string &name);
 
 		static void findFrameAfterTick(
-				GLdouble tick, GLint &frame, std::vector<KeyFrame> &keys);
+				GLdouble tick, int &frame, std::vector<KeyFrame> &keys);
 
 		static void findFrameBeforeTick(
 				GLdouble &tick, uint32_t &frame, std::vector<KeyFrame> &keys);

--- a/regen/animation/mesh-animation.h
+++ b/regen/animation/mesh-animation.h
@@ -118,7 +118,7 @@ namespace regen {
 				const Vec3f &offset = Vec3f(0.0f, 0.0f, 0.0f));
 
 		// override
-		void glAnimate(RenderState *rs, double dt) override;
+		void gpuUpdate(RenderState *rs, double dt) override;
 
 	protected:
 		struct KeyFrame {

--- a/regen/animation/mesh-animation.h
+++ b/regen/animation/mesh-animation.h
@@ -164,7 +164,7 @@ namespace regen {
 
 		bool hasMeshInterleavedAttributes_;
 
-		void loadFrame(uint32_t frameIndex, GLboolean isPongFrame);
+		void loadFrame(uint32_t frameIndex, bool isPongFrame);
 
 		ref_ptr<ShaderInput> findLastAttribute(const std::string &name);
 

--- a/regen/animation/transform-animation.cpp
+++ b/regen/animation/transform-animation.cpp
@@ -60,7 +60,7 @@ void TransformAnimation::updatePose(const TransformKeyFrame &currentFrame, doubl
 }
 
 // Override
-void TransformAnimation::animate(GLdouble dt) {
+void TransformAnimation::animate(double dt) {
 	if (it_ == frames_.end()) {
 		if (loopTransformAnimation_) {
 			it_ = frames_.begin();
@@ -78,11 +78,11 @@ void TransformAnimation::animate(GLdouble dt) {
 		lastFrame_ = currentFrame;
 		lastFrame_.pos = currentPos_;
 		lastFrame_.rotation = currentDir_;
-		GLdouble dt__ = dt_ - currentFrame.dt;
+		double dt__ = dt_ - currentFrame.dt;
 		dt_ = 0.0;
 		animate(dt__);
 	} else {
-		GLdouble t = currentFrame.dt > 0.0 ? dt_ / currentFrame.dt : 1.0;
+		double t = currentFrame.dt > 0.0 ? dt_ / currentFrame.dt : 1.0;
 		{
 			if (mesh_.get() != nullptr && mesh_->physicalObjects().size() > 0) {
 				auto &physicalObject = mesh_->physicalObjects()[0];

--- a/regen/animation/transform-animation.cpp
+++ b/regen/animation/transform-animation.cpp
@@ -60,7 +60,7 @@ void TransformAnimation::updatePose(const TransformKeyFrame &currentFrame, doubl
 }
 
 // Override
-void TransformAnimation::animate(double dt) {
+void TransformAnimation::cpuUpdate(double dt) {
 	if (it_ == frames_.end()) {
 		if (loopTransformAnimation_) {
 			it_ = frames_.begin();
@@ -80,7 +80,7 @@ void TransformAnimation::animate(double dt) {
 		lastFrame_.rotation = currentDir_;
 		double dt__ = dt_ - currentFrame.dt;
 		dt_ = 0.0;
-		animate(dt__);
+		cpuUpdate(dt__);
 	} else {
 		double t = currentFrame.dt > 0.0 ? dt_ / currentFrame.dt : 1.0;
 		{

--- a/regen/animation/transform-animation.h
+++ b/regen/animation/transform-animation.h
@@ -51,7 +51,7 @@ namespace regen {
 		void setMesh(const ref_ptr<Mesh> &mesh) { mesh_ = mesh; }
 
 		// Override Animation
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 		/**
 		 * Update the pose.

--- a/regen/animation/transform-animation.h
+++ b/regen/animation/transform-animation.h
@@ -13,7 +13,7 @@ namespace regen {
 	struct TransformKeyFrame {
 		std::optional<Vec3f> pos = std::nullopt;
 		std::optional<Vec3f> rotation = std::nullopt;
-		GLdouble dt = 0.0;
+		double dt = 0.0;
 	};
 
 	/**
@@ -51,7 +51,7 @@ namespace regen {
 		void setMesh(const ref_ptr<Mesh> &mesh) { mesh_ = mesh; }
 
 		// Override Animation
-		void animate(GLdouble dt) override;
+		void animate(double dt) override;
 
 		/**
 		 * Update the pose.
@@ -67,7 +67,7 @@ namespace regen {
 		std::list<TransformKeyFrame> frames_;
 		typename std::list<TransformKeyFrame>::iterator it_;
 		TransformKeyFrame lastFrame_;
-		GLdouble dt_;
+		double dt_;
 		Vec3f currentPos_;
 		Vec3f currentVel_ = Vec3f::zero();
 		Vec3f currentDir_;

--- a/regen/av/audio.cpp
+++ b/regen/av/audio.cpp
@@ -235,7 +235,7 @@ AudioSource::AudioSource(uint32_t cachedBytesLimit)
 	alGenSources(1, &id_);
 }
 
-AudioSource::AudioSource(AVStream *stream, GLint index, uint32_t cachedBytesLimit)
+AudioSource::AudioSource(AVStream *stream, int index, uint32_t cachedBytesLimit)
 		: AudioVideoStream(cachedBytesLimit),
 		  id_(0),
 		  alType_(AL_NONE),
@@ -323,7 +323,7 @@ void AudioSource::pop() {
 //////////////
 //////////////
 
-void AudioSource::openAudioStream(AVStream *stream, GLint index, GLboolean initial) {
+void AudioSource::openAudioStream(AVStream *stream, int index, GLboolean initial) {
 	if (!initial) {
 #ifdef HAS_LIBSWRESAMPLE
 		if (resampleContext_) swr_free(&resampleContext_);

--- a/regen/av/audio.cpp
+++ b/regen/av/audio.cpp
@@ -249,7 +249,7 @@ AudioSource::AudioSource(AVStream *stream, int index, uint32_t cachedBytesLimit)
 {
 	AudioLibrary::initializeAL();
 	alGenSources(1, &id_);
-	openAudioStream(stream, index, GL_TRUE);
+	openAudioStream(stream, index, true);
 }
 
 AudioSource::~AudioSource() {
@@ -323,7 +323,7 @@ void AudioSource::pop() {
 //////////////
 //////////////
 
-void AudioSource::openAudioStream(AVStream *stream, int index, GLboolean initial) {
+void AudioSource::openAudioStream(AVStream *stream, int index, bool initial) {
 	if (!initial) {
 #ifdef HAS_LIBSWRESAMPLE
 		if (resampleContext_) swr_free(&resampleContext_);

--- a/regen/av/audio.h
+++ b/regen/av/audio.h
@@ -200,7 +200,7 @@ namespace regen {
 			ref_ptr<AudioBuffer> buffer;
 			AVFrame *avFrame;
 			ALbyte *convertedFrame;
-			GLdouble dts;
+			double dts;
 
 			void free();
 		};
@@ -210,7 +210,7 @@ namespace regen {
 		ALenum alChannelLayout_;
 		ALenum alFormat_;
 		ALint rate_;
-		GLdouble elapsedTime_;
+		double elapsedTime_;
 
 		Stack<ref_ptr<AudioBuffer> > queued_;
 #ifdef HAS_LIBSWRESAMPLE

--- a/regen/av/audio.h
+++ b/regen/av/audio.h
@@ -188,7 +188,7 @@ namespace regen {
 		 * @param initial flag indicating if the open call comes from constructor.
 		 */
 		void openAudioStream(AVStream *stream,
-							 int index, GLboolean initial = GL_FALSE);
+							 int index, bool initial = false);
 
 		// override
 		void decode(AVPacket *packet) override;

--- a/regen/av/audio.h
+++ b/regen/av/audio.h
@@ -117,7 +117,7 @@ namespace regen {
 		 * @param index index in stream.
 		 * @param chachedBytesLimit limit for pre-loading.
 		 */
-		AudioSource(AVStream *stream, GLint index, uint32_t chachedBytesLimit);
+		AudioSource(AVStream *stream, int index, uint32_t chachedBytesLimit);
 
 		~AudioSource() override;
 
@@ -188,7 +188,7 @@ namespace regen {
 		 * @param initial flag indicating if the open call comes from constructor.
 		 */
 		void openAudioStream(AVStream *stream,
-							 GLint index, GLboolean initial = GL_FALSE);
+							 int index, GLboolean initial = GL_FALSE);
 
 		// override
 		void decode(AVPacket *packet) override;

--- a/regen/av/av-stream.cpp
+++ b/regen/av/av-stream.cpp
@@ -19,8 +19,8 @@ AudioVideoStream::AudioVideoStream(AVStream *stream, int index, uint32_t cachedB
 		  index_(-1),
 		  cachedBytes_(0),
 		  cachedBytesLimit_(cachedBytesLimit),
-		  isActive_(GL_FALSE) {
-	open(stream, index, GL_TRUE);
+		  isActive_(false) {
+	open(stream, index, true);
 }
 
 AudioVideoStream::AudioVideoStream(uint32_t cachedBytesLimit)
@@ -30,7 +30,7 @@ AudioVideoStream::AudioVideoStream(uint32_t cachedBytesLimit)
 		  index_(-1),
 		  cachedBytes_(0),
 		  cachedBytesLimit_(cachedBytesLimit),
-		  isActive_(GL_FALSE) {
+		  isActive_(false) {
 }
 
 AudioVideoStream::~AudioVideoStream() {
@@ -44,7 +44,7 @@ void AudioVideoStream::close() {
 	}
 }
 
-void AudioVideoStream::open(AVStream *stream, int index, GLboolean initial) {
+void AudioVideoStream::open(AVStream *stream, int index, bool initial) {
 	if (!initial) {
 		clearQueue();
 	}
@@ -66,7 +66,7 @@ void AudioVideoStream::open(AVStream *stream, int index, GLboolean initial) {
 	stream_ = stream;
 	index_ = index;
 	cachedBytes_ = 0;
-	isActive_ = GL_TRUE;
+	isActive_ = true;
 }
 
 uint32_t AudioVideoStream::numFrames() {

--- a/regen/av/av-stream.cpp
+++ b/regen/av/av-stream.cpp
@@ -12,7 +12,7 @@
 
 using namespace regen;
 
-AudioVideoStream::AudioVideoStream(AVStream *stream, GLint index, uint32_t cachedBytesLimit)
+AudioVideoStream::AudioVideoStream(AVStream *stream, int index, uint32_t cachedBytesLimit)
 		: stream_(nullptr),
 		  codecCtx_(nullptr),
 		  codec_(nullptr),
@@ -44,7 +44,7 @@ void AudioVideoStream::close() {
 	}
 }
 
-void AudioVideoStream::open(AVStream *stream, GLint index, GLboolean initial) {
+void AudioVideoStream::open(AVStream *stream, int index, GLboolean initial) {
 	if (!initial) {
 		clearQueue();
 	}

--- a/regen/av/av-stream.h
+++ b/regen/av/av-stream.h
@@ -44,7 +44,7 @@ namespace regen {
 		 * @param index index in stream.
 		 * @param cachedBytesLimit limit for pre-loading.
 		 */
-		AudioVideoStream(AVStream *stream, GLint index, uint32_t cachedBytesLimit);
+		AudioVideoStream(AVStream *stream, int index, uint32_t cachedBytesLimit);
 
 		/**
 		 * @param cachedBytesLimit limit for pre-loading.
@@ -108,16 +108,16 @@ namespace regen {
 		AVStream *stream_;
 		AVCodecContext *codecCtx_;
 		const AVCodec *codec_;
-		GLint index_;
+		int index_;
 
 		std::queue<AVFrame *> decodedFrames_;
-		std::queue<GLint> frameSizes_;
+		std::queue<int> frameSizes_;
 
 		uint32_t cachedBytes_;
 		uint32_t cachedBytesLimit_;
 		GLboolean isActive_;
 
-		void open(AVStream *stream, GLint index, GLboolean initial = GL_FALSE);
+		void open(AVStream *stream, int index, GLboolean initial = GL_FALSE);
 
 		void close();
 	};

--- a/regen/av/av-stream.h
+++ b/regen/av/av-stream.h
@@ -90,7 +90,7 @@ namespace regen {
 		 * Calling setInactive() will make sure that the stream
 		 * drops out the block so that other media can be loaded.
 		 */
-		void setInactive() { isActive_ = GL_FALSE; }
+		void setInactive() { isActive_ = false; }
 
 		/**
 		 * Decodes a single packet.
@@ -115,9 +115,9 @@ namespace regen {
 
 		uint32_t cachedBytes_;
 		uint32_t cachedBytesLimit_;
-		GLboolean isActive_;
+		bool isActive_;
 
-		void open(AVStream *stream, int index, GLboolean initial = GL_FALSE);
+		void open(AVStream *stream, int index, bool initial = false);
 
 		void close();
 	};

--- a/regen/av/demuxer.cpp
+++ b/regen/av/demuxer.cpp
@@ -157,7 +157,7 @@ void Demuxer::setInactive() {
 	if (audioStream_.get()) { audioStream_->setInactive(); }
 }
 
-void Demuxer::seekTo(GLdouble p) {
+void Demuxer::seekTo(double p) {
 	if (!formatCtx_) { return; }
 	p = std::max(0.0, std::min(1.0, p));
 	seek_.isRequired = true;

--- a/regen/av/demuxer.cpp
+++ b/regen/av/demuxer.cpp
@@ -64,7 +64,7 @@ Demuxer::~Demuxer() {
 	if (formatCtx_) avformat_close_input(&formatCtx_);
 }
 
-void Demuxer::set_repeat(GLboolean repeat) {
+void Demuxer::set_repeat(bool repeat) {
 	repeatStream_ = repeat;
 }
 

--- a/regen/av/demuxer.h
+++ b/regen/av/demuxer.h
@@ -67,7 +67,7 @@ namespace regen {
 		/**
 		 * Repeat video of end position reached ?
 		 */
-		void set_repeat(GLboolean repeat);
+		void set_repeat(bool repeat);
 
 		/**
 		 * Repeat video of end position reached ?

--- a/regen/av/demuxer.h
+++ b/regen/av/demuxer.h
@@ -110,7 +110,7 @@ namespace regen {
 		/**
 		 * Seek to given position [0,1]
 		 */
-		void seekTo(GLdouble p);
+		void seekTo(double p);
 
 		/**
 		 * The video stream or NULL.

--- a/regen/av/video-recorder.cpp
+++ b/regen/av/video-recorder.cpp
@@ -21,7 +21,7 @@ namespace regen {
 			desiredFrameRate_ = 30.0f;
 		}
 
-		void animate(GLdouble dt) override {
+		void animate(double dt) override {
 			encoder_->encodeNextFrame();
 		}
 
@@ -182,7 +182,7 @@ void VideoRecorder::updateFrameBuffer() {
 	pboIndex_ = nextIndex;
 }
 
-void VideoRecorder::glAnimate(RenderState *rs, GLdouble dt) {
+void VideoRecorder::glAnimate(RenderState *rs, double dt) {
 	elapsedTime_ += (dt / 1000.0);
 	if (elapsedTime_ >= 1.0 / static_cast<double>(encoder_->fps())) {
 		updateFrameBuffer();

--- a/regen/av/video-recorder.cpp
+++ b/regen/av/video-recorder.cpp
@@ -21,7 +21,7 @@ namespace regen {
 			desiredFrameRate_ = 30.0f;
 		}
 
-		void animate(double dt) override {
+		void cpuUpdate(double dt) override {
 			encoder_->encodeNextFrame();
 		}
 
@@ -182,7 +182,7 @@ void VideoRecorder::updateFrameBuffer() {
 	pboIndex_ = nextIndex;
 }
 
-void VideoRecorder::glAnimate(RenderState *rs, double dt) {
+void VideoRecorder::gpuUpdate(RenderState *rs, double dt) {
 	elapsedTime_ += (dt / 1000.0);
 	if (elapsedTime_ >= 1.0 / static_cast<double>(encoder_->fps())) {
 		updateFrameBuffer();

--- a/regen/av/video-recorder.h
+++ b/regen/av/video-recorder.h
@@ -66,7 +66,7 @@ namespace regen {
 		void finalize();
 
 		// Override Animation::glAnimate
-		void glAnimate(RenderState *rs, double dt) override;
+		void gpuUpdate(RenderState *rs, double dt) override;
 
 	protected:
 		ref_ptr<VideoEncoder> encoder_;

--- a/regen/av/video-recorder.h
+++ b/regen/av/video-recorder.h
@@ -66,7 +66,7 @@ namespace regen {
 		void finalize();
 
 		// Override Animation::glAnimate
-		void glAnimate(RenderState *rs, GLdouble dt) override;
+		void glAnimate(RenderState *rs, double dt) override;
 
 	protected:
 		ref_ptr<VideoEncoder> encoder_;

--- a/regen/av/video-stream.cpp
+++ b/regen/av/video-stream.cpp
@@ -18,7 +18,7 @@ using namespace regen;
 
 #define GL_RGB_PIXEL_FORMAT AV_PIX_FMT_RGB24
 
-VideoStream::VideoStream(AVStream *stream, GLint index, uint32_t cachedBytesLimit)
+VideoStream::VideoStream(AVStream *stream, int index, uint32_t cachedBytesLimit)
 		: AudioVideoStream(stream, index, cachedBytesLimit) {
 	stream_ = stream;
 	width_ = codecCtx_->width;

--- a/regen/av/video-stream.h
+++ b/regen/av/video-stream.h
@@ -22,7 +22,7 @@ namespace regen {
 		 * @param index the stream index.
 		 * @param cachedBytesLimit size limit for pre loading.
 		 */
-		VideoStream(AVStream *stream, GLint index, uint32_t cachedBytesLimit);
+		VideoStream(AVStream *stream, int index, uint32_t cachedBytesLimit);
 
 		~VideoStream() override;
 
@@ -67,7 +67,7 @@ namespace regen {
 		AVFrame *currFrame_;
 
 		AVStream *stream_;
-		GLint width_, height_;
+		int width_, height_;
 
 		void doClearQueue();
 	};

--- a/regen/av/video-texture.cpp
+++ b/regen/av/video-texture.cpp
@@ -73,15 +73,15 @@ void VideoTexture::seekToBegin() {
 	seekTo(0.0);
 }
 
-void VideoTexture::seekForward(GLdouble seconds) {
+void VideoTexture::seekForward(double seconds) {
 	seekTo((elapsedSeconds_ + seconds) / demuxer_->totalSeconds());
 }
 
-void VideoTexture::seekBackward(GLdouble seconds) {
+void VideoTexture::seekBackward(double seconds) {
 	seekTo((elapsedSeconds_ - seconds) / demuxer_->totalSeconds());
 }
 
-void VideoTexture::seekTo(GLdouble p) {
+void VideoTexture::seekTo(double p) {
 	boost::lock_guard<boost::mutex> lock(decodingLock_);
 	demuxer_->seekTo(p);
 	elapsedSeconds_ = p * demuxer_->totalSeconds();
@@ -131,7 +131,7 @@ void VideoTexture::decode() {
 	}
 }
 
-void VideoTexture::animate(GLdouble animateDT) {
+void VideoTexture::animate(double animateDT) {
 	if (!demuxer_->isPlaying()) { return; }
 	interval_ -= animateDT;
 	dt_ += animateDT;
@@ -186,7 +186,7 @@ void VideoTexture::animate(GLdouble animateDT) {
 	dt_ = 0.0;
 }
 
-void VideoTexture::glAnimate(RenderState *rs, GLdouble dt) {
+void VideoTexture::glAnimate(RenderState *rs, double dt) {
 	if (fileToLoaded_) { // setup the texture target
 		allocTexture();
 		set_filter(TextureFilter::create(GL_LINEAR));

--- a/regen/av/video-texture.cpp
+++ b/regen/av/video-texture.cpp
@@ -28,9 +28,9 @@ using namespace regen;
 VideoTexture::VideoTexture()
 		: Texture2D(GL_TEXTURE_2D, 1),
 		  Animation(true, true),
-		  closeFlag_(GL_FALSE),
-		  seeked_(GL_FALSE),
-		  fileToLoaded_(GL_FALSE),
+		  closeFlag_(false),
+		  seeked_(false),
+		  fileToLoaded_(false),
 		  elapsedSeconds_(0.0),
 		  idleInterval_(IDLE_SLEEP_MS / 1000.0f),
 		  interval_(idleInterval_),
@@ -85,12 +85,12 @@ void VideoTexture::seekTo(double p) {
 	boost::lock_guard<boost::mutex> lock(decodingLock_);
 	demuxer_->seekTo(p);
 	elapsedSeconds_ = p * demuxer_->totalSeconds();
-	seeked_ = GL_TRUE;
+	seeked_ = true;
 }
 
 void VideoTexture::stopDecodingThread() {
 	// stop VideoTexture::decode()
-	closeFlag_ = GL_TRUE;
+	closeFlag_ = true;
 	demuxer_->setInactive();
 	// wait for the decoding thread to stop
 	decodingThread_.join();
@@ -117,12 +117,12 @@ void VideoTexture::set_file(std::string_view file) {
 }
 
 void VideoTexture::decode() {
-	GLboolean isIdle;
+	bool isIdle;
 	while (!closeFlag_) {
 		if (demuxer_->hasInput()) {
 			isIdle = demuxer_->decode();
 		} else {
-			isIdle = GL_TRUE;
+			isIdle = true;
 		}
 		if (isIdle) {
 			// demuxer has nothing to do lets sleep a while
@@ -138,7 +138,7 @@ void VideoTexture::animate(double animateDT) {
 	if (interval_ > 0.0) { return; }
 
 	uint32_t numFrames = vs_->numFrames();
-	GLboolean isIdle = (numFrames == 0);
+	bool isIdle = (numFrames == 0);
 
 	if (isIdle) {
 		// no frames there to show
@@ -169,7 +169,7 @@ void VideoTexture::animate(double animateDT) {
 			float dt = (*t) - elapsedSeconds_;
 			intervalMili_ = std::max(0.0f, dt * 1000.0f - diff);
 		} else {
-			seeked_ = GL_FALSE;
+			seeked_ = false;
 		}
 		elapsedSeconds_ = *t;
 		delete t;
@@ -191,7 +191,7 @@ void VideoTexture::glAnimate(RenderState *rs, double dt) {
 		allocTexture();
 		set_filter(TextureFilter::create(GL_LINEAR));
 		set_wrapping(TextureWrapping::create(GL_REPEAT));
-		fileToLoaded_ = GL_FALSE;
+		fileToLoaded_ = false;
 	}
 	// upload texture data to GL
 	if (videoImageData_) {

--- a/regen/av/video-texture.cpp
+++ b/regen/av/video-texture.cpp
@@ -162,11 +162,11 @@ void VideoTexture::animate(GLdouble animateDT) {
 		}
 
 		// set next interval
-		auto *t = (GLfloat *) frame->opaque;
+		auto *t = (float *) frame->opaque;
 		if (!seeked_) {
 			// set timeout interval to time difference to last frame plus a correction
 			// value because the last timeout call was not exactly the wanted interval
-			GLfloat dt = (*t) - elapsedSeconds_;
+			float dt = (*t) - elapsedSeconds_;
 			intervalMili_ = std::max(0.0f, dt * 1000.0f - diff);
 		} else {
 			seeked_ = GL_FALSE;

--- a/regen/av/video-texture.cpp
+++ b/regen/av/video-texture.cpp
@@ -131,7 +131,7 @@ void VideoTexture::decode() {
 	}
 }
 
-void VideoTexture::animate(double animateDT) {
+void VideoTexture::cpuUpdate(double animateDT) {
 	if (!demuxer_->isPlaying()) { return; }
 	interval_ -= animateDT;
 	dt_ += animateDT;
@@ -186,7 +186,7 @@ void VideoTexture::animate(double animateDT) {
 	dt_ = 0.0;
 }
 
-void VideoTexture::glAnimate(RenderState *rs, double dt) {
+void VideoTexture::gpuUpdate(RenderState *rs, double dt) {
 	if (fileToLoaded_) { // setup the texture target
 		allocTexture();
 		set_filter(TextureFilter::create(GL_LINEAR));

--- a/regen/av/video-texture.h
+++ b/regen/av/video-texture.h
@@ -94,9 +94,9 @@ namespace regen {
 		ref_ptr<AudioSource> audioSource();
 
 		// override
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
-		void glAnimate(RenderState *rs, double dt) override;
+		void gpuUpdate(RenderState *rs, double dt) override;
 
 	protected:
 		ref_ptr<Demuxer> demuxer_;

--- a/regen/av/video-texture.h
+++ b/regen/av/video-texture.h
@@ -94,9 +94,9 @@ namespace regen {
 		ref_ptr<AudioSource> audioSource();
 
 		// override
-		void animate(GLdouble dt) override;
+		void animate(double dt) override;
 
-		void glAnimate(RenderState *rs, GLdouble dt) override;
+		void glAnimate(RenderState *rs, double dt) override;
 
 	protected:
 		ref_ptr<Demuxer> demuxer_;

--- a/regen/behavior/navigation/navigation-controller.cpp
+++ b/regen/behavior/navigation/navigation-controller.cpp
@@ -461,7 +461,7 @@ void NavigationController::updateNavController() {
 	updateNavOrientation(currentPos2D, desiredSpeed);
 }
 
-void NavigationController::animate(GLdouble dt) {
+void NavigationController::animate(double dt) {
 	if (navModeMask_ == NO_NAVIGATION) {
 		currentVel_ = Vec3f::zero();
 		currentSpeed_ = 0.0f;

--- a/regen/behavior/navigation/navigation-controller.cpp
+++ b/regen/behavior/navigation/navigation-controller.cpp
@@ -461,7 +461,7 @@ void NavigationController::updateNavController() {
 	updateNavOrientation(currentPos2D, desiredSpeed);
 }
 
-void NavigationController::animate(double dt) {
+void NavigationController::cpuUpdate(double dt) {
 	if (navModeMask_ == NO_NAVIGATION) {
 		currentVel_ = Vec3f::zero();
 		currentSpeed_ = 0.0f;

--- a/regen/behavior/navigation/navigation-controller.h
+++ b/regen/behavior/navigation/navigation-controller.h
@@ -260,7 +260,7 @@ namespace regen {
 		void navCollisionFrameAdd(const CollisionEvent &evt);
 
 		// Override Animation
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 	protected:
 		ref_ptr<ModelTransformation> tf_;

--- a/regen/behavior/navigation/navigation-controller.h
+++ b/regen/behavior/navigation/navigation-controller.h
@@ -260,7 +260,7 @@ namespace regen {
 		void navCollisionFrameAdd(const CollisionEvent &evt);
 
 		// Override Animation
-		void animate(GLdouble dt) override;
+		void animate(double dt) override;
 
 	protected:
 		ref_ptr<ModelTransformation> tf_;

--- a/regen/behavior/npc-controller.cpp
+++ b/regen/behavior/npc-controller.cpp
@@ -433,7 +433,7 @@ void NonPlayerCharacterController::updateController(double dt) {
 	}
 }
 
-void NonPlayerCharacterController::animate(GLdouble dt) {
+void NonPlayerCharacterController::animate(double dt) {
 	updateController(dt);
 	NavigationController::animate(dt);
 }

--- a/regen/behavior/npc-controller.cpp
+++ b/regen/behavior/npc-controller.cpp
@@ -433,7 +433,7 @@ void NonPlayerCharacterController::updateController(double dt) {
 	}
 }
 
-void NonPlayerCharacterController::animate(double dt) {
+void NonPlayerCharacterController::cpuUpdate(double dt) {
 	updateController(dt);
-	NavigationController::animate(dt);
+	NavigationController::cpuUpdate(dt);
 }

--- a/regen/behavior/npc-controller.h
+++ b/regen/behavior/npc-controller.h
@@ -90,7 +90,7 @@ namespace regen {
 		virtual void initializeController() {}
 
 		// override
-		void animate(GLdouble dt) override;
+		void animate(double dt) override;
 
 	protected:
 		ref_ptr<ModelTransformation> tf_;

--- a/regen/behavior/npc-controller.h
+++ b/regen/behavior/npc-controller.h
@@ -90,7 +90,7 @@ namespace regen {
 		virtual void initializeController() {}
 
 		// override
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 	protected:
 		ref_ptr<ModelTransformation> tf_;

--- a/regen/behavior/person-controller.cpp
+++ b/regen/behavior/person-controller.cpp
@@ -253,7 +253,7 @@ std::vector<ref_ptr<PersonController>> PersonController::load(
 		controller->setVelOrientationWeight(node.getValue<float>("velocity-orientation-weight", 0.5f));
 		controller->setFloorHeight(node.getValue<float>("floor-height", 0.0f));
 		if (node.hasAttribute("base-orientation")) {
-			controller->setBaseOrientation(node.getValue<GLfloat>("base-orientation", 0.0f));
+			controller->setBaseOrientation(node.getValue<float>("base-orientation", 0.0f));
 		}
 
 		auto &kb = controller->knowledgeBase();

--- a/regen/behavior/user-controller.cpp
+++ b/regen/behavior/user-controller.cpp
@@ -114,12 +114,12 @@ ref_ptr<UserController> UserController::load(
 		}
 		auto characterController =
 				ref_ptr<KinematicPlayerController>::alloc(userCamera, scene->getPhysics());
-		characterController->setCollisionHeight(node.getValue<GLfloat>("collision-height", 0.8));
-		characterController->setCollisionRadius(node.getValue<GLfloat>("collision-radius", 0.8));
-		characterController->setStepHeight(node.getValue<GLfloat>("step-height", 0.35));
-		characterController->setMaxSlope(node.getValue<GLfloat>("max-slope", 0.8));
-		characterController->setGravityForce(node.getValue<GLfloat>("gravity-force", 30.0));
-		characterController->setJumpVelocity(node.getValue<GLfloat>("jump-velocity", 16.0f));
+		characterController->setCollisionHeight(node.getValue<float>("collision-height", 0.8));
+		characterController->setCollisionRadius(node.getValue<float>("collision-radius", 0.8));
+		characterController->setStepHeight(node.getValue<float>("step-height", 0.35));
+		characterController->setMaxSlope(node.getValue<float>("max-slope", 0.8));
+		characterController->setGravityForce(node.getValue<float>("gravity-force", 30.0));
+		characterController->setJumpVelocity(node.getValue<float>("jump-velocity", 16.0f));
 		if (animItem.get()) {
 			characterController->setBoneTree(animItem);
 		}
@@ -131,11 +131,11 @@ ref_ptr<UserController> UserController::load(
 	}
 
 	controller->setMeshEyeOffset(node.getValue<Vec3f>("eye-offset", Vec3f::zero()));
-	controller->set_moveAmount(node.getValue<GLfloat>("speed", 0.01f));
-	controller->setMeshDistance(node.getValue<GLfloat>("mesh-distance", 10.0f));
-	controller->setHorizontalOrientation(node.getValue<GLfloat>("horizontal-orientation", 0.0));
-	controller->setVerticalOrientation(node.getValue<GLfloat>("vertical-orientation", 0.0));
-	controller->setMeshHorizontalOrientation(node.getValue<GLfloat>("mesh-horizontal-orientation", 0.0));
+	controller->set_moveAmount(node.getValue<float>("speed", 0.01f));
+	controller->setMeshDistance(node.getValue<float>("mesh-distance", 10.0f));
+	controller->setHorizontalOrientation(node.getValue<float>("horizontal-orientation", 0.0));
+	controller->setVerticalOrientation(node.getValue<float>("vertical-orientation", 0.0));
+	controller->setMeshHorizontalOrientation(node.getValue<float>("mesh-horizontal-orientation", 0.0));
 	if (controllerMode == "third-person") {
 		controller->setCameraMode(CameraController::THIRD_PERSON);
 	} else {

--- a/regen/behavior/user-controller.cpp
+++ b/regen/behavior/user-controller.cpp
@@ -44,7 +44,7 @@ bool UserController::isMotionActive(MotionType type) const {
 	return motionState_[motionIndex].load();
 }
 
-void UserController::animate(GLdouble dt) {
+void UserController::animate(double dt) {
 	CameraController::animate(dt);
 	if (boneController_.get()) {
 		float dt_s = dt / 1000.0f;

--- a/regen/behavior/user-controller.cpp
+++ b/regen/behavior/user-controller.cpp
@@ -44,8 +44,8 @@ bool UserController::isMotionActive(MotionType type) const {
 	return motionState_[motionIndex].load();
 }
 
-void UserController::animate(double dt) {
-	CameraController::animate(dt);
+void UserController::cpuUpdate(double dt) {
+	CameraController::cpuUpdate(dt);
 	if (boneController_.get()) {
 		float dt_s = dt / 1000.0f;
 		// Update the list of active motions from the motion state array.

--- a/regen/behavior/user-controller.h
+++ b/regen/behavior/user-controller.h
@@ -64,7 +64,7 @@ namespace regen {
 		}
 
 		// override Animation
-		void animate(GLdouble dt) override;
+		void animate(double dt) override;
 
 	protected:
 		ref_ptr<BoneAnimationItem> boneAnimation_;

--- a/regen/behavior/user-controller.h
+++ b/regen/behavior/user-controller.h
@@ -64,7 +64,7 @@ namespace regen {
 		}
 
 		// override Animation
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 	protected:
 		ref_ptr<BoneAnimationItem> boneAnimation_;

--- a/regen/behavior/world/world-model-debug.cpp
+++ b/regen/behavior/world/world-model-debug.cpp
@@ -18,7 +18,7 @@ WorldModelDebug::WorldModelDebug(const ref_ptr<WorldModel> &world)
 	lineVertices_->setVertexData(2);
 	// Create and set up the VAO and VBO
 	vao_ = ref_ptr<VAO>::alloc();
-	bufferSize_ = sizeof(GLfloat) * 3 * lineVertices_->numVertices();
+	bufferSize_ = sizeof(float) * 3 * lineVertices_->numVertices();
 	glGenBuffers(1, &vbo_);
 }
 

--- a/regen/behavior/world/world-model-debug.h
+++ b/regen/behavior/world/world-model-debug.h
@@ -34,7 +34,7 @@ namespace regen {
 		ref_ptr<WorldModel> world_;
 		ref_ptr<ShaderInput3f> lineColor_;
 		ref_ptr<ShaderInput3f> lineVertices_;
-		GLint lineLocation_;
+		int lineLocation_;
 
 		ref_ptr<VAO> vao_;
 		uint32_t vbo_{};

--- a/regen/buffer/buffer-block.cpp
+++ b/regen/buffer/buffer-block.cpp
@@ -26,14 +26,14 @@ BufferBlock::BufferBlock(
 BufferBlock::BufferBlock(const StagedBuffer &other, const std::string &name)
 		: StagedBuffer(other, name),
 		  blockQualifier_(BufferBlock::BUFFER) {
-	enableInput_ = [this](GLint loc) { enableBufferBlock(loc); };
+	enableInput_ = [this](int loc) { enableBufferBlock(loc); };
 	isBufferBlock_ = true;
 	isVertexAttribute_ = false;
 }
 
 BufferBlock::~BufferBlock() = default;
 
-void BufferBlock::enableBufferBlock(GLint loc) {
+void BufferBlock::enableBufferBlock(int loc) {
 	if (!isBufferValid_) return;
 	auto *rs = RenderState::get();
 
@@ -53,14 +53,14 @@ void BufferBlock::enableBufferBlock(GLint loc) {
 	bindingIndex_ = loc;
 }
 
-void BufferBlock::bind(GLint loc) {
+void BufferBlock::bind(int loc) {
 	auto *rs = RenderState::get();
 	prepareRebind(loc);
 	rs->bufferRange(glTarget_).apply(loc, *drawBufferRange_.get());
 	bindingIndex_ = loc;
 }
 
-void BufferBlock::prepareRebind(GLint loc) {
+void BufferBlock::prepareRebind(int loc) {
 	if (bindingIndex_ != loc && bindingIndex_ != -1) {
 		// seems the buffer switched to another index!
 		// this is something the buffer manager should try to avoid, but there are some situations

--- a/regen/buffer/buffer-block.h
+++ b/regen/buffer/buffer-block.h
@@ -79,13 +79,13 @@ namespace regen {
 		 * it is bound to the correct shader location.
 		 * @param loc the shader location to bind the block to.
 		 */
-		void enableBufferBlock(GLint loc);
+		void enableBufferBlock(int loc);
 
 		/**
 		 * Binds the uniform block to the given shader location.
 		 * @param loc the shader location to bind the block to.
 		 */
-		void bind(GLint loc);
+		void bind(int loc);
 
 		/**
 		 * Set the binding index of the block.
@@ -102,7 +102,7 @@ namespace regen {
 		Qualifier blockQualifier_;
 		int bindingIndex_ = -1;
 
-		void prepareRebind(GLint loc);
+		void prepareRebind(int loc);
 	};
 
 	std::ostream &operator<<(std::ostream &out, const BufferBlock::Qualifier &v);

--- a/regen/buffer/buffer-container.cpp
+++ b/regen/buffer/buffer-container.cpp
@@ -109,8 +109,8 @@ void BufferContainer::updateBuffer() {
 	if (isAllocated_) return;
 	isAllocated_ = true;
 
-	static auto maxUBOSize = static_cast<uint32_t>(getGLInteger(GL_MAX_UNIFORM_BLOCK_SIZE));
-	static auto maxTBOSize = static_cast<uint32_t>(getGLInteger(GL_MAX_TEXTURE_BUFFER_SIZE)) * 16;
+	static auto maxUBOSize = static_cast<uint32_t>(glGetInteger(GL_MAX_UNIFORM_BLOCK_SIZE));
+	static auto maxTBOSize = static_cast<uint32_t>(glGetInteger(GL_MAX_TEXTURE_BUFFER_SIZE)) * 16;
 	unsigned int uboSize = 0u;
 	std::vector<NamedShaderInput> nextUBOInputs;
 	std::vector<NamedShaderInput> nextSSBOInputs;

--- a/regen/buffer/buffer-object.cpp
+++ b/regen/buffer/buffer-object.cpp
@@ -74,31 +74,31 @@ void BufferObject::createMemoryPools() {
 
 		poolIndex = (int) TEXTURE_BUFFER * (int) BUFFER_STORAGE_MODE_LAST + i;
 #ifdef USE_SHARED_TBO_BUFFER
-		pools[poolIndex]->set_alignment(getGLInteger(GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT));
+		pools[poolIndex]->set_alignment(glGetInteger(GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT));
 #else
 		pools[poolIndex]->set_minSize(1);
 #endif
 		// Meaning: Max number of texels, not bytes!
-		pools[poolIndex]->set_maxSize(getGLInteger(GL_MAX_TEXTURE_BUFFER_SIZE) * 16);
+		pools[poolIndex]->set_maxSize(glGetInteger(GL_MAX_TEXTURE_BUFFER_SIZE) * 16);
 		poolIndex = (int) UNIFORM_BUFFER * (int) BUFFER_STORAGE_MODE_LAST + i;
 #ifdef USE_SHARED_UBO_BUFFER
-		pools[poolIndex]->set_alignment(getGLInteger(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT));
+		pools[poolIndex]->set_alignment(glGetInteger(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT));
 #else
 		pools[poolIndex]->set_minSize(1);
 #endif
 		// common: ~64KB
-		pools[poolIndex]->set_maxSize(getGLInteger(GL_MAX_UNIFORM_BLOCK_SIZE));
+		pools[poolIndex]->set_maxSize(glGetInteger(GL_MAX_UNIFORM_BLOCK_SIZE));
 		poolIndex = (int) SHADER_STORAGE_BUFFER * (int) BUFFER_STORAGE_MODE_LAST + i;
 #ifdef USE_SHARED_SSBO_BUFFER
-		pools[poolIndex]->set_alignment(getGLInteger(GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT));
+		pools[poolIndex]->set_alignment(glGetInteger(GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT));
 #else
 		pools[poolIndex]->set_minSize(1);
 #endif
 		// common: ~2GB
-		pools[poolIndex]->set_maxSize(getGLInteger(GL_MAX_SHADER_STORAGE_BLOCK_SIZE));
+		pools[poolIndex]->set_maxSize(glGetInteger(GL_MAX_SHADER_STORAGE_BLOCK_SIZE));
 		// common: ~4KB
 		poolIndex = (int) ATOMIC_COUNTER_BUFFER * (int) BUFFER_STORAGE_MODE_LAST + i;
-		pools[poolIndex]->set_maxSize(getGLInteger(GL_MAX_ATOMIC_COUNTER_BUFFER_SIZE));
+		pools[poolIndex]->set_maxSize(glGetInteger(GL_MAX_ATOMIC_COUNTER_BUFFER_SIZE));
 
 		poolIndex = (int) DRAW_INDIRECT_BUFFER * (int) BUFFER_STORAGE_MODE_LAST + i;
 		// The Indirect draw buffers are rather small.

--- a/regen/buffer/staged-buffer.cpp
+++ b/regen/buffer/staged-buffer.cpp
@@ -59,7 +59,7 @@ static std::string getName(const StagedBuffer &other, const std::string &name) {
 
 StagedBuffer::StagedBuffer(const StagedBuffer &other, const std::string &name)
 		: BufferObject(other),
-		  ShaderInput(getName(other,name), GL_INVALID_ENUM, 0, 0, 0, GL_FALSE),
+		  ShaderInput(getName(other,name), GL_INVALID_ENUM, 0, 0, 0, false),
 		  stagingFlags_(other.bufferTarget(), other.bufferUpdateHints()) {
 	memoryLayout_ = other.memoryLayout_;
 	hasClientData_ = other.hasClientData_;

--- a/regen/buffer/staging-system.cpp
+++ b/regen/buffer/staging-system.cpp
@@ -106,11 +106,11 @@ StagingSystem::StagingSystem()
 	if (STAGING_RANGE_ALIGNMENT == 0) {
 		// make sure to meet all alignment requirements
 		STAGING_RANGE_ALIGNMENT = std::max(16u,
-										   static_cast<uint32_t>(getGLInteger(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT)));
+										   static_cast<uint32_t>(glGetInteger(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT)));
 		STAGING_RANGE_ALIGNMENT = std::max(STAGING_RANGE_ALIGNMENT,
-										   static_cast<uint32_t>(getGLInteger(GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT)));
+										   static_cast<uint32_t>(glGetInteger(GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT)));
 		STAGING_RANGE_ALIGNMENT = std::max(STAGING_RANGE_ALIGNMENT,
-										   static_cast<uint32_t>(getGLInteger(
+										   static_cast<uint32_t>(glGetInteger(
 												   GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT)));
 		REGEN_INFO("Buffer alignment is " << STAGING_BUFFER_ALIGNMENT << " bytes "
 										  << " and range alignment is " << STAGING_RANGE_ALIGNMENT << " bytes.");

--- a/regen/buffer/vertex-buffer.cpp
+++ b/regen/buffer/vertex-buffer.cpp
@@ -27,7 +27,7 @@ VertexBuffer::VertexBuffer(
 
 VertexBuffer::VertexBuffer(const StagedBuffer &other, const std::string &name)
 		: StagedBuffer(other, name) {
-	enableInput_ = [this](GLint loc) {};
+	enableInput_ = [this](int loc) {};
 	isBufferBlock_ = true;
 	isVertexAttribute_ = false;
 }

--- a/regen/camera/camera-controller.cpp
+++ b/regen/camera/camera-controller.cpp
@@ -150,7 +150,7 @@ void CameraController::jump() {
 	// do nothing
 }
 
-void CameraController::animate(double dt) {
+void CameraController::cpuUpdate(double dt) {
 	step_ = Vec3f::zero();
 	isMoving_ = moveForward_ || moveBackward_ || moveLeft_ || moveRight_;
 	auto orientation = horizontalOrientation_ + meshHorizontalOrientation_;

--- a/regen/camera/camera-controller.cpp
+++ b/regen/camera/camera-controller.cpp
@@ -57,31 +57,31 @@ void CameraController::step(const Vec3f &v) {
 	step_ += v;
 }
 
-void CameraController::lookLeft(GLdouble amount) {
+void CameraController::lookLeft(double amount) {
 	horizontalOrientation_ = fmod(horizontalOrientation_ + amount, 2.0 * M_PI);
 }
 
-void CameraController::lookRight(GLdouble amount) {
+void CameraController::lookRight(double amount) {
 	horizontalOrientation_ = fmod(horizontalOrientation_ - amount, 2.0 * M_PI);
 }
 
 #define REGEN_ORIENT_THRESHOLD_ 0.1
 
-void CameraController::lookUp(GLdouble amount) {
+void CameraController::lookUp(double amount) {
 	verticalOrientation_ = math::clamp<float>(verticalOrientation_ + amount, -orientThreshold_, orientThreshold_);
 }
 
-void CameraController::lookDown(GLdouble amount) {
+void CameraController::lookDown(double amount) {
 	verticalOrientation_ = math::clamp<float>(verticalOrientation_ - amount, -orientThreshold_, orientThreshold_);
 }
 
-void CameraController::zoomIn(GLdouble amount) {
+void CameraController::zoomIn(double amount) {
 	if(isThirdPerson()) {
 		meshDistance_ = math::clamp<float>(meshDistance_ - amount, 0.0, 100.0);
 	}
 }
 
-void CameraController::zoomOut(GLdouble amount) {
+void CameraController::zoomOut(double amount) {
 	if(isThirdPerson()) {
 		meshDistance_ = math::clamp<float>(meshDistance_ + amount, 0.0, 100.0);
 	}
@@ -150,7 +150,7 @@ void CameraController::jump() {
 	// do nothing
 }
 
-void CameraController::animate(GLdouble dt) {
+void CameraController::animate(double dt) {
 	step_ = Vec3f::zero();
 	isMoving_ = moveForward_ || moveBackward_ || moveLeft_ || moveRight_;
 	auto orientation = horizontalOrientation_ + meshHorizontalOrientation_;

--- a/regen/camera/camera-controller.cpp
+++ b/regen/camera/camera-controller.cpp
@@ -29,27 +29,27 @@ void CameraController::setAttachedTo(
 	pos_ = target->position(0).r;
 }
 
-void CameraController::stepUp(const GLfloat &v) {
+void CameraController::stepUp(const float &v) {
 	step(Vec3f(0.0f, v, 0.0f));
 }
 
-void CameraController::stepDown(const GLfloat &v) {
+void CameraController::stepDown(const float &v) {
 	step(Vec3f(0.0f, -v, 0.0f));
 }
 
-void CameraController::stepForward(const GLfloat &v) {
+void CameraController::stepForward(const float &v) {
 	step(dirXZ_ * v);
 }
 
-void CameraController::stepBackward(const GLfloat &v) {
+void CameraController::stepBackward(const float &v) {
 	step(dirXZ_ * (-v));
 }
 
-void CameraController::stepLeft(const GLfloat &v) {
+void CameraController::stepLeft(const float &v) {
 	step(dirSidestep_ * (-v));
 }
 
-void CameraController::stepRight(const GLfloat &v) {
+void CameraController::stepRight(const float &v) {
 	step(dirSidestep_ * v);
 }
 
@@ -142,7 +142,7 @@ void CameraController::updateModel() {
 	}
 }
 
-void CameraController::applyStep(GLfloat dt, const Vec3f &offset) {
+void CameraController::applyStep(float dt, const Vec3f &offset) {
 	pos_ += offset;
 }
 

--- a/regen/camera/camera-controller.h
+++ b/regen/camera/camera-controller.h
@@ -159,42 +159,42 @@ namespace regen {
 		/**
 		 * @param v the amount of camera direction change in left direction.
 		 */
-		void lookLeft(GLdouble v);
+		void lookLeft(double v);
 
 		/**
 		 * @param v the amount of camera direction change in right direction.
 		 */
-		void lookRight(GLdouble v);
+		void lookRight(double v);
 
 		/**
 		 * @param amount the amount of camera direction change in up direction.
 		 */
-		void lookUp(GLdouble amount);
+		void lookUp(double amount);
 
 		/**
 		 * @param amount the amount of camera direction change in down direction.
 		 */
-		void lookDown(GLdouble amount);
+		void lookDown(double amount);
 
 		/**
 		 * @param amount the amount to zoom in.
 		 */
-		void zoomIn(GLdouble amount);
+		void zoomIn(double amount);
 
 		/**
 		 * @param amount the amount to zoom out.
 		 */
-		void zoomOut(GLdouble amount);
+		void zoomOut(double amount);
 
 		/**
 		 * @param orientation the orientation of the camera.
 		 */
-		void setHorizontalOrientation(GLdouble orientation) { horizontalOrientation_ = orientation; }
+		void setHorizontalOrientation(double orientation) { horizontalOrientation_ = orientation; }
 
 		/**
 		 * @param orientation the orientation of the camera.
 		 */
-		void setVerticalOrientation(GLdouble orientation) { verticalOrientation_ = orientation; }
+		void setVerticalOrientation(double orientation) { verticalOrientation_ = orientation; }
 
 		/**
 		 * @param distance the distance to the mesh.
@@ -211,7 +211,7 @@ namespace regen {
 		/**
 		 * @param orientation initial orientation of the mesh relative to the camera.
 		 */
-		void setMeshHorizontalOrientation(GLdouble orientation) { meshHorizontalOrientation_ = orientation; }
+		void setMeshHorizontalOrientation(double orientation) { meshHorizontalOrientation_ = orientation; }
 
 		/**
 		 * Move a step in the direction of the given offset.
@@ -225,7 +225,7 @@ namespace regen {
 		virtual void jump();
 
 		// override Animation
-		void animate(GLdouble dt) override;
+		void animate(double dt) override;
 
 	protected:
 		Mode cameraMode_;

--- a/regen/camera/camera-controller.h
+++ b/regen/camera/camera-controller.h
@@ -225,7 +225,7 @@ namespace regen {
 		virtual void jump();
 
 		// override Animation
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 	protected:
 		Mode cameraMode_;

--- a/regen/camera/camera-controller.h
+++ b/regen/camera/camera-controller.h
@@ -94,32 +94,32 @@ namespace regen {
 		/**
 		 * @param v moving forward toggle.
 		 */
-		void moveForward(GLboolean v) { moveForward_ = v; }
+		void moveForward(bool v) { moveForward_ = v; }
 
 		/**
 		 * @param v moving backward toggle.
 		 */
-		void moveBackward(GLboolean v) { moveBackward_ = v; }
+		void moveBackward(bool v) { moveBackward_ = v; }
 
 		/**
 		 * @param v moving left toggle.
 		 */
-		void moveLeft(GLboolean v) { moveLeft_ = v; }
+		void moveLeft(bool v) { moveLeft_ = v; }
 
 		/**
 		 * @param v moving right toggle.
 		 */
-		void moveRight(GLboolean v) { moveRight_ = v; }
+		void moveRight(bool v) { moveRight_ = v; }
 
 		/**
 		 * @param v moving up toggle.
 		 */
-		void moveUp(GLboolean v) { moveUp_ = v; }
+		void moveUp(bool v) { moveUp_ = v; }
 
 		/**
 		 * @param v moving down toggle.
 		 */
-		void moveDown(GLboolean v) { moveDown_ = v; }
+		void moveDown(bool v) { moveDown_ = v; }
 
 		/**
 		 * @param v the amount to step forward.

--- a/regen/camera/camera-controller.h
+++ b/regen/camera/camera-controller.h
@@ -89,7 +89,7 @@ namespace regen {
 		/**
 		 * @param v move velocity.
 		 */
-		void set_moveAmount(GLfloat v) { moveAmount_ = v; }
+		void set_moveAmount(float v) { moveAmount_ = v; }
 
 		/**
 		 * @param v moving forward toggle.
@@ -124,32 +124,32 @@ namespace regen {
 		/**
 		 * @param v the amount to step forward.
 		 */
-		void stepForward(const GLfloat &v);
+		void stepForward(const float &v);
 
 		/**
 		 * @param v the amount to step backward.
 		 */
-		void stepBackward(const GLfloat &v);
+		void stepBackward(const float &v);
 
 		/**
 		 * @param v the amount to step left.
 		 */
-		void stepLeft(const GLfloat &v);
+		void stepLeft(const float &v);
 
 		/**
 		 * @param v the amount to step right.
 		 */
-		void stepRight(const GLfloat &v);
+		void stepRight(const float &v);
 
 		/**
 		 * @param v the amount to step up.
 		 */
-		void stepUp(const GLfloat &v);
+		void stepUp(const float &v);
 
 		/**
 		 * @param v the amount to step down.
 		 */
-		void stepDown(const GLfloat &v);
+		void stepDown(const float &v);
 
 		/**
 		 * @param v the amount to change the position.
@@ -200,7 +200,7 @@ namespace regen {
 		 * @param distance the distance to the mesh.
 		 * @note only has an effect in third person mode.
 		 */
-		void setMeshDistance(GLfloat distance) { meshDistance_ = distance; }
+		void setMeshDistance(float distance) { meshDistance_ = distance; }
 
 		/**
 		 * @param offset the offset to the "eye position" of the mesh.
@@ -217,7 +217,7 @@ namespace regen {
 		 * Move a step in the direction of the given offset.
 		 * @param offset the offset.
 		 */
-		virtual void applyStep(GLfloat dt, const Vec3f &offset);
+		virtual void applyStep(float dt, const Vec3f &offset);
 
 		/**
 		 * Jump.
@@ -236,7 +236,7 @@ namespace regen {
 		ref_ptr<ModelTransformation> attachedToTransform_;
 		ref_ptr<Mesh> attachedToMesh_;
 		Vec3f meshPos_;
-		GLfloat meshDistance_;
+		float meshDistance_;
 
 		Vec3f pos_;
 		Vec3f step_;

--- a/regen/camera/camera.cpp
+++ b/regen/camera/camera.cpp
@@ -538,7 +538,7 @@ ref_ptr<Camera> createLightCamera(LoadingContext &ctx, scene::SceneInputNode &in
 		return {};
 	}
 	auto numLayer = input.getValue<uint32_t>("num-layer", 1u);
-	auto splitWeight = input.getValue<GLdouble>("split-weight", 0.9);
+	auto splitWeight = input.getValue<double>("split-weight", 0.9);
 	auto cameraType = input.getValue<std::string>("camera-type", "spot");
 	auto near = input.getValue<float>("near", 0.1f);
 	ref_ptr<Camera> lightCamera;

--- a/regen/camera/camera.cpp
+++ b/regen/camera/camera.cpp
@@ -409,7 +409,7 @@ void Camera::setOrtho(float left, float right, float bottom, float top, float ne
 	camStamp_ += 1u;
 }
 
-void Camera::set_isAudioListener(GLboolean isAudioListener) {
+void Camera::set_isAudioListener(bool isAudioListener) {
 	isAudioListener_ = isAudioListener;
 	if (isAudioListener_) {
 		AudioListener::set3f(AL_POSITION, position_[0].xyz());

--- a/regen/camera/camera.cpp
+++ b/regen/camera/camera.cpp
@@ -613,7 +613,7 @@ ProjectionUpdater::ProjectionUpdater(const ref_ptr<Camera> &cam,
 
 void ProjectionUpdater::call(EventObject *, EventData *) {
 	auto windowViewport = screen_->viewport().r;
-	auto windowAspect = (GLfloat) windowViewport.x / (GLfloat) windowViewport.y;
+	auto windowAspect = (float) windowViewport.x / (float) windowViewport.y;
 
 	auto &lastProjParams = cam_->projParams()[0];
 	if (cam_->isOrtho()) {
@@ -709,20 +709,20 @@ ref_ptr<Camera> Camera::createCamera(LoadingContext &ctx, scene::SceneInputNode 
 		cam->setDirection(0, dir);
 
 		if (camType == "ortho" || camType == "orthographic" || camType == "orthogonal") {
-			auto width = input.getValue<GLfloat>("width", 10.0f);
-			auto height = input.getValue<GLfloat>("height", 10.0f);
+			auto width = input.getValue<float>("width", 10.0f);
+			auto height = input.getValue<float>("height", 10.0f);
 			cam->setOrtho(
 					-width / 2.0f, width / 2.0f,
 					-height / 2.0f, height / 2.0f,
-					input.getValue<GLfloat>("near", 0.1f),
-					input.getValue<GLfloat>("far", 200.0f));
+					input.getValue<float>("near", 0.1f),
+					input.getValue<float>("far", 200.0f));
 		} else {
 			auto viewport = ctx.scene()->screen()->viewport();
 			cam->setPerspective(
-					(GLfloat) viewport.r.x / (GLfloat) viewport.r.y,
-					input.getValue<GLfloat>("fov", 45.0f),
-					input.getValue<GLfloat>("near", 0.1f),
-					input.getValue<GLfloat>("far", 200.0f));
+					(float) viewport.r.x / (float) viewport.r.y,
+					input.getValue<float>("fov", 45.0f),
+					input.getValue<float>("near", 0.1f),
+					input.getValue<float>("far", 200.0f));
 			// Update frustum when window size changes
 			ctx.scene()->addEventHandler(Scene::RESIZE_EVENT,
 										 ref_ptr<ProjectionUpdater>::alloc(cam, ctx.scene()->screen()));

--- a/regen/camera/camera.cpp
+++ b/regen/camera/camera.cpp
@@ -16,7 +16,7 @@ namespace regen {
 				: Animation(false, true),
 				  camera_(camera) {}
 
-		void animate(double dt) override {
+		void cpuUpdate(double dt) override {
 			if(camera_->updatePose()) {
 				camera_->updateShaderData(dt);
 			}

--- a/regen/camera/camera.h
+++ b/regen/camera/camera.h
@@ -457,7 +457,7 @@ namespace regen {
 		/**
 		 * @param useAudio true if this camera is the OpenAL audio listener.
 		 */
-		void set_isAudioListener(GLboolean useAudio);
+		void set_isAudioListener(bool useAudio);
 
 		/**
 		 * @return true if this camera is the OpenAL audio listener.

--- a/regen/camera/key-frame-controller.cpp
+++ b/regen/camera/key-frame-controller.cpp
@@ -5,11 +5,11 @@ using namespace regen;
 KeyFrameController::KeyFrameController(const ref_ptr<Camera> &cam)
 		: Animation(false, true),
 		  CameraControllerBase(cam),
-		  repeat_(GL_TRUE),
-		  skipFirstFrameOnLoop_(GL_TRUE),
+		  repeat_(true),
+		  skipFirstFrameOnLoop_(true),
 		  pauseTime_(0.0),
 		  currentPauseDuration_(0.0),
-		  isPaused_(GL_FALSE) {
+		  isPaused_(false) {
 	setAnimationName("controller");
 	camPos_ = cam->position()[0].xyz();
 	camDir_ = cam->direction()[0].xyz();
@@ -136,7 +136,7 @@ void KeyFrameController::animate(double dt) {
 	if (isPaused_) {
 		currentPauseDuration_ += dtSeconds;
 		if(currentPauseDuration_ >= pauseTime_) {
-			isPaused_ = GL_FALSE;
+			isPaused_ = false;
 			dtSeconds = currentPauseDuration_ - pauseTime_;
 			currentPauseDuration_ = 0.0;
 		} else {
@@ -171,7 +171,7 @@ void KeyFrameController::animate(double dt) {
 		}
 		// enter pause mode if pause time is set
 		if (pauseTime_ > 0.0) {
-			isPaused_ = GL_TRUE;
+			isPaused_ = true;
 			currentPauseDuration_ = dtNewFrame;
 			dt_ = 0.0;
 			return;

--- a/regen/camera/key-frame-controller.cpp
+++ b/regen/camera/key-frame-controller.cpp
@@ -113,7 +113,7 @@ Vec3f KeyFrameController::interpolateDirection(const Vec3f &v0, const Vec3f &v1,
 }
 **/
 
-void KeyFrameController::animate(double dt) {
+void KeyFrameController::cpuUpdate(double dt) {
 	double dtSeconds = dt / 1000.0;
 
 	if (it_ == frames_.end()) {
@@ -162,7 +162,7 @@ void KeyFrameController::animate(double dt) {
 				}
 			} else if (currentFrame.anchor->following()) {
 				dt_ = 0.0;
-				animate(dtNewFrame);
+				cpuUpdate(dtNewFrame);
 				return;
 			} else {
 				stopAnimation();
@@ -177,7 +177,7 @@ void KeyFrameController::animate(double dt) {
 			return;
 		} else {
 			dt_ = 0.0;
-			animate(dtNewFrame);
+			cpuUpdate(dtNewFrame);
 			return;
 		}
 	}

--- a/regen/camera/key-frame-controller.cpp
+++ b/regen/camera/key-frame-controller.cpp
@@ -22,7 +22,7 @@ KeyFrameController::KeyFrameController(const ref_ptr<Camera> &cam)
 	updateCamera(camPos_, camDir_, 0.0);
 }
 
-void KeyFrameController::push_back(const ref_ptr<CameraAnchor> &anchor, GLdouble dt) {
+void KeyFrameController::push_back(const ref_ptr<CameraAnchor> &anchor, double dt) {
 	CameraKeyFrame f;
 	f.anchor = anchor;
 	f.dt = dt;
@@ -33,18 +33,18 @@ void KeyFrameController::push_back(const ref_ptr<CameraAnchor> &anchor, GLdouble
 	}
 }
 
-void KeyFrameController::push_back(const Vec3f &pos, const Vec3f &dir, GLdouble dt) {
+void KeyFrameController::push_back(const Vec3f &pos, const Vec3f &dir, double dt) {
 	auto anchor = ref_ptr<FixedCameraAnchor>::alloc(pos, dir);
 	push_back(anchor, dt);
 }
 
-static inline auto easeInOutCubic(GLdouble t, GLdouble intensity) {
+static inline auto easeInOutCubic(double t, double intensity) {
 	t = pow(t, intensity);
 	return t < 0.5 ? 4 * t * t * t : 1 - pow(-2 * t + 2, 3) / 2;
 }
 
-Vec3f KeyFrameController::interpolatePosition(const Vec3f &v0, const Vec3f &v1, GLdouble t) const {
-	GLdouble sample;
+Vec3f KeyFrameController::interpolatePosition(const Vec3f &v0, const Vec3f &v1, double t) const {
+	double sample;
 	if (easeInOutIntensity_ > 0.0) {
 		sample = easeInOutCubic(t, easeInOutIntensity_);
 	} else {
@@ -53,7 +53,7 @@ Vec3f KeyFrameController::interpolatePosition(const Vec3f &v0, const Vec3f &v1, 
     return math::mix(v0, v1, sample);
 }
 
-Vec3f KeyFrameController::interpolateDirection(const Vec3f &v0, const Vec3f &v1, GLdouble t) const {
+Vec3f KeyFrameController::interpolateDirection(const Vec3f &v0, const Vec3f &v1, double t) const {
 	if (v0 == v1) return v0;
 
 	double sample = easeInOutIntensity_ > 0.0
@@ -98,8 +98,8 @@ Vec3f KeyFrameController::interpolateDirection(const Vec3f &v0, const Vec3f &v1,
 }
 
 /**
-Vec3f KeyFrameController::interpolateDirection(const Vec3f &v0, const Vec3f &v1, GLdouble t) const {
-	GLdouble sample;
+Vec3f KeyFrameController::interpolateDirection(const Vec3f &v0, const Vec3f &v1, double t) const {
+	double sample;
 	// skip if the direction is the same
 	if (v0 == v1) {
 		return v0;
@@ -113,8 +113,8 @@ Vec3f KeyFrameController::interpolateDirection(const Vec3f &v0, const Vec3f &v1,
 }
 **/
 
-void KeyFrameController::animate(GLdouble dt) {
-	GLdouble dtSeconds = dt / 1000.0;
+void KeyFrameController::animate(double dt) {
+	double dtSeconds = dt / 1000.0;
 
 	if (it_ == frames_.end()) {
 		// end reached
@@ -148,7 +148,7 @@ void KeyFrameController::animate(GLdouble dt) {
 
 	// reached next frame?
 	if (dt_ > currentFrame.dt) {
-		GLdouble dtNewFrame = dt_ - currentFrame.dt;
+		double dtNewFrame = dt_ - currentFrame.dt;
 		// move to next frame
 		++it_;
 		lastFrame_ = currentFrame;
@@ -186,7 +186,7 @@ void KeyFrameController::animate(GLdouble dt) {
 	Vec3f pos1 = currentFrame.anchor->position();
 	Vec3f dir0 = lastFrame_.anchor->direction();
 	Vec3f dir1 = currentFrame.anchor->direction();
-	GLdouble t = currentFrame.dt > 0.0 ? dt_ / currentFrame.dt : 1.0;
+	double t = currentFrame.dt > 0.0 ? dt_ / currentFrame.dt : 1.0;
 	dir0.normalize();
 	dir1.normalize();
 

--- a/regen/camera/key-frame-controller.h
+++ b/regen/camera/key-frame-controller.h
@@ -51,7 +51,7 @@ namespace regen {
 		void setRepeat(bool repeat) { repeat_ = repeat; }
 
 		// override
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 	protected:
 		struct CameraKeyFrame {

--- a/regen/camera/key-frame-controller.h
+++ b/regen/camera/key-frame-controller.h
@@ -48,7 +48,7 @@ namespace regen {
 		/**
 		 * @param repeat the repeat flag.
 		 */
-		void setRepeat(GLboolean repeat) { repeat_ = repeat; }
+		void setRepeat(bool repeat) { repeat_ = repeat; }
 
 		// override
 		void animate(double dt) override;
@@ -65,12 +65,12 @@ namespace regen {
 		Vec3f camDir_;
 		double dt_;
 		double easeInOutIntensity_;
-		GLboolean repeat_;
-		GLboolean skipFirstFrameOnLoop_;
+		bool repeat_;
+		bool skipFirstFrameOnLoop_;
 
 		double pauseTime_;
 		double currentPauseDuration_;
-		GLboolean isPaused_;
+		bool isPaused_;
 
 		Vec3f interpolatePosition(const Vec3f &v0, const Vec3f &v1, double t) const;
 		Vec3f interpolateDirection(const Vec3f &v0, const Vec3f &v1, double t) const;

--- a/regen/camera/key-frame-controller.h
+++ b/regen/camera/key-frame-controller.h
@@ -28,22 +28,22 @@ namespace regen {
 		/**
 		 * Adds a frame to the list of key frames for camera animation.
 		 */
-		void push_back(const Vec3f &pos, const Vec3f &dir, GLdouble dt);
+		void push_back(const Vec3f &pos, const Vec3f &dir, double dt);
 
 		/**
 		 * Adds a frame to the list of key frames for camera animation.
 		 */
-		void push_back(const ref_ptr<CameraAnchor> &anchor, GLdouble dt);
+		void push_back(const ref_ptr<CameraAnchor> &anchor, double dt);
 
 		/**
 		 * @param intensity the intensity of the ease in/out effect.
 		 */
-		void setEaseInOutIntensity(GLdouble intensity) { easeInOutIntensity_ = intensity; }
+		void setEaseInOutIntensity(double intensity) { easeInOutIntensity_ = intensity; }
 
 		/**
 		 * @param pauseTime the pause time between key frames.
 		 */
-		void setPauseBetweenFrames(GLdouble pauseTime) { pauseTime_ = pauseTime; }
+		void setPauseBetweenFrames(double pauseTime) { pauseTime_ = pauseTime; }
 
 		/**
 		 * @param repeat the repeat flag.
@@ -51,29 +51,29 @@ namespace regen {
 		void setRepeat(GLboolean repeat) { repeat_ = repeat; }
 
 		// override
-		void animate(GLdouble dt) override;
+		void animate(double dt) override;
 
 	protected:
 		struct CameraKeyFrame {
 			ref_ptr<CameraAnchor> anchor;
-			GLdouble dt;
+			double dt;
 		};
 		std::list<CameraKeyFrame> frames_;
 		std::list<CameraKeyFrame>::iterator it_;
 		CameraKeyFrame lastFrame_;
 		Vec3f camPos_;
 		Vec3f camDir_;
-		GLdouble dt_;
-		GLdouble easeInOutIntensity_;
+		double dt_;
+		double easeInOutIntensity_;
 		GLboolean repeat_;
 		GLboolean skipFirstFrameOnLoop_;
 
-		GLdouble pauseTime_;
-		GLdouble currentPauseDuration_;
+		double pauseTime_;
+		double currentPauseDuration_;
 		GLboolean isPaused_;
 
-		Vec3f interpolatePosition(const Vec3f &v0, const Vec3f &v1, GLdouble t) const;
-		Vec3f interpolateDirection(const Vec3f &v0, const Vec3f &v1, GLdouble t) const;
+		Vec3f interpolatePosition(const Vec3f &v0, const Vec3f &v1, double t) const;
+		Vec3f interpolateDirection(const Vec3f &v0, const Vec3f &v1, double t) const;
 	};
 } // namespace
 

--- a/regen/camera/light-camera.cpp
+++ b/regen/camera/light-camera.cpp
@@ -8,7 +8,7 @@ namespace regen {
 		explicit LightCameraAnimation(LightCamera *camera)
 				: Animation(false, true),
 				  camera_(camera) {}
-		void animate(double dt) override {
+		void cpuUpdate(double dt) override {
 			if(camera_->updateLight()) {
 				camera_->lightCamera()->updateShaderData(static_cast<float>(dt));
 				camera_->updateShadowData();

--- a/regen/camera/reflection-camera.cpp
+++ b/regen/camera/reflection-camera.cpp
@@ -8,7 +8,7 @@ namespace regen {
 		explicit ReflectionUpdater(ReflectionCamera *camera)
 				: Animation(false, true),
 				  camera_(camera) {}
-		void animate(double dt) override {
+		void cpuUpdate(double dt) override {
 			if(camera_->updateReflection()) {
 				camera_->updateShaderData(static_cast<float>(dt));
 			}

--- a/regen/camera/reflection-camera.h
+++ b/regen/camera/reflection-camera.h
@@ -21,7 +21,7 @@ namespace regen {
 				const ref_ptr<Camera> &cam,
 				const ref_ptr<Mesh> &mesh,
 				uint32_t vertexIndex = 0,
-				bool hasBackFace = GL_FALSE);
+				bool hasBackFace = false);
 
 		/**
 		 * @param userCamera The user camera to reflect.
@@ -33,7 +33,7 @@ namespace regen {
 				const ref_ptr<Camera> &userCamera,
 				const Vec3f &reflectorNormal,
 				const Vec3f &reflectorPoint,
-				bool hasBackFace = GL_FALSE);
+				bool hasBackFace = false);
 
 		/**
 		 * Update reflection camera.

--- a/regen/effects/bloom-pass.cpp
+++ b/regen/effects/bloom-pass.cpp
@@ -59,8 +59,8 @@ void BloomPass::downsample(RenderState *rs) {
 
 	downsampleState_->enable(rs);
 	glUniform2f(inverseInputSizeLocDS_,
-				static_cast<GLfloat>(1.0 / nextInputTexture->width()),
-				static_cast<GLfloat>(1.0 / nextInputTexture->height()));
+				static_cast<float>(1.0 / nextInputTexture->width()),
+				static_cast<float>(1.0 / nextInputTexture->height()));
 
 	for (auto &mip: bloomTexture_->mips()) {
 		glNamedFramebufferTexture(fbo_->id(),

--- a/regen/effects/bloom-pass.h
+++ b/regen/effects/bloom-pass.h
@@ -38,14 +38,14 @@ namespace regen {
 
 		ref_ptr<State> upsampleState_;
 		ref_ptr<ShaderState> upsampleShader_;
-		GLint inverseViewportLocUS_;
-		GLint inputTextureLocUS_;
+		int inverseViewportLocUS_;
+		int inputTextureLocUS_;
 
 		ref_ptr<State> downsampleState_;
 		ref_ptr<ShaderState> downsampleShader_;
-		GLint inverseViewportLocDS_;
-		GLint inverseInputSizeLocDS_;
-		GLint inputTextureLocDS_;
+		int inverseViewportLocDS_;
+		int inverseInputSizeLocDS_;
+		int inputTextureLocDS_;
 
 		void downsample(RenderState *rs);
 

--- a/regen/effects/filter.cpp
+++ b/regen/effects/filter.cpp
@@ -104,10 +104,10 @@ void Filter::setInput(
 /////////////////
 
 
-FilterSequence::FilterSequence(const ref_ptr<Texture> &input, GLboolean bindInput)
+FilterSequence::FilterSequence(const ref_ptr<Texture> &input, bool bindInput)
 		: State(),
 		  input_(input),
-		  clearFirstFilter_(GL_FALSE),
+		  clearFirstFilter_(false),
 		  clearColor_(Vec4f::zero()),
 		  lastWidth_(0u),
 		  lastHeight_(0u),

--- a/regen/effects/filter.cpp
+++ b/regen/effects/filter.cpp
@@ -185,7 +185,7 @@ ref_ptr<FilterSequence> FilterSequence::load(LoadingContext &ctx, scene::SceneIn
 		}
 		filterSeq->addFilter(ref_ptr<Filter>::alloc(
 				n->getValue("shader"),
-				n->getValue<GLfloat>("scale", 1.0f)));
+				n->getValue<float>("scale", 1.0f)));
 	}
 
 	StateConfigurer shaderConfigurer;

--- a/regen/effects/filter.h
+++ b/regen/effects/filter.h
@@ -109,7 +109,7 @@ namespace regen {
 		 * @param input the input texture.
 		 * @param bindInput bind and activate input before filtering.
 		 */
-		explicit FilterSequence(const ref_ptr<Texture> &input, GLboolean bindInput = GL_TRUE);
+		explicit FilterSequence(const ref_ptr<Texture> &input, bool bindInput = true);
 
 		static ref_ptr<FilterSequence> load(LoadingContext &ctx, scene::SceneInputNode &input);
 

--- a/regen/gl-types/draw-command.h
+++ b/regen/gl-types/draw-command.h
@@ -10,7 +10,7 @@ namespace regen {
 	 *        uint32_t count;           // index count
 	 *        uint32_t instanceCount;
 	 *        uint32_t firstIndex;
-	 *        GLint baseVertex;
+	 *        int baseVertex;
 	 *        uint32_t baseInstance;
 	 *    };
 	 *    struct IndirectArrayData {

--- a/regen/gl-types/gl-enum.cpp
+++ b/regen/gl-types/gl-enum.cpp
@@ -18,7 +18,7 @@ static const GLenum glslStages__[] = {
 		, GL_COMPUTE_SHADER
 #endif
 };
-static const GLint glslStageCount__ = sizeof(glslStages__) / sizeof(GLenum);
+static const int glslStageCount__ = sizeof(glslStages__) / sizeof(GLenum);
 
 static std::string getValue(const std::string &in) {
 	std::string val = in;
@@ -31,7 +31,7 @@ static std::string getValue(const std::string &in) {
 
 const GLenum *glenum::glslStages() { return glslStages__; }
 
-GLint glenum::glslStageCount() { return glslStageCount__; }
+int glenum::glslStageCount() { return glslStageCount__; }
 
 std::string glenum::glslStageName(GLenum stage) {
 	switch (stage) {

--- a/regen/gl-types/gl-enum.h
+++ b/regen/gl-types/gl-enum.h
@@ -278,7 +278,7 @@ namespace regen {
 		/**
 		 * Number of known shader stages.
 		 */
-		GLint glslStageCount();
+		int glslStageCount();
 
 		/**
 		 * Maps stage enum to name representation.

--- a/regen/gl-types/gl-param.cpp
+++ b/regen/gl-types/gl-param.cpp
@@ -20,7 +20,7 @@ namespace regen {
 		if (it != store.params_.end()) {
 			return it->second;
 		} else {
-			GLfloat value;
+			float value;
 			glGetFloatv(param, &value);
 			store.params_[param] = value;
 			return value;

--- a/regen/gl-types/gl-param.cpp
+++ b/regen/gl-types/gl-param.cpp
@@ -33,7 +33,7 @@ namespace regen {
 		if (it != store.params_.end()) {
 			return it->second;
 		} else {
-			GLdouble value;
+			double value;
 			glGetDoublev(param, &value);
 			store.params_[param] = value;
 			return value;

--- a/regen/gl-types/gl-param.cpp
+++ b/regen/gl-types/gl-param.cpp
@@ -46,7 +46,7 @@ namespace regen {
 		if (it != store.params_.end()) {
 			return it->second;
 		} else {
-			GLint value;
+			int value;
 			glGetIntegerv(param, &value);
 			store.params_[param] = value;
 			return value;
@@ -60,7 +60,7 @@ namespace regen {
 			return it->second;
 		} else {
 			uint32_t value;
-			glGetIntegerv(param, (GLint *) &value);
+			glGetIntegerv(param, (int *) &value);
 			store.params_[param] = value;
 			return value;
 		}

--- a/regen/gl-types/gl-util.cpp
+++ b/regen/gl-types/gl-util.cpp
@@ -82,26 +82,26 @@ namespace regen {
 		return v;
 	}
 
-	GLint getGLInteger(GLenum e) {
-		GLint i = 0;
+	int glGetInteger(GLenum e) {
+		int i = 0;
 		glGetIntegerv(e, &i);
 		return i;
 	}
 
-	GLint getGLInteger(const std::string &ext, GLenum key, GLint defaultValue) {
-		GLint i = defaultValue;
+	int glGetInteger(const std::string &ext, GLenum key, int defaultValue) {
+		int i = defaultValue;
 		if (glewIsSupported(ext.c_str())) { glGetIntegerv(key, &i); }
 		return i;
 	}
 
-	GLfloat getGLFloat(GLenum e) {
+	GLfloat glGetFloat(GLenum e) {
 		GLfloat i = 0;
 		glGetFloatv(e, &i);
 		return i;
 	}
 
-	GLint getGLBufferInteger(GLenum target, GLenum e) {
-		GLint i = 0;
+	int getGLBufferInteger(GLenum target, GLenum e) {
+		int i = 0;
 		glGetBufferParameteriv(target, e, &i);
 		return i;
 	}

--- a/regen/gl-types/gl-util.cpp
+++ b/regen/gl-types/gl-util.cpp
@@ -94,8 +94,8 @@ namespace regen {
 		return i;
 	}
 
-	GLfloat glGetFloat(GLenum e) {
-		GLfloat i = 0;
+	float glGetFloat(GLenum e) {
+		float i = 0;
 		glGetFloatv(e, &i);
 		return i;
 	}

--- a/regen/gl-types/gl-util.h
+++ b/regen/gl-types/gl-util.h
@@ -64,20 +64,20 @@ namespace regen {
 	/**
 	 * Query a GL integer attribute.
 	 */
-	GLint getGLInteger(GLenum e);
+	int glGetInteger(GLenum e);
 
 	/**
 	 * Query a GL integer attribute.
 	 * Check for required extension if not supported return default value.
 	 */
-	GLint getGLInteger(const std::string &ext, GLenum key, GLint defaultValue);
+	int glGetInteger(const std::string &ext, GLenum key, int defaultValue);
 
 	/**
 	 * Query a GL float attribute.
 	 */
-	GLfloat getGLFloat(GLenum e);
+	GLfloat glGetFloat(GLenum e);
 
-	GLint getGLBufferInteger(GLenum target, GLenum e);
+	int getGLBufferInteger(GLenum target, GLenum e);
 
 } // namespace
 

--- a/regen/gl-types/gl-util.h
+++ b/regen/gl-types/gl-util.h
@@ -75,7 +75,7 @@ namespace regen {
 	/**
 	 * Query a GL float attribute.
 	 */
-	GLfloat glGetFloat(GLenum e);
+	float glGetFloat(GLenum e);
 
 	int getGLBufferInteger(GLenum target, GLenum e);
 

--- a/regen/gl-types/input-location.h
+++ b/regen/gl-types/input-location.h
@@ -9,13 +9,13 @@ namespace regen {
 	 */
 	struct InputLocation {
 		ref_ptr<ShaderInput> input; /**< the shader input. */
-		GLint location; /**< the input location. */
+		int location; /**< the input location. */
 		uint32_t uploadStamp; /**< time stamp of last upload. */
 		/**
 		 * @param _input input data.
 		 * @param _location input location in shader.
 		 */
-		InputLocation(const ref_ptr<ShaderInput> &_input, GLint _location)
+		InputLocation(const ref_ptr<ShaderInput> &_input, int _location)
 				: input(_input), location(_location), uploadStamp(0) {}
 
 		InputLocation()

--- a/regen/gl-types/render-state.cpp
+++ b/regen/gl-types/render-state.cpp
@@ -181,16 +181,16 @@ template<typename T> void Regen_VAO(T v)
 template<typename T> void regen_noop_arg1(const T &v) {}
 
 RenderState::RenderState()
-		: maxDrawBuffers_(getGLInteger(GL_MAX_DRAW_BUFFERS)),
-		  maxTextureUnits_(getGLInteger(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS)),
-		  maxViewports_(getGLInteger(GL_MAX_VIEWPORTS)),
-		  maxAttributes_(getGLInteger(GL_MAX_VERTEX_ATTRIBS)),
-		  maxFeedbackBuffers_(getGLInteger(GL_MAX_TRANSFORM_FEEDBACK_BUFFERS)),
-		  maxUniformBuffers_(getGLInteger("GL_ARB_uniform_buffer_object",
+		: maxDrawBuffers_(glGetInteger(GL_MAX_DRAW_BUFFERS)),
+		  maxTextureUnits_(glGetInteger(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS)),
+		  maxViewports_(glGetInteger(GL_MAX_VIEWPORTS)),
+		  maxAttributes_(glGetInteger(GL_MAX_VERTEX_ATTRIBS)),
+		  maxFeedbackBuffers_(glGetInteger(GL_MAX_TRANSFORM_FEEDBACK_BUFFERS)),
+		  maxUniformBuffers_(glGetInteger("GL_ARB_uniform_buffer_object",
 										  GL_MAX_UNIFORM_BUFFER_BINDINGS, 0)),
-		  maxAtomicCounterBuffers_(getGLInteger("GL_ARB_shader_atomic_counters",
+		  maxAtomicCounterBuffers_(glGetInteger("GL_ARB_shader_atomic_counters",
 												GL_MAX_ATOMIC_COUNTER_BUFFER_BINDINGS, 0)),
-		  maxShaderStorageBuffers_(getGLInteger("GL_ARB_shader_storage_buffer_object",
+		  maxShaderStorageBuffers_(glGetInteger("GL_ARB_shader_storage_buffer_object",
 												GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS, 0)),
 		  feedbackCount_(0),
 		  toggles_(TOGGLE_STATE_LAST, regen_noop_arg1, Regen_Toggle),
@@ -254,7 +254,7 @@ RenderState::RenderState()
 			GL_CULL_FACE, GL_DEPTH_TEST,
 			GL_TEXTURE_CUBE_MAP_SEAMLESS
 	};
-	for (GLint i = 0; i < TOGGLE_STATE_LAST; ++i) {
+	for (int i = 0; i < TOGGLE_STATE_LAST; ++i) {
 		GLenum e = toggleToID((Toggle) i);
 		// avoid initial state set for unsupported states
 		if (e == GL_NONE) continue;

--- a/regen/gl-types/render-state.cpp
+++ b/regen/gl-types/render-state.cpp
@@ -93,7 +93,7 @@ static inline void Regen_PatchLevel(const PatchLevels &l) {
 
 typedef void (GLAPIENTRY *ToggleFunc)(GLenum);
 
-inline void Regen_Toggle(uint32_t index, const GLboolean &v) {
+inline void Regen_Toggle(uint32_t index, const bool &v) {
 	GLenum toggleID = RenderState::toggleToID((RenderState::Toggle) index);
 	static ToggleFunc toggleFunctions[2] = {glDisable, glEnable};
 	toggleFunctions[v](toggleID);
@@ -259,19 +259,19 @@ RenderState::RenderState()
 		// avoid initial state set for unsupported states
 		if (e == GL_NONE) continue;
 
-		GLboolean enabled = GL_FALSE;
+		bool enabled = false;
 		for (uint32_t j = 0; j < sizeof(enabledToggles) / sizeof(GLenum); ++j) {
 			if (enabledToggles[j] == e) {
-				enabled = GL_TRUE;
+				enabled = true;
 				break;
 			}
 		}
 		toggles_.push(i, enabled);
 	}
-	toggles_.push(RenderState::BLEND, GL_FALSE);
+	toggles_.push(RenderState::BLEND, false);
 	// init value states
 	cullFace_.push(GL_BACK);
-	depthMask_.push(GL_TRUE);
+	depthMask_.push(true);
 	depthFunc_.push(GL_LEQUAL);
 	depthRange_.push(DepthRange(0.0, 1.0));
 	blendEquation_.push(BlendEquation::create(GL_FUNC_ADD));
@@ -280,7 +280,7 @@ RenderState::RenderState()
 	polygonOffset_.push(Vec2f::zero());
 	pointSize_.push(1.0);
 	lineWidth_.push(1.0);
-	colorMask_.push(ColorMask::create(GL_TRUE));
+	colorMask_.push(ColorMask::create(true));
 	logicOp_.push(GL_COPY);
 	frontFace_.push(GL_CCW);
 	pointFadeThreshold_.push(1.0);

--- a/regen/gl-types/render-state.h
+++ b/regen/gl-types/render-state.h
@@ -626,13 +626,13 @@ namespace regen {
 		 * Specify the diameter of rasterized points.
 		 * The initial value is 1.
 		 */
-		inline ByValueStateStack<GLfloat> &pointSize() { return pointSize_; }
+		inline ByValueStateStack<float> &pointSize() { return pointSize_; }
 
 		/**
 		 * Specifies the threshold value to which point sizes are clamped
 		 * if they exceed the specified value. The default value is 1.0.
 		 */
-		inline KeyedStateStack<GLfloat> &pointFadeThreshold() { return pointFadeThreshold_; }
+		inline KeyedStateStack<float> &pointFadeThreshold() { return pointFadeThreshold_; }
 
 		/**
 		 * Specify the point sprite texture coordinate origin,
@@ -662,12 +662,12 @@ namespace regen {
 		 * Specify the width of rasterized lines.
 		 * The initial value is 1.
 		 */
-		inline ByValueStateStack<GLfloat> &lineWidth() { return lineWidth_; }
+		inline ByValueStateStack<float> &lineWidth() { return lineWidth_; }
 
 		/**
 		 * Specifies minimum rate at which sample shaing takes place.
 		 */
-		inline ByValueStateStack<GLfloat> &sampleShading() { return minSampleShading_; }
+		inline ByValueStateStack<float> &sampleShading() { return minSampleShading_; }
 
 		/**
 		 * Specify a logical pixel operation for rendering.
@@ -737,8 +737,8 @@ namespace regen {
 		KeyedStateStack<GLenum> polygonMode_;
 		ByReferenceStateStack<Vec2f> polygonOffset_;
 
-		ByValueStateStack<GLfloat> pointSize_;
-		KeyedStateStack<GLfloat> pointFadeThreshold_;
+		ByValueStateStack<float> pointSize_;
+		KeyedStateStack<float> pointFadeThreshold_;
 		KeyedStateStack<int> pointSpriteOrigin_;
 
 		KeyedStateStack<int> patchVertices_;
@@ -746,8 +746,8 @@ namespace regen {
 
 		IndexedStateStack<ColorMask> colorMask_;
 
-		ByValueStateStack<GLfloat> lineWidth_;
-		ByValueStateStack<GLfloat> minSampleShading_;
+		ByValueStateStack<float> lineWidth_;
+		ByValueStateStack<float> minSampleShading_;
 		ByValueStateStack<GLenum> logicOp_;
 		ByValueStateStack<GLenum> frontFace_;
 

--- a/regen/gl-types/render-state.h
+++ b/regen/gl-types/render-state.h
@@ -33,7 +33,7 @@ namespace regen {
 		GLenum func_;
 		/** specifies the reference value for the stencil test.
 		 * The initial value is 0. */
-		GLint ref_;
+		int ref_;
 		/** specifies a mask that is ANDed with both the reference value
 		 * and the stored stencil value when the test is done.
 		 * The initial value is all 1's. */
@@ -639,13 +639,13 @@ namespace regen {
 		 * either GL_LOWER_LEFT or GL_UPPER_LEFT.
 		 * The default value is GL_UPPER_LEFT.
 		 */
-		inline KeyedStateStack<GLint> &pointSpriteOrigin() { return pointSpriteOrigin_; }
+		inline KeyedStateStack<int> &pointSpriteOrigin() { return pointSpriteOrigin_; }
 
 		/**
 		 * Specifies the number of vertices that
 		 * will be used to make up a single patch primitive.
 		 */
-		inline KeyedStateStack<GLint> &patchVertices() { return patchVertices_; }
+		inline KeyedStateStack<int> &patchVertices() { return patchVertices_; }
 
 		/**
 		 * Specifies the default outer or inner tessellation levels
@@ -678,15 +678,15 @@ namespace regen {
 		inline ByValueStateStack<GLenum> &logicOp() { return logicOp_; }
 
 	protected:
-		GLint maxDrawBuffers_;
-		GLint maxTextureUnits_;
-		GLint maxViewports_;
-		GLint maxAttributes_;
-		GLint maxFeedbackBuffers_;
-		GLint maxUniformBuffers_;
-		GLint maxAtomicCounterBuffers_;
-		GLint maxShaderStorageBuffers_;
-		GLint feedbackCount_;
+		int maxDrawBuffers_;
+		int maxTextureUnits_;
+		int maxViewports_;
+		int maxAttributes_;
+		int maxFeedbackBuffers_;
+		int maxUniformBuffers_;
+		int maxAtomicCounterBuffers_;
+		int maxShaderStorageBuffers_;
+		int feedbackCount_;
 
 		IndexedStateStack<GLboolean> toggles_;
 
@@ -739,9 +739,9 @@ namespace regen {
 
 		ByValueStateStack<GLfloat> pointSize_;
 		KeyedStateStack<GLfloat> pointFadeThreshold_;
-		KeyedStateStack<GLint> pointSpriteOrigin_;
+		KeyedStateStack<int> pointSpriteOrigin_;
 
-		KeyedStateStack<GLint> patchVertices_;
+		KeyedStateStack<int> patchVertices_;
 		ByReferenceStateStack<PatchLevels> patchLevel_;
 
 		IndexedStateStack<ColorMask> colorMask_;

--- a/regen/gl-types/render-state.h
+++ b/regen/gl-types/render-state.h
@@ -269,7 +269,7 @@ namespace regen {
 			/**
 			 * If enabled,
 			 * the fragment's coverage is ANDed with the temporary coverage value.  If
-			 * GL_SAMPLE_COVERAGE_INVERT is set to GL_TRUE, invert the coverage value.
+			 * GL_SAMPLE_COVERAGE_INVERT is set to true, invert the coverage value.
 			 */
 			SAMPLE_COVERAGE,
 			/**
@@ -335,7 +335,7 @@ namespace regen {
 		/**
 		 * Returns true if a transform feedback operation was started.
 		 */
-		inline GLboolean isTransformFeedbackAcive() const { return feedbackCount_ > 0; }
+		inline bool isTransformFeedbackAcive() const { return feedbackCount_ > 0; }
 
 		/**
 		 * Start transform feedback operation.
@@ -358,7 +358,7 @@ namespace regen {
 		/**
 		 * Enable or disable server-side GL capabilities.
 		 */
-		inline IndexedStateStack<GLboolean> &toggles() { return toggles_; }
+		inline IndexedStateStack<bool> &toggles() { return toggles_; }
 
 		/**
 		 * bind a buffer to given target.
@@ -515,7 +515,7 @@ namespace regen {
 
 		/**
 		 * Specifies whether the depth buffer is enabled for writing.
-		 * If flag is GL_FALSE, depth buffer writing is disabled.
+		 * If flag is false, depth buffer writing is disabled.
 		 * Otherwise, it is enabled. Initially, depth buffer writing is enabled.
 		 */
 		inline ByValueStateStack<GLboolean> &depthMask() { return depthMask_; }
@@ -688,7 +688,7 @@ namespace regen {
 		int maxShaderStorageBuffers_;
 		int feedbackCount_;
 
-		IndexedStateStack<GLboolean> toggles_;
+		IndexedStateStack<bool> toggles_;
 
 		std::map<uint32_t,uint32_t> bufferBaseBindings_[4];
 		KeyedStateStack<uint32_t> arrayBuffer_;

--- a/regen/math/simd.h
+++ b/regen/math/simd.h
@@ -454,6 +454,19 @@ namespace regen {
 		}
 
 		/**
+		 * Blend two batches based on a mask.
+		 * For each element, if the corresponding element in the mask has its sign bit set,
+		 * the element from 'other' is selected; otherwise, the element from this batch is retained.
+		 * @param other The other batch to blend with.
+		 * @param mask The mask batch determining which elements to select from 'other'.
+		 * @return A blended BatchOf_float.
+		 */
+		BatchOf_float blend(const BatchOf_float &other, const BatchOf_float &mask) const {
+			// select elements from 'other' where the sign bit of 'mask' is set
+			return BatchOf_float{ _mm256_blendv_ps(c, other.c, mask.c)};
+		}
+
+		/**
 		 * Convert the comparison mask to an 8-bit bitmask.
 		 * Each bit in the returned byte corresponds to an element in the batch.
 		 * @return An 8-bit bitmask representing the comparison results.

--- a/regen/math/simd.h
+++ b/regen/math/simd.h
@@ -548,6 +548,40 @@ namespace regen {
 			return BatchOf_int32{simd::set1_epi32(v)};
 		}
 
+		/**
+		 * Fill an array of aligned int32_t with a specified value using SIMD.
+		 * @param data Pointer to the aligned int32_t array to fill.
+		 * @param numElements Number of elements to fill.
+		 * @param value The int32_t value to fill the array with.
+		 */
+		template <typename IntType>
+		static void fillAligned(IntType* __restrict data, size_t numElements, IntType value) {
+			size_t i = 0;
+			BatchOf_int32 v = fromScalar(value);
+			for (; i + simd::RegisterWidth <= numElements; i += simd::RegisterWidth) {
+				v.storeAligned(data + i);
+			}
+			// Tail loop (in case size is not divisible by 8)
+			for (; i < numElements; ++i) { data[i] = value; }
+		}
+
+		/**
+		 * Fill an array of unaligned int32_t with a specified value using SIMD.
+		 * @param data Pointer to the unaligned int32_t array to fill.
+		 * @param numElements Number of elements to fill.
+		 * @param value The int32_t value to fill the array with.
+		 */
+		template <typename IntType>
+		static void fillUnaligned(IntType* __restrict data, size_t numElements, IntType value) {
+			size_t i = 0;
+			BatchOf_int32 v = fromScalar(value);
+			for (; i + simd::RegisterWidth <= numElements; i += simd::RegisterWidth) {
+				v.storeUnaligned(data + i);
+			}
+			// Tail loop (in case size is not divisible by 8)
+			for (; i < numElements; ++i) { data[i] = value; }
+		}
+
 		static BatchOf_int32 castFloatBatch(const BatchOf_float &v) {
 			return BatchOf_int32{_mm256_castps_si256(v.c)};
 		}

--- a/regen/math/simd.h
+++ b/regen/math/simd.h
@@ -385,6 +385,15 @@ namespace regen {
 		template <typename T>
 		BatchOf_float operator>=(const T &other) const { return other.cmp_lt(*this); }
 
+		/**
+		 * Convert the comparison mask to a float batch.
+		 * Each element in the returned batch will be 1.0f if the corresponding element in this batch is non-zero, else 0.0f.
+		 * @return A BatchOf_float representing the mask as floats.
+		 */
+		BatchOf_float maskToFloat() const {
+			return { _mm256_and_ps(c, _mm256_set1_ps(1.0f)) };
+		}
+
 		template <typename T>
 		BatchOf_float operator&&(const T &other) const { return cmp_and(other); }
 		template <typename T>

--- a/regen/math/vector.cpp
+++ b/regen/math/vector.cpp
@@ -22,7 +22,7 @@ namespace regen {
 		Vec3f edge2 = vertices[2] - vertices[0];
 		Vec2f texEdge1 = texco[1] - texco[0];
 		Vec2f texEdge2 = texco[2] - texco[0];
-		GLfloat det = texEdge1.x * texEdge2.y - texEdge2.x * texEdge1.y;
+		float det = texEdge1.x * texEdge2.y - texEdge2.x * texEdge1.y;
 
 		if (math::isApprox(det, 0.0)) {
 			tangent = Vec3f(1.0, 0.0, 0.0);
@@ -47,7 +47,7 @@ namespace regen {
 
 		Vec3f bitangent = normal.cross(tangent);
 		// Calculate the handedness of the local tangent space.
-		GLfloat handedness = (bitangent.dot(binormal) < 0.0f) ? 1.0f : -1.0f;
+		float handedness = (bitangent.dot(binormal) < 0.0f) ? 1.0f : -1.0f;
 
 		return {tangent.x, tangent.y, tangent.z, handedness};
 	}

--- a/regen/objects/assimp-importer.cpp
+++ b/regen/objects/assimp-importer.cpp
@@ -44,7 +44,7 @@ static void assimpLog(const char *msg, char *) {
 
 static const struct aiScene *importFile(
 		const string &assimpFile,
-		GLint userSpecifiedFlags) {
+		int userSpecifiedFlags) {
 	// get a handle to the predefined STDOUT log stream and attach
 	// it to the logging system. It remains active for all further
 	// calls to aiImportFile(Ex) and aiApplyPostProcessing.
@@ -978,7 +978,7 @@ uint32_t AssetImporter::numBoneWeights(Mesh *meshState) {
 
 	auto *counter = new uint32_t[meshState->numVertices()];
 	uint32_t numWeights = 1;
-	for (GLint i = 0; i < meshState->numVertices(); ++i) counter[i] = 0u;
+	for (int i = 0; i < meshState->numVertices(); ++i) counter[i] = 0u;
 	for (uint32_t boneIndex = 0; boneIndex < mesh->mNumBones; ++boneIndex) {
 		aiBone *assimpBone = mesh->mBones[boneIndex];
 		for (uint32_t t = 0; t < assimpBone->mNumWeights; ++t) {

--- a/regen/objects/assimp-importer.cpp
+++ b/regen/objects/assimp-importer.cpp
@@ -49,7 +49,7 @@ static const struct aiScene *importFile(
 	// it to the logging system. It remains active for all further
 	// calls to aiImportFile(Ex) and aiApplyPostProcessing.
 	static struct aiLogStream stream;
-	static GLboolean isLoggingInitialled = false;
+	static bool isLoggingInitialled = false;
 	if (!isLoggingInitialled) {
 		stream.callback = assimpLog;
 		stream.user = nullptr;
@@ -293,7 +293,7 @@ static void loadTexture(
 			REGEN_WARN("aiTextureFlags_UseAlpha is not supported.");
 		}
 		if (intVal & aiTextureFlags_IgnoreAlpha) {
-			texState->set_ignoreAlpha(GL_TRUE);
+			texState->set_ignoreAlpha(true);
 		}
 	}
 
@@ -662,7 +662,7 @@ std::vector<ref_ptr<Material> > AssetImporter::loadMaterials() {
 			mat->set_fillMode(GL_FILL);
 		}
 		if (AI_SUCCESS == aiMat->Get(AI_MATKEY_TWOSIDED, intVal)) {
-			mat->set_twoSided(intVal ? GL_TRUE : GL_FALSE);
+			mat->set_twoSided(intVal ? true : false);
 		}
 	}
 

--- a/regen/objects/assimp-importer.cpp
+++ b/regen/objects/assimp-importer.cpp
@@ -115,16 +115,16 @@ void AssetImporter::setAiProcessFlags_Regen() {
 ///////////// LIGHTS
 
 static void setLightRadius(aiLight *aiLight, ref_ptr<Light> &light) {
-	GLfloat ax = aiLight->mAttenuationLinear;
-	GLfloat ay = aiLight->mAttenuationConstant;
-	GLfloat az = aiLight->mAttenuationQuadratic;
-	GLfloat z = ay / (2.0f * az);
+	float ax = aiLight->mAttenuationLinear;
+	float ay = aiLight->mAttenuationConstant;
+	float az = aiLight->mAttenuationQuadratic;
+	float z = ay / (2.0f * az);
 
-	GLfloat start = 0.01;
-	GLfloat stop = 0.99;
+	float start = 0.01;
+	float stop = 0.99;
 
-	GLfloat inner = -z + sqrt(z * z - (ax / start - 1.0f / (start * az)));
-	GLfloat outer = -z + sqrt(z * z - (ax / stop - 1.0f / (stop * az)));
+	float inner = -z + sqrt(z * z - (ax / start - 1.0f / (start * az)));
+	float outer = -z + sqrt(z * z - (ax / stop - 1.0f / (stop * az)));
 
 	light->setRadius(0, Vec2f(inner, outer));
 }
@@ -863,7 +863,7 @@ ref_ptr<Mesh> AssetImporter::loadMesh(const struct aiMesh &mesh, const Mat4f &tr
 		texco->setVertexData(numVertices);
 		auto v_texco = (float*) texco->clientBuffer()->clientData(0);
 		for (uint32_t n = 0; n < numVertices; ++n) {
-			GLfloat *aiTexcoData = &(aiTexcos[n].x);
+			float *aiTexcoData = &(aiTexcos[n].x);
 			for (uint32_t x = 0; x < texcoComponents; ++x) v_texco[x] = aiTexcoData[x];
 			v_texco += texcoComponents;
 		}
@@ -879,7 +879,7 @@ ref_ptr<Mesh> AssetImporter::loadMesh(const struct aiMesh &mesh, const Mat4f &tr
 			Vec3f &b = *((Vec3f *) &mesh.mBitangents[i].x);
 			Vec3f &n = *((Vec3f *) &mesh.mNormals[i].x);
 			// Calculate the handedness of the local tangent space.
-			GLfloat handeness;
+			float handeness;
 			if (n.cross(t).dot(b) < 0.0) {
 				handeness = -1.0;
 			} else {
@@ -896,7 +896,7 @@ ref_ptr<Mesh> AssetImporter::loadMesh(const struct aiMesh &mesh, const Mat4f &tr
 	// Its offset matrix declares the transformation needed to transform from mesh space
 	// to the local space of this bone.
 	if (mesh.HasBones()) {
-		typedef list<pair<GLfloat, uint32_t> > WeightList;
+		typedef list<pair<float, uint32_t> > WeightList;
 		map<uint32_t, WeightList> vertexToWeights;
 		uint32_t maxNumWeights = 0;
 
@@ -920,7 +920,7 @@ ref_ptr<Mesh> AssetImporter::loadMesh(const struct aiMesh &mesh, const Mat4f &tr
 			auto boneIndices = ref_ptr<ShaderInput1ui>::alloc("boneIndices", maxNumWeights);
 			boneWeights->setVertexData(numVertices);
 			boneIndices->setVertexData(numVertices);
-			auto v_weights = (GLfloat*) boneWeights->clientBuffer()->clientData(0);
+			auto v_weights = (float*) boneWeights->clientBuffer()->clientData(0);
 			auto v_indices = (uint32_t*) boneIndices->clientBuffer()->clientData(0);
 
 			for (uint32_t j = 0; j < numVertices; j++) {
@@ -1178,7 +1178,7 @@ ref_ptr<AssetImporter> AssetImporter::load(LoadingContext &ctx, scene::SceneInpu
 	animConfig.forceStates =
 			input.getValue<bool>("animation-force-states", true);
 	animConfig.ticksPerSecond =
-			input.getValue<GLfloat>("animation-tps", 20.0);
+			input.getValue<float>("animation-tps", 20.0);
 	animConfig.postState = input.getValue<AnimationChannelBehavior>(
 			"animation-post-state",
 			AnimationChannelBehavior::LINEAR);
@@ -1192,7 +1192,7 @@ ref_ptr<AssetImporter> AssetImporter::load(LoadingContext &ctx, scene::SceneInpu
 			asset->setTexturePath(resourcePath(input.getValue("texture-path")));
 		}
 		if (input.hasAttribute("emission-strength")) {
-			asset->setEmissionStrength(input.getValue<GLfloat>("emission-strength", 1.0f));
+			asset->setEmissionStrength(input.getValue<float>("emission-strength", 1.0f));
 		}
 		auto preset = input.getValue<std::string>("preset", "");
 		if (preset == "fast") {

--- a/regen/objects/composite-mesh.cpp
+++ b/regen/objects/composite-mesh.cpp
@@ -663,7 +663,7 @@ ref_ptr<Particles> CompositeMesh::createParticleMesh(LoadingContext &ctx, scene:
 			} else if (type == "vec4") {
 				configureParticleAttribute<ShaderInput4f, Vec4f>(parser, particles, *child.get());
 			} else if (type == "int") {
-				configureParticleAttribute<ShaderInput1i, GLint>(parser, particles, *child.get());
+				configureParticleAttribute<ShaderInput1i, int>(parser, particles, *child.get());
 			} else if (type == "ivec2") {
 				configureParticleAttribute<ShaderInput2i, Vec2i>(parser, particles, *child.get());
 			} else if (type == "ivec3") {

--- a/regen/objects/lod/impostor-billboard.cpp
+++ b/regen/objects/lod/impostor-billboard.cpp
@@ -13,10 +13,10 @@ static ref_ptr<Rectangle> getImpostorQuad() {
 	static ref_ptr<Rectangle> mesh;
 	if (mesh.get() == nullptr) {
 		Rectangle::Config cfg;
-		cfg.centerAtOrigin = GL_FALSE;
-		cfg.isNormalRequired = GL_FALSE;
-		cfg.isTangentRequired = GL_FALSE;
-		cfg.isTexcoRequired = GL_FALSE;
+		cfg.centerAtOrigin = false;
+		cfg.isNormalRequired = false;
+		cfg.isTangentRequired = false;
+		cfg.isTexcoRequired = false;
 		cfg.levelOfDetails = {0};
 		cfg.posScale = Vec3f::one();
 		cfg.rotation = Vec3f(0.5 * M_PI, 0.0f, 0.0f);
@@ -45,7 +45,7 @@ ImpostorBillboard::ImpostorBillboard()
 	// note: we generally do not need culling when rendering impostor billboards
 	//       as they only have a two front face.
 	//       this is also important for the billboards to be rendered into shadow maps.
-	joinStates(ref_ptr<ToggleState>::alloc(RenderState::CULL_FACE, GL_FALSE));
+	joinStates(ref_ptr<ToggleState>::alloc(RenderState::CULL_FACE, false));
 	setShaderKey("regen.models.impostor");
 }
 

--- a/regen/objects/lod/mesh-simplifier.cpp
+++ b/regen/objects/lod/mesh-simplifier.cpp
@@ -19,7 +19,6 @@ MeshSimplifier::MeshSimplifier(const ref_ptr<Mesh> &mesh) : mesh_(mesh) {
 		case GL_LINE_LOOP:
 		case GL_LINE_STRIP:
 		default:
-			// TODO: Support other primitive types than triangles.
 			REGEN_ERROR("Mesh simplifier only supports triangle meshes.");
 			hasValidAttributes_ = false;
 			break;

--- a/regen/objects/lod/mesh-simplifier.h
+++ b/regen/objects/lod/mesh-simplifier.h
@@ -19,6 +19,8 @@ namespace regen {
 	 * This class implements a mesh simplification algorithm based on
 	 * edge collapses. It uses a priority queue to select the edges to
 	 * collapse based on the cost of the collapse.
+	 *
+	 * Currently, it supports only triangle meshes with position and normal attributes.
 	 */
 	class MeshSimplifier {
 	public:

--- a/regen/objects/mesh.cpp
+++ b/regen/objects/mesh.cpp
@@ -204,7 +204,7 @@ void Mesh::addShaderInput(const std::string &name, const ref_ptr<ShaderInput> &i
 	}
 
 	if (in->isVertexAttribute()) {
-		GLint loc = meshShader_->attributeLocation(name);
+		int loc = meshShader_->attributeLocation(name);
 		if (loc == -1) {
 			// not used in shader
 			return;

--- a/regen/objects/particles.cpp
+++ b/regen/objects/particles.cpp
@@ -253,7 +253,7 @@ void Particles::createUpdateShader() {
 	shaderCfg.feedbackAttributes_.clear();
 }
 
-void Particles::glAnimate(RenderState *rs, GLdouble dt) {
+void Particles::glAnimate(RenderState *rs, double dt) {
 	const uint32_t nextIdx = (updateIdx_ == 0) ? 1 : 0;
 
 	rs->toggles().push(RenderState::RASTERIZER_DISCARD, GL_TRUE);

--- a/regen/objects/particles.cpp
+++ b/regen/objects/particles.cpp
@@ -253,7 +253,7 @@ void Particles::createUpdateShader() {
 	shaderCfg.feedbackAttributes_.clear();
 }
 
-void Particles::glAnimate(RenderState *rs, double dt) {
+void Particles::gpuUpdate(RenderState *rs, double dt) {
 	const uint32_t nextIdx = (updateIdx_ == 0) ? 1 : 0;
 
 	rs->toggles().push(RenderState::RASTERIZER_DISCARD, true);

--- a/regen/objects/particles.cpp
+++ b/regen/objects/particles.cpp
@@ -111,7 +111,7 @@ void Particles::configureAdvancing(
 		AdvanceMode mode) {
 	std::string advanceImportKey;
 	std::string advanceFunction;
-	GLfloat advanceFactor = 1.0f;
+	float advanceFactor = 1.0f;
 	switch (mode) {
 		case ADVANCE_MODE_CUSTOM: {
 			auto needle = advanceFunctions_.find(in->name());

--- a/regen/objects/particles.cpp
+++ b/regen/objects/particles.cpp
@@ -256,7 +256,7 @@ void Particles::createUpdateShader() {
 void Particles::glAnimate(RenderState *rs, double dt) {
 	const uint32_t nextIdx = (updateIdx_ == 0) ? 1 : 0;
 
-	rs->toggles().push(RenderState::RASTERIZER_DISCARD, GL_TRUE);
+	rs->toggles().push(RenderState::RASTERIZER_DISCARD, true);
 	updateState_->enable(rs);
 
 	rs->vao().apply(particleVAO_.id());

--- a/regen/objects/particles.cpp
+++ b/regen/objects/particles.cpp
@@ -86,7 +86,7 @@ ref_ptr<BufferReference> Particles::end() {
 	for (auto &particleInput: inputs()) {
 		const ref_ptr<ShaderInput> in = particleInput.in_;
 		if (!in->isVertexAttribute()) continue;
-		GLint loc = updateState_->shader()->attributeLocation(particleInput.in_->name());
+		int loc = updateState_->shader()->attributeLocation(particleInput.in_->name());
 		if (loc == -1) continue;
 		particleAttributes_.emplace_back(in, loc);
 	}

--- a/regen/objects/particles.h
+++ b/regen/objects/particles.h
@@ -130,7 +130,7 @@ namespace regen {
 		 * @param attributeName name of the attribute.
 		 * @param factor advance factor.
 		 */
-		void setAdvanceFactor(const std::string &attributeName, GLfloat factor) { advanceFactors_.emplace(attributeName, factor); }
+		void setAdvanceFactor(const std::string &attributeName, float factor) { advanceFactors_.emplace(attributeName, factor); }
 
 		/**
 		 * Set the advance function for a particle attribute.
@@ -179,7 +179,7 @@ namespace regen {
 
 		std::map<std::string, AdvanceMode> advanceModes_;
 		std::map<std::string, std::string> advanceFunctions_;
-		std::map<std::string, GLfloat> advanceFactors_;
+		std::map<std::string, float> advanceFactors_;
 		struct Ramp {
 			ref_ptr<Texture> texture;
 			RampMode mode;

--- a/regen/objects/particles.h
+++ b/regen/objects/particles.h
@@ -157,7 +157,7 @@ namespace regen {
 		void setRampFunction(const std::string &attributeName, const std::string &shaderFunction) { rampFunctions_.emplace(attributeName, shaderFunction); }
 
 		// override
-		void glAnimate(RenderState *rs, double dt) override;
+		void gpuUpdate(RenderState *rs, double dt) override;
 
 		void begin();
 

--- a/regen/objects/particles.h
+++ b/regen/objects/particles.h
@@ -157,7 +157,7 @@ namespace regen {
 		void setRampFunction(const std::string &attributeName, const std::string &shaderFunction) { rampFunctions_.emplace(attributeName, shaderFunction); }
 
 		// override
-		void glAnimate(RenderState *rs, GLdouble dt) override;
+		void glAnimate(RenderState *rs, double dt) override;
 
 		void begin();
 

--- a/regen/objects/primitives/blanket.cpp
+++ b/regen/objects/primitives/blanket.cpp
@@ -30,7 +30,7 @@ namespace regen {
 			  blanket_(blanket) {
 		}
 
-		void animate(GLdouble dt) override {
+		void animate(double dt) override {
 			blanket_->updateLifetime(dt * 0.001f);
 		}
 

--- a/regen/objects/primitives/blanket.cpp
+++ b/regen/objects/primitives/blanket.cpp
@@ -30,7 +30,7 @@ namespace regen {
 			  blanket_(blanket) {
 		}
 
-		void animate(double dt) override {
+		void cpuUpdate(double dt) override {
 			blanket_->updateLifetime(dt * 0.001f);
 		}
 

--- a/regen/objects/primitives/blanket.cpp
+++ b/regen/objects/primitives/blanket.cpp
@@ -12,10 +12,10 @@ static Rectangle::Config getRectangleConfig(const Blanket::BlanketConfig &cfg) {
 	rectCfg.posScale.y = 1.0;
 	rectCfg.rotation = Vec3f(0.0f, 0.0f, M_PIf);
 	rectCfg.texcoScale = cfg.texcoScale;
-	rectCfg.isNormalRequired = GL_TRUE;
-	rectCfg.isTangentRequired = GL_TRUE;
-	rectCfg.isTexcoRequired = GL_TRUE;
-	rectCfg.centerAtOrigin = GL_TRUE;
+	rectCfg.isNormalRequired = true;
+	rectCfg.isTangentRequired = true;
+	rectCfg.isTexcoRequired = true;
+	rectCfg.centerAtOrigin = true;
 	rectCfg.updateHint = cfg.updateHint;
 	rectCfg.mapMode = cfg.mapMode;
 	rectCfg.accessMode = cfg.accessMode;

--- a/regen/objects/primitives/box.cpp
+++ b/regen/objects/primitives/box.cpp
@@ -38,8 +38,8 @@ ref_ptr<Box> Box::getUnitCube() {
 		cfg.posScale = Vec3f::one();
 		cfg.rotation = Vec3f(0.0, 0.0f, 0.0f);
 		cfg.texcoMode = TEXCO_MODE_NONE;
-		cfg.isNormalRequired = GL_FALSE;
-		cfg.isTangentRequired = GL_FALSE;
+		cfg.isNormalRequired = false;
+		cfg.isTangentRequired = false;
 		cfg.levelOfDetails = {0};
 		mesh = ref_ptr<Box>::alloc(cfg);
 	}
@@ -72,8 +72,8 @@ Box::Config::Config()
 		  rotation(Vec3f::zero()),
 		  texcoScale(Vec2f::one()),
 		  texcoMode(TEXCO_MODE_UV),
-		  isNormalRequired(GL_TRUE),
-		  isTangentRequired(GL_FALSE) {
+		  isNormalRequired(true),
+		  isTangentRequired(false) {
 }
 
 void Box::generateLODLevel(

--- a/regen/objects/primitives/box.h
+++ b/regen/objects/primitives/box.h
@@ -52,9 +52,9 @@ namespace regen {
 			/** texture coordinate mode. */
 			TexcoMode texcoMode;
 			/** generate normal attribute ?. */
-			GLboolean isNormalRequired;
+			bool isNormalRequired;
 			/** generate tangent attribute ?. */
-			GLboolean isTangentRequired;
+			bool isTangentRequired;
 			/** Buffer usage hints. */
 			ClientAccessMode accessMode = BUFFER_CPU_WRITE;
 			BufferUpdateFlags updateHint = BufferUpdateFlags::NEVER;

--- a/regen/objects/primitives/cone.cpp
+++ b/regen/objects/primitives/cone.cpp
@@ -14,7 +14,7 @@ Cone::Cone(GLenum primitive, const BufferUpdateFlags &hints)
 ConeOpened::Config::Config()
 		: cosAngle(0.5),
 		  height(1.0f),
-		  isNormalRequired(GL_TRUE),
+		  isNormalRequired(true),
 		  levelOfDetails({1}) {
 }
 
@@ -102,8 +102,8 @@ void ConeOpened::updateAttributes(const Config &cfg) {
 ConeClosed::Config::Config()
 		: radius(0.5),
 		  height(1.0f),
-		  isNormalRequired(GL_TRUE),
-		  isBaseRequired(GL_TRUE),
+		  isNormalRequired(true),
+		  isBaseRequired(true),
 		  levelOfDetails({1}) {
 }
 
@@ -114,8 +114,8 @@ ref_ptr<Mesh> ConeClosed::getBaseCone() {
 		cfg.height = 1.0f;
 		cfg.radius = 0.5;
 		cfg.levelOfDetails = {3, 2, 1};
-		cfg.isNormalRequired = GL_FALSE;
-		cfg.isBaseRequired = GL_TRUE;
+		cfg.isNormalRequired = false;
+		cfg.isBaseRequired = true;
 		mesh = ref_ptr<ConeClosed>::alloc(cfg);
 	}
 	return ref_ptr<Mesh>::alloc(mesh);
@@ -132,7 +132,7 @@ static void loadConeData(
 		Vec3f *pos, Vec3f *nor,
 		Vec3f &min,
 		Vec3f &max,
-		GLboolean useBase,
+		bool useBase,
 		uint32_t subdivisions,
 		float radius,
 		float height) {

--- a/regen/objects/primitives/cone.cpp
+++ b/regen/objects/primitives/cone.cpp
@@ -34,10 +34,10 @@ void ConeOpened::generateLODLevel(const Config &cfg,
 	auto v_nor = (cfg.isNormalRequired ?
 				  (Vec3f*) nor_->clientBuffer()->clientData(0) : nullptr);
 
-	GLfloat phi = acos(cfg.cosAngle);
-	GLfloat radius = tan(phi) * cfg.height;
-	GLfloat angle = 0.0f;
-	GLfloat angleStep = 2.0f * M_PI / (GLfloat) lodLevel;
+	float phi = acos(cfg.cosAngle);
+	float radius = tan(phi) * cfg.height;
+	float angle = 0.0f;
+	float angleStep = 2.0f * M_PI / (float) lodLevel;
 	uint32_t i = vertexOffset;
 
 	v_pos[i] = Vec3f::zero();
@@ -47,8 +47,8 @@ void ConeOpened::generateLODLevel(const Config &cfg,
 
 	for (; i < lodLevel + 1; ++i) {
 		angle += angleStep;
-		GLfloat s = sin(angle) * radius;
-		GLfloat c = cos(angle) * radius;
+		float s = sin(angle) * radius;
+		float c = cos(angle) * radius;
 		Vec3f pos(c, s, cfg.height);
 		v_pos[i + 1] = pos;
 		minPosition_.setMin(pos);
@@ -134,10 +134,10 @@ static void loadConeData(
 		Vec3f &max,
 		GLboolean useBase,
 		uint32_t subdivisions,
-		GLfloat radius,
-		GLfloat height) {
-	GLfloat angle = 0.0f;
-	GLfloat angleStep = 2.0f * M_PI / (GLfloat) subdivisions;
+		float radius,
+		float height) {
+	float angle = 0.0f;
+	float angleStep = 2.0f * M_PI / (float) subdivisions;
 	int i = 0;
 
 	// apex
@@ -156,8 +156,8 @@ static void loadConeData(
 	int numVertices = subdivisions + i;
 	for (; i < numVertices; ++i) {
 		angle += angleStep;
-		GLfloat s = sin(angle) * radius;
-		GLfloat c = cos(angle) * radius;
+		float s = sin(angle) * radius;
+		float c = cos(angle) * radius;
 		pos[i] = Vec3f(c, s, height);
 		min.setMin(pos[i]);
 		max.setMax(pos[i]);

--- a/regen/objects/primitives/cone.cpp
+++ b/regen/objects/primitives/cone.cpp
@@ -138,7 +138,7 @@ static void loadConeData(
 		GLfloat height) {
 	GLfloat angle = 0.0f;
 	GLfloat angleStep = 2.0f * M_PI / (GLfloat) subdivisions;
-	GLint i = 0;
+	int i = 0;
 
 	// apex
 	pos[i] = Vec3f::zero();
@@ -153,7 +153,7 @@ static void loadConeData(
 		++i;
 	}
 
-	GLint numVertices = subdivisions + i;
+	int numVertices = subdivisions + i;
 	for (; i < numVertices; ++i) {
 		angle += angleStep;
 		GLfloat s = sin(angle) * radius;
@@ -192,7 +192,7 @@ void ConeClosed::generateLODLevel(
 	const uint32_t apexIndex = vertexOffset;
 	const uint32_t baseCenterIndex = vertexOffset + 1;
 	uint32_t faceIndex = indexOffset;
-	GLint vIndex = vertexOffset + cfg.isBaseRequired ? 2 : 1;
+	int vIndex = vertexOffset + cfg.isBaseRequired ? 2 : 1;
 	// cone
 	for (uint32_t i = 0; i < lodLevel; ++i) {
 		setIndexValue(indices, indexType, faceIndex++, apexIndex);

--- a/regen/objects/primitives/cone.h
+++ b/regen/objects/primitives/cone.h
@@ -38,7 +38,7 @@ namespace regen {
 			/** distance from apex to base */
 			float height;
 			/** generate normal attribute ? */
-			GLboolean isNormalRequired;
+			bool isNormalRequired;
 			/** subdivisions = 4*levelOfDetail^2 */
 			std::vector<uint32_t> levelOfDetails;
 			/** Buffer usage hints. */
@@ -93,9 +93,9 @@ namespace regen {
 			/** the base apex distance */
 			float height;
 			/** generate cone normals */
-			GLboolean isNormalRequired;
+			bool isNormalRequired;
 			/** generate cone base geometry */
-			GLboolean isBaseRequired;
+			bool isBaseRequired;
 			/** level of detail for base circle */
 			std::vector<uint32_t> levelOfDetails;
 			/** Buffer usage hints. */

--- a/regen/objects/primitives/cone.h
+++ b/regen/objects/primitives/cone.h
@@ -34,9 +34,9 @@ namespace regen {
 		 */
 		struct Config {
 			/** cosine of cone angle */
-			GLfloat cosAngle;
+			float cosAngle;
 			/** distance from apex to base */
-			GLfloat height;
+			float height;
 			/** generate normal attribute ? */
 			GLboolean isNormalRequired;
 			/** subdivisions = 4*levelOfDetail^2 */
@@ -89,9 +89,9 @@ namespace regen {
 		 */
 		struct Config {
 			/** the base radius */
-			GLfloat radius;
+			float radius;
 			/** the base apex distance */
-			GLfloat height;
+			float height;
 			/** generate cone normals */
 			GLboolean isNormalRequired;
 			/** generate cone base geometry */

--- a/regen/objects/primitives/disc.cpp
+++ b/regen/objects/primitives/disc.cpp
@@ -36,8 +36,8 @@ ref_ptr<Disc> Disc::getUnitDisc() {
 		cfg.posScale = Vec3f::one();
 		cfg.rotation = Vec3f(0.0, 0.0f, 0.0f);
 		cfg.texcoMode = TEXCO_MODE_NONE;
-		cfg.isNormalRequired = GL_FALSE;
-		cfg.isTangentRequired = GL_FALSE;
+		cfg.isNormalRequired = false;
+		cfg.isTangentRequired = false;
 		cfg.discRadius = 1.0f;
 		mesh = ref_ptr<Disc>::alloc(cfg);
 		return mesh;
@@ -70,8 +70,8 @@ Disc::Config::Config()
 		  rotation(Vec3f::zero()),
 		  texcoScale(Vec2f::one()),
 		  texcoMode(TEXCO_MODE_UV),
-		  isNormalRequired(GL_TRUE),
-		  isTangentRequired(GL_FALSE),
+		  isNormalRequired(true),
+		  isTangentRequired(false),
 		  discRadius(1.0f) {
 }
 

--- a/regen/objects/primitives/disc.h
+++ b/regen/objects/primitives/disc.h
@@ -45,7 +45,7 @@ namespace regen {
 			/** generate tangent attribute ?. */
 			GLboolean isTangentRequired;
 			/** radius of the disc. */
-			GLfloat discRadius;
+			float discRadius;
 			/** Buffer usage hints. */
 			ClientAccessMode accessMode = BUFFER_CPU_WRITE;
 			BufferUpdateFlags updateHint = BufferUpdateFlags::NEVER;

--- a/regen/objects/primitives/disc.h
+++ b/regen/objects/primitives/disc.h
@@ -41,9 +41,9 @@ namespace regen {
 			/** texture coordinate mode. */
 			TexcoMode texcoMode;
 			/** generate normal attribute ?. */
-			GLboolean isNormalRequired;
+			bool isNormalRequired;
 			/** generate tangent attribute ?. */
-			GLboolean isTangentRequired;
+			bool isTangentRequired;
 			/** radius of the disc. */
 			float discRadius;
 			/** Buffer usage hints. */

--- a/regen/objects/primitives/frame.cpp
+++ b/regen/objects/primitives/frame.cpp
@@ -38,8 +38,8 @@ ref_ptr<FrameMesh> FrameMesh::getUnitFrame() {
 		cfg.posScale = Vec3f::one();
 		cfg.rotation = Vec3f(0.0, 0.0f, 0.0f);
 		cfg.texcoMode = TEXCO_MODE_NONE;
-		cfg.isNormalRequired = GL_FALSE;
-		cfg.isTangentRequired = GL_FALSE;
+		cfg.isNormalRequired = false;
+		cfg.isTangentRequired = false;
 		cfg.borderSize = 0.1f;
 		mesh = ref_ptr<FrameMesh>::alloc(cfg);
 		return mesh;
@@ -73,8 +73,8 @@ FrameMesh::Config::Config()
 		  rotation(Vec3f::zero()),
 		  texcoScale(Vec2f::one()),
 		  texcoMode(TEXCO_MODE_UV),
-		  isNormalRequired(GL_TRUE),
-		  isTangentRequired(GL_FALSE),
+		  isNormalRequired(true),
+		  isTangentRequired(false),
 		  borderSize(0.1f) {
 }
 

--- a/regen/objects/primitives/frame.h
+++ b/regen/objects/primitives/frame.h
@@ -45,7 +45,7 @@ namespace regen {
 			/** generate tangent attribute ?. */
 			GLboolean isTangentRequired;
 			/** size of the frame border. */
-			GLfloat borderSize;
+			float borderSize;
 			/** Buffer usage hints. */
 			ClientAccessMode accessMode = BUFFER_CPU_WRITE;
 			BufferUpdateFlags updateHint = BufferUpdateFlags::NEVER;

--- a/regen/objects/primitives/frame.h
+++ b/regen/objects/primitives/frame.h
@@ -41,9 +41,9 @@ namespace regen {
 			/** texture coordinate mode. */
 			TexcoMode texcoMode;
 			/** generate normal attribute ?. */
-			GLboolean isNormalRequired;
+			bool isNormalRequired;
 			/** generate tangent attribute ?. */
-			GLboolean isTangentRequired;
+			bool isTangentRequired;
 			/** size of the frame border. */
 			float borderSize;
 			/** Buffer usage hints. */

--- a/regen/objects/primitives/rectangle.cpp
+++ b/regen/objects/primitives/rectangle.cpp
@@ -7,10 +7,10 @@ ref_ptr<Rectangle> Rectangle::getUnitQuad() {
 	static ref_ptr<Rectangle> mesh;
 	if (mesh.get() == nullptr) {
 		Config cfg;
-		cfg.centerAtOrigin = GL_FALSE;
-		cfg.isNormalRequired = GL_FALSE;
-		cfg.isTangentRequired = GL_FALSE;
-		cfg.isTexcoRequired = GL_FALSE;
+		cfg.centerAtOrigin = false;
+		cfg.isNormalRequired = false;
+		cfg.isTangentRequired = false;
+		cfg.isTexcoRequired = false;
 		cfg.levelOfDetails = {0};
 		cfg.posScale = Vec3f::create(2.0f);
 		cfg.rotation = Vec3f(0.5 * M_PI, 0.0f, 0.0f);
@@ -49,10 +49,10 @@ Rectangle::Config::Config()
 		  rotation(Vec3f::zero()),
 		  translation(Vec3f::zero()),
 		  texcoScale(Vec2f::one()),
-		  isNormalRequired(GL_TRUE),
-		  isTexcoRequired(GL_TRUE),
-		  isTangentRequired(GL_FALSE),
-		  centerAtOrigin(GL_FALSE) {
+		  isNormalRequired(true),
+		  isTexcoRequired(true),
+		  isTangentRequired(false),
+		  centerAtOrigin(false) {
 }
 
 void Rectangle::generateLODLevel(const Config &cfg,
@@ -161,8 +161,8 @@ void Rectangle::updateAttributes() {
 		}
 	}
 	if (rectangleConfig_.isTangentRequired) {
-		rectangleConfig_.isNormalRequired = GL_TRUE;
-		rectangleConfig_.isTexcoRequired = GL_TRUE;
+		rectangleConfig_.isNormalRequired = true;
+		rectangleConfig_.isTexcoRequired = true;
 	}
 
 	// allocate attributes

--- a/regen/objects/primitives/sphere.cpp
+++ b/regen/objects/primitives/sphere.cpp
@@ -45,9 +45,9 @@ Sphere::Config::Config()
 		  texcoScale(Vec2f::one()),
 		  levelOfDetails({4}),
 		  texcoMode(TEXCO_MODE_UV),
-		  isNormalRequired(GL_TRUE),
-		  isTangentRequired(GL_FALSE),
-		  isHalfSphere(GL_FALSE) {
+		  isNormalRequired(true),
+		  isTangentRequired(false),
+		  isHalfSphere(false) {
 }
 
 static Vec3f computeSphereTangent(const Vec3f &v) {

--- a/regen/objects/primitives/sphere.cpp
+++ b/regen/objects/primitives/sphere.cpp
@@ -69,14 +69,14 @@ static Vec3f computeSphereTangent(const Vec3f &v) {
 
 void pushVertex(
 		uint32_t vertexIndex,
-		GLdouble u,
-		GLdouble v,
+		double u,
+		double v,
 		const Sphere::Config &cfg,
 		Vec3f *pos,
 		Vec3f *nor,
 		Vec4f *tan,
 		Vec2f *texco) {
-	GLdouble r = std::sin(M_PI * v);
+	double r = std::sin(M_PI * v);
 	pos[vertexIndex] = Vec3f(
 			static_cast<float>(r * std::cos(2.0 * M_PI * u)),
 			static_cast<float>(r * std::sin(2.0 * M_PI * u)),
@@ -113,15 +113,15 @@ void Sphere::generateLODLevel(const Config &cfg,
 	auto indices = (byte*)indices_->clientBuffer()->clientData(0);
 	auto indexType = indices_->baseType();
 
-	GLdouble stepSizeInv = 1.0 / (GLdouble) lodLevel;
+	double stepSizeInv = 1.0 / (double) lodLevel;
 	uint32_t vertexIndex = vertexOffset, faceIndex = indexOffset / 6;
 
 	for (uint32_t i = 0; i < lodLevel; i++) {
 		for (uint32_t j = 0; j < lodLevel; j++) {
-			GLdouble u0 = (GLdouble) i * stepSizeInv;
-			GLdouble u1 = (GLdouble) (i + 1) * stepSizeInv;
-			GLdouble v0 = (GLdouble) j * stepSizeInv;
-			GLdouble v1 = (GLdouble) (j + 1) * stepSizeInv;
+			double u0 = (double) i * stepSizeInv;
+			double u1 = (double) (i + 1) * stepSizeInv;
+			double v0 = (double) j * stepSizeInv;
+			double v1 = (double) (j + 1) * stepSizeInv;
 
 			if (cfg.isHalfSphere && u0 < 0.5) continue;
 

--- a/regen/objects/primitives/sphere.h
+++ b/regen/objects/primitives/sphere.h
@@ -80,7 +80,7 @@ namespace regen {
 		ref_ptr<ShaderInput2f> texco_;
 		ref_ptr<ShaderInput4f> tan_;
 		ref_ptr<ShaderInput> indices_;
-		GLfloat radius_;
+		float radius_;
 
 		void generateLODLevel(const Config &cfg,
 				uint32_t lodLevel,
@@ -109,7 +109,7 @@ namespace regen {
 		 */
 		struct Config {
 			/** one radius for each sphere. */
-			GLfloat *radius;
+			float *radius;
 			/** one position for each sphere. */
 			Vec3f *position;
 			/** number of spheres. */

--- a/regen/objects/primitives/sphere.h
+++ b/regen/objects/primitives/sphere.h
@@ -45,11 +45,11 @@ namespace regen {
 			/** texture coordinate mode */
 			TexcoMode texcoMode;
 			/** generate normal attribute */
-			GLboolean isNormalRequired;
+			bool isNormalRequired;
 			/** generate tangent attribute */
-			GLboolean isTangentRequired;
+			bool isTangentRequired;
 			/** If true only bottom half sphere is used. */
-			GLboolean isHalfSphere;
+			bool isHalfSphere;
 			/** Buffer usage hints. */
 			ClientAccessMode accessMode = BUFFER_CPU_WRITE;
 			BufferUpdateFlags updateHint = BufferUpdateFlags::NEVER;

--- a/regen/objects/primitives/torus.cpp
+++ b/regen/objects/primitives/torus.cpp
@@ -39,8 +39,8 @@ ref_ptr<Torus> Torus::getUnitTorus() {
 		cfg.posScale = Vec3f::one();
 		cfg.rotation = Vec3f(0.0, 0.0f, 0.0f);
 		cfg.texcoMode = TEXCO_MODE_NONE;
-		cfg.isNormalRequired = GL_FALSE;
-		cfg.isTangentRequired = GL_FALSE;
+		cfg.isNormalRequired = false;
+		cfg.isTangentRequired = false;
 		mesh = ref_ptr<Torus>::alloc(cfg);
 		return mesh;
 	} else {
@@ -72,8 +72,8 @@ Torus::Config::Config()
 		  rotation(Vec3f::zero()),
 		  texcoScale(Vec2f::one()),
 		  texcoMode(TEXCO_MODE_UV),
-		  isNormalRequired(GL_TRUE),
-		  isTangentRequired(GL_FALSE),
+		  isNormalRequired(true),
+		  isTangentRequired(false),
 		  ringRadius(1.0f),
 		  tubeRadius(0.5f) {
 }

--- a/regen/objects/primitives/torus.h
+++ b/regen/objects/primitives/torus.h
@@ -44,9 +44,9 @@ namespace regen {
 			/** texture coordinate mode. */
 			TexcoMode texcoMode;
 			/** generate normal attribute ?. */
-			GLboolean isNormalRequired;
+			bool isNormalRequired;
 			/** generate tangent attribute ?. */
-			GLboolean isTangentRequired;
+			bool isTangentRequired;
 			/** radius of the torus ring. */
 			float ringRadius;
 			/** radius of the tube. */

--- a/regen/objects/primitives/torus.h
+++ b/regen/objects/primitives/torus.h
@@ -48,9 +48,9 @@ namespace regen {
 			/** generate tangent attribute ?. */
 			GLboolean isTangentRequired;
 			/** radius of the torus ring. */
-			GLfloat ringRadius;
+			float ringRadius;
 			/** radius of the tube. */
-			GLfloat tubeRadius;
+			float tubeRadius;
 			/** Buffer usage hints. */
 			ClientAccessMode accessMode = BUFFER_CPU_WRITE;
 			BufferUpdateFlags updateHints = BufferUpdateFlags::NEVER;

--- a/regen/objects/sky-box.cpp
+++ b/regen/objects/sky-box.cpp
@@ -18,8 +18,8 @@ using namespace regen;
 
 static Box::Config cubeCfg(uint32_t levelOfDetail) {
 	Box::Config cfg;
-	cfg.isNormalRequired = GL_FALSE;
-	cfg.isTangentRequired = GL_FALSE;
+	cfg.isNormalRequired = false;
+	cfg.isTangentRequired = false;
 	cfg.texcoMode = Box::TEXCO_MODE_CUBE_MAP;
 	cfg.updateHint.frequency = BUFFER_UPDATE_NEVER;
 	cfg.updateHint.scope = BUFFER_UPDATE_FULLY;

--- a/regen/objects/sky/atmosphere.cpp
+++ b/regen/objects/sky/atmosphere.cpp
@@ -209,7 +209,7 @@ const ref_ptr<TextureCube> &Atmosphere::cubeMap() const {
 	return drawState_->cubeMap();
 }
 
-void Atmosphere::updateSkyLayer(RenderState *rs, GLdouble dt) {
+void Atmosphere::updateSkyLayer(RenderState *rs, double dt) {
 	rs->drawFrameBuffer().apply(fbo_->id());
 	rs->viewport().apply(fbo_->glViewport());
 	updateState_->enable(rs);

--- a/regen/objects/sky/atmosphere.h
+++ b/regen/objects/sky/atmosphere.h
@@ -152,7 +152,7 @@ namespace regen {
 		const ref_ptr<TextureCube> &cubeMap() const;
 
 		// Override SkyLayer
-		void updateSkyLayer(RenderState *rs, GLdouble dt) override;
+		void updateSkyLayer(RenderState *rs, double dt) override;
 
 		// Override SkyLayer
 		void createUpdateShader() override;

--- a/regen/objects/sky/atmosphere.h
+++ b/regen/objects/sky/atmosphere.h
@@ -16,9 +16,9 @@ namespace regen {
 		/** aerosol profile */
 		Vec4f mie;
 		/** sun-spotlight */
-		GLfloat spot;
+		float spot;
 		/** scattering strength */
-		GLfloat scatterStrength;
+		float scatterStrength;
 		/** Absorption color */
 		Vec3f absorption;
 	};

--- a/regen/objects/sky/cloud-layer.cpp
+++ b/regen/objects/sky/cloud-layer.cpp
@@ -166,7 +166,7 @@ float CloudLayer::defaultChangeLow() {
 	return 0.1f;
 }
 
-void CloudLayer::updateSkyLayer(RenderState *rs, GLdouble dt) {
+void CloudLayer::updateSkyLayer(RenderState *rs, double dt) {
 	static const Vec4f clearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	fbo_->clearAllColorAttachments(clearColor);
 	rs->viewport().push(fbo_->glViewport());

--- a/regen/objects/sky/cloud-layer.cpp
+++ b/regen/objects/sky/cloud-layer.cpp
@@ -5,9 +5,9 @@
 
 using namespace regen;
 
-static GLfloat *createNoiseSlice(uint32_t texSize, uint32_t octave) {
+static float *createNoiseSlice(uint32_t texSize, uint32_t octave) {
 	uint32_t size2 = texSize * texSize;
-	GLfloat oneOverTexSize = 1.f / static_cast<float>(texSize);
+	float oneOverTexSize = 1.f / static_cast<float>(texSize);
 	osgHimmel::Noise n(1 << (octave + 2),
 					   math::random<float>(0.f, 1.f),
 					   math::random<float>(0.f, 1.f));
@@ -35,7 +35,7 @@ static ref_ptr<Texture3D> createNoiseArray(uint32_t texSize, uint32_t octave, ui
 	tex->set_pixelType(GL_FLOAT);
 	tex->allocTexture();
 	for (uint32_t s = 0; s < slices; ++s) {
-		GLfloat *data = createNoiseSlice(texSize, octave);
+		float *data = createNoiseSlice(texSize, octave);
 		tex->updateSubImage(static_cast<int>(s), (GLubyte *) data);
 		delete[]data;
 	}

--- a/regen/objects/sky/cloud-layer.h
+++ b/regen/objects/sky/cloud-layer.h
@@ -72,7 +72,7 @@ namespace regen {
 		static float defaultChangeLow();
 
 		// Override
-		void updateSkyLayer(RenderState *rs, GLdouble dt) override;
+		void updateSkyLayer(RenderState *rs, double dt) override;
 
 		// Override SkyLayer
 		void createUpdateShader() override;

--- a/regen/objects/sky/darkness.cpp
+++ b/regen/objects/sky/darkness.cpp
@@ -2,7 +2,7 @@
 
 using namespace regen;
 
-Darkness::Darkness(const ref_ptr<Sky> &sky, GLint levelOfDetail)
+Darkness::Darkness(const ref_ptr<Sky> &sky, int levelOfDetail)
 		: SkyLayer(sky) {
 	meshState_ = ref_ptr<SkyBox>::alloc(levelOfDetail, "regen.weather.darkness");
 }

--- a/regen/objects/sky/darkness.h
+++ b/regen/objects/sky/darkness.h
@@ -12,7 +12,7 @@ namespace regen {
 	 */
 	class Darkness : public SkyLayer {
 	public:
-		explicit Darkness(const ref_ptr<Sky> &sky, GLint levelOfDetail = 4);
+		explicit Darkness(const ref_ptr<Sky> &sky, int levelOfDetail = 4);
 
 		ref_ptr<Mesh> getMeshState() override { return meshState_; }
 

--- a/regen/objects/sky/lightning-bolt.cpp
+++ b/regen/objects/sky/lightning-bolt.cpp
@@ -423,7 +423,7 @@ void LightningBolt::createResources() {
 	}
 }
 
-void LightningBolt::animate(GLdouble dt) {
+void LightningBolt::animate(double dt) {
 	bool active = false;
 	double dt_s = dt * 0.001;
 	for (auto &strike : strikes_) {
@@ -435,7 +435,7 @@ void LightningBolt::animate(GLdouble dt) {
 	}
 }
 
-void LightningBolt::glAnimate(RenderState *rs, GLdouble dt) {
+void LightningBolt::glAnimate(RenderState *rs, double dt) {
 	if (!isActive_) return;
 
 	const uint32_t maxVertices = pos_->numVertices();

--- a/regen/objects/sky/lightning-bolt.cpp
+++ b/regen/objects/sky/lightning-bolt.cpp
@@ -334,7 +334,7 @@ void LightningBolt::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 				strike->lifetimeConfig_ = lifetime;
 			}
 			if (child->hasAttribute("jitter-offset")) {
-				strike->jitterOffset_ = child->getValue<GLfloat>("jitter-offset", 8.0f);
+				strike->jitterOffset_ = child->getValue<float>("jitter-offset", 8.0f);
 			}
 			if (child->hasAttribute("frequency")) {
 				auto frequency = child->getValue<Vec2f>("frequency", Vec2f::zero());
@@ -342,19 +342,19 @@ void LightningBolt::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 				strike->hasFrequency_ = (frequency.x != 0.0f || frequency.y != 0.0f);
 			}
 			if (child->hasAttribute("branch-probability")) {
-				strike->branchProbability_ = child->getValue<GLfloat>("branch-probability", 0.5f);
+				strike->branchProbability_ = child->getValue<float>("branch-probability", 0.5f);
 			}
 			if (child->hasAttribute("branch-offset")) {
-				strike->branchOffset_ = child->getValue<GLfloat>("branch-offset", 0.5f);
+				strike->branchOffset_ = child->getValue<float>("branch-offset", 0.5f);
 			}
 			if (child->hasAttribute("branch-length")) {
-				strike->branchLength_ = child->getValue<GLfloat>("branch-length", 0.5f);
+				strike->branchLength_ = child->getValue<float>("branch-length", 0.5f);
 			}
 			if (child->hasAttribute("branch-darkening")) {
-				strike->branchDarkening_ = child->getValue<GLfloat>("branch-darkening", 0.5f);
+				strike->branchDarkening_ = child->getValue<float>("branch-darkening", 0.5f);
 			}
 			if (child->hasAttribute("width-factor")) {
-				strike->widthFactor_ = child->getValue<GLfloat>("width-factor", 0.5f);
+				strike->widthFactor_ = child->getValue<float>("width-factor", 0.5f);
 			}
 			addLightningStrike(strike);
 		}

--- a/regen/objects/sky/lightning-bolt.cpp
+++ b/regen/objects/sky/lightning-bolt.cpp
@@ -423,7 +423,7 @@ void LightningBolt::createResources() {
 	}
 }
 
-void LightningBolt::animate(double dt) {
+void LightningBolt::cpuUpdate(double dt) {
 	bool active = false;
 	double dt_s = dt * 0.001;
 	for (auto &strike : strikes_) {
@@ -435,7 +435,7 @@ void LightningBolt::animate(double dt) {
 	}
 }
 
-void LightningBolt::glAnimate(RenderState *rs, double dt) {
+void LightningBolt::gpuUpdate(RenderState *rs, double dt) {
 	if (!isActive_) return;
 
 	const uint32_t maxVertices = pos_->numVertices();

--- a/regen/objects/sky/lightning-bolt.h
+++ b/regen/objects/sky/lightning-bolt.h
@@ -158,10 +158,10 @@ namespace regen {
 		void createResources();
 
 		// override
-		void animate(GLdouble dt) override;
+		void animate(double dt) override;
 
 		// override
-		void glAnimate(RenderState *, GLdouble dt) override;
+		void glAnimate(RenderState *, double dt) override;
 
 	protected:
 		ref_ptr<ShaderInput3f> pos_;

--- a/regen/objects/sky/lightning-bolt.h
+++ b/regen/objects/sky/lightning-bolt.h
@@ -158,10 +158,10 @@ namespace regen {
 		void createResources();
 
 		// override
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 		// override
-		void glAnimate(RenderState *, double dt) override;
+		void gpuUpdate(RenderState *, double dt) override;
 
 	protected:
 		ref_ptr<ShaderInput3f> pos_;

--- a/regen/objects/sky/moon.cpp
+++ b/regen/objects/sky/moon.cpp
@@ -283,7 +283,7 @@ void Moon::set_sunShineIntensity(float intensity) {
 	v_color.w = Vec4f::create(v_color.r.xyz(), intensity);
 }
 
-void Moon::updateSkyLayer(RenderState *rs, GLdouble dt) {
+void Moon::updateSkyLayer(RenderState *rs, double dt) {
 	moonOrientation_->setVertex(0, sky_->astro().getMoonOrientation());
 	earthShine_->setVertex(0, earthShineColor_ *
 							  (sky_->astro().getEarthShineIntensity() * earthShineIntensity_));

--- a/regen/objects/sky/moon.h
+++ b/regen/objects/sky/moon.h
@@ -82,7 +82,7 @@ namespace regen {
 		static float meanRadius();
 
 		// Override
-		void updateSkyLayer(RenderState *rs, GLdouble dt) override;
+		void updateSkyLayer(RenderState *rs, double dt) override;
 
 		ref_ptr<Mesh> getMeshState() override { return meshState_; }
 

--- a/regen/objects/sky/sky-layer.cpp
+++ b/regen/objects/sky/sky-layer.cpp
@@ -17,7 +17,7 @@ bool SkyLayer::advanceTime(double dt) {
 	return (dt_ >= updateInterval_);
 }
 
-void SkyLayer::updateSky(RenderState *rs, GLdouble dt) {
+void SkyLayer::updateSky(RenderState *rs, double dt) {
 	updateSkyLayer(rs, dt_);
 	dt_ = 0.0;
 }

--- a/regen/objects/sky/sky-layer.h
+++ b/regen/objects/sky/sky-layer.h
@@ -15,13 +15,13 @@ namespace regen {
 
 		~SkyLayer() override;
 
-		void updateSky(RenderState *rs, GLdouble dt);
+		void updateSky(RenderState *rs, double dt);
 
-		virtual void set_updateInterval(GLdouble interval_ms) { updateInterval_ = interval_ms; }
+		virtual void set_updateInterval(double interval_ms) { updateInterval_ = interval_ms; }
 
-		virtual GLdouble updateInterval() const { return updateInterval_; }
+		virtual double updateInterval() const { return updateInterval_; }
 
-		virtual void updateSkyLayer(RenderState *rs, GLdouble dt) {}
+		virtual void updateSkyLayer(RenderState *rs, double dt) {}
 
 		bool advanceTime(double dt);
 
@@ -37,8 +37,8 @@ namespace regen {
 		ref_ptr<Sky> sky_;
 		ref_ptr<State> updateState_;
 
-		GLdouble updateInterval_;
-		GLdouble dt_;
+		double updateInterval_;
+		double dt_;
 	};
 
 	class SkyLayerView : public SkyLayer {
@@ -53,15 +53,15 @@ namespace regen {
 			state()->joinStates(mesh_);
 		}
 
-		void set_updateInterval(GLdouble interval_ms) override { source_->set_updateInterval(interval_ms); }
+		void set_updateInterval(double interval_ms) override { source_->set_updateInterval(interval_ms); }
 
-		GLdouble updateInterval() const override { return source_->updateInterval(); }
+		double updateInterval() const override { return source_->updateInterval(); }
 
 		ref_ptr<Mesh> getMeshState() override { return mesh_; }
 
 		ref_ptr<HasShader> getShaderState() override { return shader_; }
 
-		void updateSkyLayer(RenderState *rs, GLdouble dt) override {}
+		void updateSkyLayer(RenderState *rs, double dt) override {}
 
 	protected:
 		ref_ptr<SkyLayer> source_;

--- a/regen/objects/sky/sky.cpp
+++ b/regen/objects/sky/sky.cpp
@@ -96,7 +96,7 @@ Sky::Sky(const ref_ptr<Camera> &cam, const ref_ptr<Screen> &screen)
 	// mae some parts of the sky configurable from the GUI.
 	setAnimationName("sky");
 	// make sure the client buffer data is initialized
-	Sky::animate(0.0f);
+	Sky::cpuUpdate(0.0f);
 	// Note: disabled because animation manager allways activates this state,
 	//       but we do not need to if sky does not need update.
 	// TODO: Make the "idle" state part of animation, then animation manager can
@@ -154,12 +154,12 @@ void Sky::createShader() {
 }
 
 void Sky::startAnimation() {
-	if (isRunning_) return;
+	if (isRunning()) return;
 	Animation::startAnimation();
 }
 
 void Sky::stopAnimation() {
-	if (!isRunning_) return;
+	if (!isRunning()) return;
 	Animation::stopAnimation();
 }
 
@@ -195,7 +195,7 @@ static Vec3f computeColor(const Vec3f &color, float ext) {
 	}
 }
 
-void Sky::animate(double dt) {
+void Sky::cpuUpdate(double dt) {
 	if (worldTime_) {
 		time_osg_.sett(boost::posix_time::to_time_t(worldTime_->p_time));
 		time_osg_.setUtcOffset(14400); // UTC+4, Berlin time
@@ -233,7 +233,7 @@ void Sky::animate(double dt) {
 	updateSeed();
 }
 
-void Sky::glAnimate(RenderState *rs, double dt) {
+void Sky::gpuUpdate(RenderState *rs, double dt) {
 	bool needsUpdate = false;
 	for (auto &layer: layer_) {
 		if (layer->advanceTime(dt)) {

--- a/regen/objects/sky/sky.h
+++ b/regen/objects/sky/sky.h
@@ -76,9 +76,9 @@ namespace regen {
 		void createShader();
 
 		// override
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
-		void glAnimate(RenderState *rs, double dt) override;
+		void gpuUpdate(RenderState *rs, double dt) override;
 
 		void startAnimation() override;
 

--- a/regen/objects/terrain/blanket-trail.cpp
+++ b/regen/objects/terrain/blanket-trail.cpp
@@ -123,12 +123,12 @@ ref_ptr<BlanketTrail> BlanketTrail::load(LoadingContext &ctx,
 	meshCfg.texcoScale = input.getValue<Vec2f>("texco-scaling", Vec2f::one());
 	meshCfg.blanketSize = input.getValue<Vec2f>("blanket-size", Vec2f(1.0f, 1.0f));
 	meshCfg.isInitiallyDead = input.getValue<bool>("initially-dead", false);
-	meshCfg.blanketLifetime = input.getValue<GLfloat>("blanket-lifetime", 0.0f);
+	meshCfg.blanketLifetime = input.getValue<float>("blanket-lifetime", 0.0f);
 	meshCfg.updateHint = updateFlags;
 	meshCfg.mapMode = input.getValue<BufferMapMode>("map-mode", BUFFER_MAP_DISABLED);
 	meshCfg.accessMode = input.getValue<ClientAccessMode>("access-mode", BUFFER_CPU_WRITE);
 	meshCfg.numTrails = input.getValue<uint32_t>("blanket-trails", 1u);
-	meshCfg.blanketFrequency = input.getValue<GLfloat>("blanket-frequency", 0.5f);
+	meshCfg.blanketFrequency = input.getValue<float>("blanket-frequency", 0.5f);
 	auto blanket = ref_ptr<BlanketTrail>::alloc(groundMesh, meshCfg);
 
 	// early add mesh vector to scene for children handling below

--- a/regen/objects/terrain/ground.cpp
+++ b/regen/objects/terrain/ground.cpp
@@ -622,8 +622,8 @@ void Ground::createWeightPass() {
 	}
 	{ // disable depth test/write
 		auto depth = ref_ptr<DepthState>::alloc();
-		depth->set_useDepthTest(GL_FALSE);
-		depth->set_useDepthWrite(GL_FALSE);
+		depth->set_useDepthTest(false);
+		depth->set_useDepthWrite(false);
 		weightUpdateState_->joinStates(depth);
 	}
 	// run weight pass

--- a/regen/objects/text/font.cpp
+++ b/regen/objects/text/font.cpp
@@ -166,12 +166,12 @@ void Font::initGlyph(FT_Face face, GLushort ch, uint32_t textureWidth, uint32_t 
 	FT_Bitmap &bitmap = bitmap_glyph->bitmap;
 
 	{
-		auto bitmapWith = (GLfloat) bitmap.width;
-		auto bitmapHeight = (GLfloat) bitmap.rows;
-		GLfloat sizeFactor = 1.0f / (GLfloat) size();
+		auto bitmapWith = (float) bitmap.width;
+		auto bitmapHeight = (float) bitmap.rows;
+		float sizeFactor = 1.0f / (float) size();
 
-		glyphData.uvX = bitmapWith / ((GLfloat) textureWidth);
-		glyphData.uvY = bitmapHeight / ((GLfloat) textureHeight);
+		glyphData.uvX = bitmapWith / ((float) textureWidth);
+		glyphData.uvY = bitmapHeight / ((float) textureHeight);
 		glyphData.height = bitmapHeight * sizeFactor;
 		glyphData.width = bitmapWith * sizeFactor;
 		glyphData.advanceX = (face->glyph->advance.x >> 6) * sizeFactor;

--- a/regen/objects/text/font.cpp
+++ b/regen/objects/text/font.cpp
@@ -15,12 +15,12 @@ using namespace regen;
 
 FT_Library Font::ftlib_ = FT_Library();
 Font::FontMap Font::fonts_ = FontMap();
-GLboolean Font::isFreetypeInitialized_ = GL_FALSE;
+bool Font::isFreetypeInitialized_ = false;
 
 ref_ptr<Font> Font::get(const std::string &f, uint32_t size, uint32_t dpi) {
 	if (!isFreetypeInitialized_) {
 		if (FT_Init_FreeType(&ftlib_)) { throw Font::Error("FT_Init_FreeType failed."); }
-		isFreetypeInitialized_ = GL_TRUE;
+		isFreetypeInitialized_ = true;
 	}
 	// unique font identifier
 	std::string fontKey = REGEN_STRING(f << size << "_" << dpi);
@@ -48,7 +48,7 @@ ref_ptr<Font> Font::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 
 void Font::closeLibrary() {
 	FT_Done_FreeType(ftlib_);
-	isFreetypeInitialized_ = GL_FALSE;
+	isFreetypeInitialized_ = false;
 }
 
 Font::Font(const std::string &fontPath, uint32_t size, uint32_t dpi)

--- a/regen/objects/text/font.h
+++ b/regen/objects/text/font.h
@@ -52,19 +52,19 @@ namespace regen {
 		 */
 		typedef struct {
 			/** face width */
-			GLfloat width;
+			float width;
 			/** face height */
-			GLfloat height;
+			float height;
 			/** max uv.x in array texture (min is 0). */
-			GLfloat uvX;
+			float uvX;
 			/** max uv.y in array texture (min is 0). */
-			GLfloat uvY;
+			float uvY;
 			/** left margin */
-			GLfloat left;
+			float left;
 			/** top margin */
-			GLfloat top;
+			float top;
 			/** distance to net glyph */
-			GLfloat advanceX;
+			float advanceX;
 		} FaceData;
 
 		/**
@@ -128,7 +128,7 @@ namespace regen {
 		const uint32_t dpi_;
 		ref_ptr<Texture2DArray> arrayTexture_;
 		FaceData *faceData_;
-		GLfloat lineHeight_;
+		float lineHeight_;
 
 		Font(const Font &)
 				: fontPath_(""),

--- a/regen/objects/text/font.h
+++ b/regen/objects/text/font.h
@@ -121,7 +121,7 @@ namespace regen {
 		typedef std::map<std::string, ref_ptr<Font> > FontMap;
 		static FT_Library ftlib_;
 		static FontMap fonts_;
-		static GLboolean isFreetypeInitialized_;
+		static bool isFreetypeInitialized_;
 
 		const std::string fontPath_;
 		const uint32_t size_;

--- a/regen/objects/text/texture-mapped-text.cpp
+++ b/regen/objects/text/texture-mapped-text.cpp
@@ -7,7 +7,7 @@
 
 using namespace regen;
 
-TextureMappedText::TextureMappedText(const ref_ptr<Font> &font, const GLfloat &height)
+TextureMappedText::TextureMappedText(const ref_ptr<Font> &font, const float &height)
 		: Mesh(GL_TRIANGLES, BufferUpdateFlags::NEVER ),
 		  font_(font),
 		  value_(),
@@ -34,14 +34,14 @@ void TextureMappedText::set_color(const Vec4f &color) {
 	textColor_->setVertex(0, color);
 }
 
-void TextureMappedText::set_height(GLfloat height) { height_ = height; }
+void TextureMappedText::set_height(float height) { height_ = height; }
 
 const std::list<std::wstring> &TextureMappedText::value() const { return value_; }
 
 void TextureMappedText::set_value(
 		const std::list<std::wstring> &value,
 		Alignment alignment,
-		GLfloat maxLineWidth) {
+		float maxLineWidth) {
 	value_ = value;
 	numCharacters_ = 0;
 	for (auto it = value.begin(); it != value.end(); ++it) {
@@ -53,17 +53,17 @@ void TextureMappedText::set_value(
 void TextureMappedText::set_value(
 		const std::wstring &value,
 		Alignment alignment,
-		GLfloat maxLineWidth) {
+		float maxLineWidth) {
 	std::list<std::wstring> v;
 	boost::split(v, value, boost::is_any_of("\n"));
 	set_value(v, alignment, maxLineWidth);
 }
 
-void TextureMappedText::updateAttributes(Alignment alignment, GLfloat maxLineWidth) {
+void TextureMappedText::updateAttributes(Alignment alignment, float maxLineWidth) {
 	Vec3f translation, glyphTranslation;
 	uint32_t vertexCounter = 0u;
 
-	GLfloat actualMaxLineWidth = 0.0;
+	float actualMaxLineWidth = 0.0;
 
 	posAttribute_->setVertexData(numCharacters_ * 6);
 	texcoAttribute_->setVertexData(numCharacters_ * 6);
@@ -80,12 +80,12 @@ void TextureMappedText::updateAttributes(Alignment alignment, GLfloat maxLineWid
 	for (auto it = value_.begin(); it != value_.end(); ++it) {
 		translation.y -= font_->lineHeight() * height_;
 
-		GLfloat buf;
+		float buf;
 		// actual width for this line
-		GLfloat lineWidth = 0.0;
+		float lineWidth = 0.0;
 		// remember space for splitting string at words
 		int lastSpaceIndex = 0;
-		GLfloat lastSpaceWidth = 0.0;
+		float lastSpaceWidth = 0.0;
 
 		// get line width and split the line
 		// where it exceeds the width limit
@@ -156,7 +156,7 @@ void TextureMappedText::updateAttributes(Alignment alignment, GLfloat maxLineWid
 
 	// apply offset to each vertex
 	if (centerAtOrigin_) {
-		GLfloat centerOffset = actualMaxLineWidth * 0.5f;
+		float centerOffset = actualMaxLineWidth * 0.5f;
 		for (uint32_t i = 0; i < vertexCounter; ++i) {
 			v_pos.w[i].x -= centerOffset;
 		}
@@ -184,7 +184,7 @@ void TextureMappedText::updateAttributes(Alignment alignment, GLfloat maxLineWid
 void TextureMappedText::makeGlyphGeometry(
 		const Font::FaceData &data,
 		const Vec3f &translation,
-		GLfloat layer,
+		float layer,
 		ClientData_rw<Vec3f> &posAttribute,
 		ClientData_rw<Vec3f> &norAttribute,
 		ClientData_rw<Vec3f> &texcoAttribute,

--- a/regen/objects/text/texture-mapped-text.cpp
+++ b/regen/objects/text/texture-mapped-text.cpp
@@ -84,7 +84,7 @@ void TextureMappedText::updateAttributes(Alignment alignment, GLfloat maxLineWid
 		// actual width for this line
 		GLfloat lineWidth = 0.0;
 		// remember space for splitting string at words
-		GLint lastSpaceIndex = 0;
+		int lastSpaceIndex = 0;
 		GLfloat lastSpaceWidth = 0.0;
 
 		// get line width and split the line

--- a/regen/objects/text/texture-mapped-text.h
+++ b/regen/objects/text/texture-mapped-text.h
@@ -64,13 +64,13 @@ namespace regen {
 		/**
 		 * Sets the centerAtOrigin flag.
 		 */
-		void set_centerAtOrigin(GLboolean centerAtOrigin) { centerAtOrigin_ = centerAtOrigin; }
+		void set_centerAtOrigin(bool centerAtOrigin) { centerAtOrigin_ = centerAtOrigin; }
 
 	protected:
 		ref_ptr<Font> font_;
 		std::list<std::wstring> value_;
 		float height_;
-		GLboolean centerAtOrigin_;
+		bool centerAtOrigin_;
 		uint32_t numCharacters_;
 
 		ref_ptr<ShaderInput4f> textColor_;

--- a/regen/objects/text/texture-mapped-text.h
+++ b/regen/objects/text/texture-mapped-text.h
@@ -28,7 +28,7 @@ namespace regen {
 		 * @param font font for the text.
 		 * @param height text height.
 		 */
-		TextureMappedText(const ref_ptr<Font> &font, const GLfloat &height);
+		TextureMappedText(const ref_ptr<Font> &font, const float &height);
 
 		/**
 		 * @param color the text color.
@@ -46,7 +46,7 @@ namespace regen {
 		void set_value(
 				const std::wstring &value,
 				Alignment alignment = ALIGNMENT_LEFT,
-				GLfloat maxLineWidth = 0.0f);
+				float maxLineWidth = 0.0f);
 
 		/**
 		 * Sets the text to be displayed.
@@ -54,12 +54,12 @@ namespace regen {
 		void set_value(
 				const std::list<std::wstring> &lines,
 				Alignment alignment = ALIGNMENT_LEFT,
-				GLfloat maxLineWidth = 0.0f);
+				float maxLineWidth = 0.0f);
 
 		/**
 		 * Sets the y value of the primitive-set topmost point.
 		 */
-		void set_height(GLfloat height);
+		void set_height(float height);
 
 		/**
 		 * Sets the centerAtOrigin flag.
@@ -69,7 +69,7 @@ namespace regen {
 	protected:
 		ref_ptr<Font> font_;
 		std::list<std::wstring> value_;
-		GLfloat height_;
+		float height_;
 		GLboolean centerAtOrigin_;
 		uint32_t numCharacters_;
 
@@ -79,12 +79,12 @@ namespace regen {
 		ref_ptr<ShaderInput3f> norAttribute_;
 		ref_ptr<ShaderInput3f> texcoAttribute_;
 
-		void updateAttributes(Alignment alignment, GLfloat maxLineWidth);
+		void updateAttributes(Alignment alignment, float maxLineWidth);
 
 		void makeGlyphGeometry(
 				const Font::FaceData &data,
 				const Vec3f &translation,
-				GLfloat layer,
+				float layer,
 				ClientData_rw<Vec3f> &posAttribute,
 				ClientData_rw<Vec3f> &norAttribute,
 				ClientData_rw<Vec3f> &texcoAttribute,

--- a/regen/scene/mesh-processor.cpp
+++ b/regen/scene/mesh-processor.cpp
@@ -147,7 +147,7 @@ void MeshNodeProvider::processInput(
 		bool hasShader = false;
 		if (!meshCopy->hasShaderKey()) {
 			// try to find a shader in the parent node
-			// TODO: what about the LOD levels? might be better to refer to the shader by ID instead
+			// TODO: What about the LOD levels? might be better to refer to the shader by ID instead
 			//        of getting it from the parent. there is also the problem with configuration for compilation
 			//        if shader is shared.
 			auto meshShader = ShaderState::findShader(parent.get());

--- a/regen/scene/node-processor.h
+++ b/regen/scene/node-processor.h
@@ -27,7 +27,7 @@ namespace regen::scene {
 		SortByModelMatrix(
 				const ref_ptr<StateNode> &n,
 				const ref_ptr<Camera> &cam,
-				GLboolean frontToBack)
+				bool frontToBack)
 				: State(),
 				  n_(n),
 				  comparator_(cam, frontToBack) {}

--- a/regen/scene/scene-input.cpp
+++ b/regen/scene/scene-input.cpp
@@ -58,10 +58,10 @@ list<IndexRange> SceneInputNode::getIndexSequence(uint32_t numIndices) {
 	list<IndexRange> indices;
 	if (hasAttribute("index")) {
 		pushIndexToSequence(numIndices, indices,
-			IndexRange(getValue<GLint>("index", 0u)));
+			IndexRange(getValue<int>("index", 0u)));
 	} else if (hasAttribute("instance")) {
 		pushIndexToSequence(numIndices, indices,
-			IndexRange(getValue<GLint>("instance", 0u)));
+			IndexRange(getValue<int>("instance", 0u)));
 	} else if (hasAttribute("from-index") || hasAttribute("to-index")) {
 		auto from = getValue<uint32_t>("from-index", 0u);
 		auto to = getValue<uint32_t>("to-index", numIndices - 1);

--- a/regen/scene/scene.cpp
+++ b/regen/scene/scene.cpp
@@ -141,8 +141,8 @@ void Scene::updateMousePosition() {
 	auto viewport = screen_->viewport();
 	// mouse position in range [0,1] within viewport
 	mouseTexco_->setVertex(0, Vec2f(
-			mousePosition.r.x / (GLfloat) viewport.r.x,
-			1.0f - mousePosition.r.y / (GLfloat) viewport.r.y));
+			mousePosition.r.x / (float) viewport.r.x,
+			1.0f - mousePosition.r.y / (float) viewport.r.y));
 }
 
 void Scene::mouseMove(const Vec2i &pos) {

--- a/regen/scene/scene.cpp
+++ b/regen/scene/scene.cpp
@@ -395,7 +395,7 @@ void Scene::updateBOs() {
 	std::set<const ShaderInput*> visited;
 	nodeQueue.push(renderTree_.get());
 
-	for (auto &anim : AnimationManager::get().graphicsAnimations()) {
+	for (auto &anim : AnimationManager::get().gpuAnimations()) {
 		if(anim->animationState().get() != nullptr)
 			stateQueue.push(anim->animationState().get());
 	}
@@ -477,7 +477,7 @@ namespace regen {
 				Animation(true, false),
 				f_(f) {}
 
-		void glAnimate(RenderState *rs, double dt) override {
+		void gpuUpdate(RenderState *rs, double dt) override {
 			f_();
 			stopAnimation();
 		}

--- a/regen/scene/scene.cpp
+++ b/regen/scene/scene.cpp
@@ -121,7 +121,7 @@ void Scene::addOptionalExtension(const std::string &ext) { optionalExt_.push_bac
 void Scene::mouseEnter() {
 	isMouseEntered_->setVertex(0, 1);
 	ref_ptr<MouseLeaveEvent> event = ref_ptr<MouseLeaveEvent>::alloc();
-	event->entered = GL_TRUE;
+	event->entered = true;
 	queueEmit(MOUSE_LEAVE_EVENT, event);
 }
 
@@ -282,7 +282,7 @@ void Scene::initGL() {
 	glEnable(GL_DEBUG_OUTPUT);
 	glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
 	glDebugMessageCallback(openglDebugCallback, NULL);
-	glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, NULL, GL_TRUE);
+	glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, NULL, true);
 #endif
 
 	setupShaderLoading();
@@ -290,7 +290,7 @@ void Scene::initGL() {
 	BufferObject::createMemoryPools();
 	renderTree_->init();
 	renderState_ = RenderState::get();
-	isGLInitialized_ = GL_TRUE;
+	isGLInitialized_ = true;
 	REGEN_INFO("GL initialized.");
 
 	globalUniforms_ = ref_ptr<UBO>::alloc("GlobalUniforms", BufferUpdateFlags::FULL_PER_FRAME);
@@ -311,7 +311,7 @@ void Scene::setTime() {
 	lastTime_ = boost::posix_time::ptime(
 			boost::posix_time::microsec_clock::local_time());
 	lastMotionTime_ = lastTime_;
-	isTimeInitialized_ = GL_TRUE;
+	isTimeInitialized_ = true;
 }
 
 void Scene::clear() {
@@ -319,7 +319,7 @@ void Scene::clear() {
 	renderTree_->clear();
 	namedToObject_.clear();
 	idToObject_.clear();
-	isTimeInitialized_ = GL_FALSE;
+	isTimeInitialized_ = false;
 	StagingSystem::instance().clear();
 	RenderState::reset();
 	BindingManager::clear();

--- a/regen/scene/scene.cpp
+++ b/regen/scene/scene.cpp
@@ -158,7 +158,7 @@ void Scene::mouseMove(const Vec2i &pos) {
 	updateMousePosition();
 
 	ref_ptr<MouseMotionEvent> event = ref_ptr<MouseMotionEvent>::alloc();
-	event->dt = ((GLdouble) (time - lastMotionTime_).total_microseconds()) / 1000.0;
+	event->dt = ((double) (time - lastMotionTime_).total_microseconds()) / 1000.0;
 	event->dx = dx;
 	event->dy = dy;
 	queueEmit(MOUSE_MOTION_EVENT, event);
@@ -477,7 +477,7 @@ namespace regen {
 				Animation(true, false),
 				f_(f) {}
 
-		void glAnimate(RenderState *rs, GLdouble dt) override {
+		void glAnimate(RenderState *rs, double dt) override {
 			f_();
 			stopAnimation();
 		}

--- a/regen/scene/scene.h
+++ b/regen/scene/scene.h
@@ -149,7 +149,7 @@ namespace regen {
 		/**
 		 * @param enabled enable/disable vsync.
 		 */
-		auto setVSyncEnabled(const GLboolean &enabled) { isVSyncEnabled_ = enabled; }
+		auto setVSyncEnabled(const bool &enabled) { isVSyncEnabled_ = enabled; }
 
 		/**
 		 * Initialize default loggers.

--- a/regen/scene/shader-input-processor.h
+++ b/regen/scene/shader-input-processor.h
@@ -29,7 +29,7 @@ namespace regen {
 		}
 
 		// Override
-		void animate(GLdouble dt) override {
+		void animate(double dt) override {
 			auto mapped = mapClientVertex<float>(BUFFER_GPU_READ | BUFFER_GPU_WRITE, 0);
 			mapped.w = mapped.r + static_cast<float>(dt) * timeScale_;
 		}
@@ -347,7 +347,7 @@ namespace regen {
 					for (const auto &m: n->getChildren("key-frame")) {
 						inputAnimation->push_back(
 								m->getValue<T>("value", T()),
-								m->getValue<GLdouble>("dt", 1.0)
+								m->getValue<double>("dt", 1.0)
 						);
 					}
 					state->attach(inputAnimation);

--- a/regen/scene/shader-input-processor.h
+++ b/regen/scene/shader-input-processor.h
@@ -21,7 +21,7 @@ namespace regen {
 		 * @param timeScale scale for dt values.
 		 * @param name optional timer name.
 		 */
-		explicit TimerInput(GLfloat timeScale, const std::string &name = "time")
+		explicit TimerInput(float timeScale, const std::string &name = "time")
 				: ShaderInput1f(name),
 				  Animation(false, true),
 				  timeScale_(timeScale) {
@@ -35,7 +35,7 @@ namespace regen {
 		}
 
 	private:
-		GLfloat timeScale_;
+		float timeScale_;
 	};
 } // namespace
 
@@ -241,7 +241,7 @@ namespace regen {
 				else {
 					auto type = input.getValue<std::string>("type", "");
 					if (type == "time") {
-						auto scale = input.getValue<GLfloat>("scale", 1.0f);
+						auto scale = input.getValue<float>("scale", 1.0f);
 						auto timer = ref_ptr<TimerInput>::alloc(scale);
 						in = timer;
 						timer->startAnimation();

--- a/regen/scene/shader-input-processor.h
+++ b/regen/scene/shader-input-processor.h
@@ -29,7 +29,7 @@ namespace regen {
 		}
 
 		// Override
-		void animate(double dt) override {
+		void cpuUpdate(double dt) override {
 			auto mapped = mapClientVertex<float>(BUFFER_GPU_READ | BUFFER_GPU_WRITE, 0);
 			mapped.w = mapped.r + static_cast<float>(dt) * timeScale_;
 		}

--- a/regen/scene/shape-processor.cpp
+++ b/regen/scene/shape-processor.cpp
@@ -18,7 +18,6 @@ static ref_ptr<btCollisionShape> createSphere(SceneInputNode &input) {
 
 static ref_ptr<btCollisionShape> createWall(SceneInputNode &input) {
 	auto size = input.getValue<Vec2f>("size", Vec2f::one());
-	// TODO: allow configuration of orientation and position
 	btVector3 halfExtend(size.x * 0.5f, 0.001f, size.y * 0.5f);
 	return ref_ptr<btBoxShape>::alloc(halfExtend);
 }

--- a/regen/scene/shape-processor.cpp
+++ b/regen/scene/shape-processor.cpp
@@ -12,7 +12,7 @@ using namespace regen::scene;
 using namespace regen;
 
 static ref_ptr<btCollisionShape> createSphere(SceneInputNode &input) {
-	auto radius = input.getValue<GLfloat>("radius", 1.0f) * 0.5;
+	auto radius = input.getValue<float>("radius", 1.0f) * 0.5;
 	return ref_ptr<btSphereShape>::alloc(radius);
 }
 
@@ -24,7 +24,7 @@ static ref_ptr<btCollisionShape> createWall(SceneInputNode &input) {
 
 static ref_ptr<btCollisionShape> createInfiniteWall(SceneInputNode &input) {
 	auto planeNormal = input.getValue<Vec3f>("normal", Vec3f(0.0f, 1.0f, 0.0f));
-	auto planeConstant = input.getValue<GLfloat>("constant", GLfloat(0.0f));
+	auto planeConstant = input.getValue<float>("constant", float(0.0f));
 	return ref_ptr<btStaticPlaneShape>::alloc(
 			btVector3(planeNormal.x, planeNormal.y, planeNormal.z),
 			planeConstant);
@@ -44,14 +44,14 @@ static ref_ptr<btCollisionShape> createCylinder(SceneInputNode &input) {
 
 static ref_ptr<btCollisionShape> createCapsule(SceneInputNode &input) {
 	return ref_ptr<btCapsuleShape>::alloc(
-			input.getValue<GLfloat>("radius", 1.0f),
-			input.getValue<GLfloat>("height", 1.0f));
+			input.getValue<float>("radius", 1.0f),
+			input.getValue<float>("height", 1.0f));
 }
 
 static ref_ptr<btCollisionShape> createCone(SceneInputNode &input) {
 	return ref_ptr<btConeShape>::alloc(
-			input.getValue<GLfloat>("radius", 1.0f),
-			input.getValue<GLfloat>("height", 1.0f));
+			input.getValue<float>("radius", 1.0f),
+			input.getValue<float>("height", 1.0f));
 }
 
 static ref_ptr<btCollisionShape>
@@ -152,7 +152,7 @@ static ref_ptr<PhysicalProps> createPhysicalProps(
 		const ref_ptr<Mesh> &mesh,
 		const ref_ptr<btMotionState> &motion) {
 	const std::string shapeName(input.getValue("shape"));
-	auto mass = input.getValue<GLfloat>("mass", 1.0f);
+	auto mass = input.getValue<float>("mass", 1.0f);
 
 	// create a collision shape
 	ref_ptr<btCollisionShape> shape;
@@ -192,34 +192,34 @@ static ref_ptr<PhysicalProps> createPhysicalProps(
 	props->setGravity(btVector3(gravity.x, gravity.y, gravity.z));
 
 	props->setRestitution(
-			input.getValue<GLfloat>("restitution", 0.0f));
+			input.getValue<float>("restitution", 0.0f));
 
 	props->setLinearSleepingThreshold(
-			input.getValue<GLfloat>("linear-sleeping-threshold", 0.8f));
+			input.getValue<float>("linear-sleeping-threshold", 0.8f));
 	props->setAngularSleepingThreshold(
-			input.getValue<GLfloat>("angular-sleeping-threshold", 1.0f));
+			input.getValue<float>("angular-sleeping-threshold", 1.0f));
 
 	props->setFriction(
-			input.getValue<GLfloat>("friction", 0.5f));
+			input.getValue<float>("friction", 0.5f));
 	props->setRollingFriction(
-			input.getValue<GLfloat>("rolling-friction", 0.0f));
+			input.getValue<float>("rolling-friction", 0.0f));
 
 	props->setAdditionalDamping(
 			input.getValue<bool>("additional-damping", false));
 	props->setAdditionalDampingFactor(
-			input.getValue<GLfloat>("additional-damping-factor", 0.005f));
+			input.getValue<float>("additional-damping-factor", 0.005f));
 
 	props->setLinearDamping(
-			input.getValue<GLfloat>("linear-damping", 0.0f));
+			input.getValue<float>("linear-damping", 0.0f));
 	props->setAdditionalLinearDampingThresholdSqr(
-			input.getValue<GLfloat>("additional-linear-damping-threshold", 0.01f));
+			input.getValue<float>("additional-linear-damping-threshold", 0.01f));
 
 	props->setAngularDamping(
-			input.getValue<GLfloat>("angular-damping", 0.0f));
+			input.getValue<float>("angular-damping", 0.0f));
 	props->setAdditionalAngularDampingFactor(
-			input.getValue<GLfloat>("additional-angular-damping-factor", 0.01f));
+			input.getValue<float>("additional-angular-damping-factor", 0.01f));
 	props->setAdditionalAngularDampingThresholdSqr(
-			input.getValue<GLfloat>("additional-angular-damping-threshold", 0.01f));
+			input.getValue<float>("additional-angular-damping-threshold", 0.01f));
 
 	if (mass > 0) props->calculateLocalInertia();
 
@@ -228,7 +228,7 @@ static ref_ptr<PhysicalProps> createPhysicalProps(
 
 static std::optional<float> getRadius(SceneInputNode &input) {
 	if (input.hasAttribute("radius")) {
-		return input.getValue<GLfloat>("radius", 1.0f);
+		return input.getValue<float>("radius", 1.0f);
 	}
 	REGEN_WARN("Ignoring sphere " << input.getDescription() << " without radius or mesh.");
 	return std::nullopt;

--- a/regen/scene/value-generator.h
+++ b/regen/scene/value-generator.h
@@ -118,7 +118,7 @@ namespace regen {
 			T nextFade() {
 				const T start = n_->getValue<T>("start", Vec::create<T>(1.0f));
 				const T stop = n_->getValue<T>("stop", Vec::create<T>(2.0f));
-				const GLfloat progress = ((GLfloat) counter_.x) / ((GLfloat) numValues_);
+				const float progress = ((float) counter_.x) / ((float) numValues_);
 				value_ = start + (stop - start) * progress;
 				counter_.x += 1;
 				return value_;

--- a/regen/shader/directive-processor.cpp
+++ b/regen/shader/directive-processor.cpp
@@ -96,7 +96,7 @@ void DirectiveProcessor::MacroTree::clear() {
 	root_ = MacroBranch();
 }
 
-GLboolean DirectiveProcessor::MacroTree::isDefined(const string &arg) const {
+bool DirectiveProcessor::MacroTree::isDefined(const string &arg) const {
 	return defines_.count(arg) > 0;
 }
 
@@ -243,7 +243,7 @@ void DirectiveProcessor::MacroTree::_if(const string &s) { root_.open(evaluate(s
 
 void DirectiveProcessor::MacroTree::_elif(const string &s) { root_.add(evaluate(s)); }
 
-void DirectiveProcessor::MacroTree::_else() { root_.add(GL_TRUE); }
+void DirectiveProcessor::MacroTree::_else() { root_.add(true); }
 
 void DirectiveProcessor::MacroTree::_endif() { root_.close(); }
 
@@ -257,7 +257,7 @@ bool DirectiveProcessor::MacroTree::isDefined() { return root_.getActive().isDef
 DirectiveProcessor::DirectiveProcessor()
 		: GLSLProcessor("Directives"),
 		  continuedLine_(""),
-		  wasEmpty_(GL_TRUE),
+		  wasEmpty_(true),
 		  lastStage_(GL_NONE) {}
 
 void DirectiveProcessor::parseVariables(string &line) {
@@ -269,7 +269,7 @@ void DirectiveProcessor::parseVariables(string &line) {
 
 	if (regexIt == NO_REGEX_MATCH) { return; }
 
-	GLboolean replacedSomething = GL_FALSE;
+	bool replacedSomething = false;
 
 	for (; regexIt != NO_REGEX_MATCH; ++regexIt) {
 		const string &match = (*regexIt)[1];
@@ -281,12 +281,12 @@ void DirectiveProcessor::parseVariables(string &line) {
 		const string &value = tree_.define(name);
 		if (value != name) {
 			boost::replace_all(line, "${" + name + "}", value);
-			replacedSomething = GL_TRUE;
+			replacedSomething = true;
 		}
 	}
 
 	// parse nested vars
-	if (replacedSomething == GL_TRUE) parseVariables(line);
+	if (replacedSomething == true) parseVariables(line);
 }
 
 void DirectiveProcessor::clear() {
@@ -301,7 +301,7 @@ bool DirectiveProcessor::process(PreProcessorState &state, string &line) {
 		continuedLine_.clear();
 		forBranch_.clear();
 		forLoopCounter_ = 0;
-		wasEmpty_ = GL_TRUE;
+		wasEmpty_ = true;
 	}
 
 	if (inputs_.empty()) {
@@ -335,7 +335,7 @@ bool DirectiveProcessor::process(PreProcessorState &state, string &line) {
 	string statement(line);
 	boost::trim(statement);
 
-	GLboolean isEmpty = statement.empty();
+	bool isEmpty = statement.empty();
 	if (isEmpty && wasEmpty_) {
 		return DirectiveProcessor::getline(state, line);
 	}

--- a/regen/shader/directive-processor.cpp
+++ b/regen/shader/directive-processor.cpp
@@ -115,7 +115,7 @@ string DirectiveProcessor::MacroTree::define(const string &arg) {
 		const string &arg0 = define(arg0_);
 		const string &arg1 = define(arg1_);
 		if (!isNumber(arg0) || !isNumber(arg1)) return arg;
-		GLfloat number0, number1;
+		float number0, number1;
 		stringstream(arg0) >> number0;
 		stringstream(arg1) >> number1;
 		if (op == "+") return REGEN_STRING(number0 + number1);

--- a/regen/shader/directive-processor.h
+++ b/regen/shader/directive-processor.h
@@ -75,7 +75,7 @@ namespace regen {
 
       void clear();
 
-      GLboolean isDefined(const std::string &arg) const;
+      bool isDefined(const std::string &arg) const;
       std::string define(const std::string &arg);
 
       bool evaluateInner(const std::string &expression);
@@ -109,7 +109,7 @@ namespace regen {
     ForBranch forBranch_;
     uint32_t forLoopCounter_ = 0;
 
-    GLboolean wasEmpty_;
+    bool wasEmpty_;
     GLenum lastStage_;
 
     void parseVariables(std::string &line);

--- a/regen/shader/io-processor.cpp
+++ b/regen/shader/io-processor.cpp
@@ -61,7 +61,7 @@ string IOProcessor::InputOutput::declaration() {
 
 IOProcessor::IOProcessor()
 		: GLSLProcessor("InputOutput"),
-		  isInputSpecified_(GL_FALSE),
+		  isInputSpecified_(false),
 		  currStage_(-1) {
 }
 
@@ -442,7 +442,7 @@ void IOProcessor::clear() {
 	uniforms_.clear();
 	lineQueue_.clear();
 	inputNames_.clear();
-	isInputSpecified_ = GL_FALSE;
+	isInputSpecified_ = false;
 	currStage_ = -1;
 }
 
@@ -461,7 +461,7 @@ bool IOProcessor::process(PreProcessorState &state, string &line) {
 
 	if (currStage_ != state.currStage) {
 		inputNames_.clear();
-		isInputSpecified_ = GL_FALSE;
+		isInputSpecified_ = false;
 		currStage_ = state.currStage;
 	}
 
@@ -482,7 +482,7 @@ bool IOProcessor::process(PreProcessorState &state, string &line) {
 	if (it != NO_REGEX_MATCH) {
 		if (!isInputSpecified_) {
 			declareSpecifiedInput(state);
-			isInputSpecified_ = GL_TRUE;
+			isInputSpecified_ = true;
 		}
 		defineHandleIO(state);
 		return process(state, line);
@@ -507,7 +507,7 @@ bool IOProcessor::process(PreProcessorState &state, string &line) {
 
 	if (!isInputSpecified_) {
 		declareSpecifiedInput(state);
-		isInputSpecified_ = GL_TRUE;
+		isInputSpecified_ = true;
 	}
 
 	io.ioType = (*it)[2];

--- a/regen/shader/io-processor.h
+++ b/regen/shader/io-processor.h
@@ -84,7 +84,7 @@ namespace regen {
 		std::map<GLenum, std::map<std::string, InputOutput> > outputs_;
 		std::map<GLenum, std::map<std::string, InputOutput> > uniforms_;
 		std::set<std::string> inputNames_;
-		GLboolean isInputSpecified_;
+		bool isInputSpecified_;
 		GLenum currStage_;
 
 		void declareSpecifiedInput(PreProcessorState &state);

--- a/regen/shader/preprocessor.cpp
+++ b/regen/shader/preprocessor.cpp
@@ -59,7 +59,7 @@ std::map<GLenum, std::string> PreProcessor::processStages(const PreProcessorInpu
 
 	// reverse process stages, because stages must know inputs
 	// of next stages.
-	for (GLint i = glenum::glslStageCount() - 1; i >= 0; --i) {
+	for (int i = glenum::glslStageCount() - 1; i >= 0; --i) {
 		GLenum stage = glenum::glslStages()[i];
 #ifdef DEBUG_GLSL_PREPROCESSOR
 		REGEN_DEBUG("[GLSL] Processing " << glenum::glslStageName(stage) << ".");

--- a/regen/shader/shader-input.cpp
+++ b/regen/shader/shader-input.cpp
@@ -617,7 +617,7 @@ ShaderInputMat3::ShaderInputMat3(
 		uint32_t numArrayElements,
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
-	transpose_ = GL_FALSE;
+	transpose_ = false;
 	enableAttribute_ = &ShaderInput::enableAttributeMat3;
 	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
@@ -630,7 +630,7 @@ ShaderInputMat4::ShaderInputMat4(
 		uint32_t numArrayElements,
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
-	transpose_ = GL_FALSE;
+	transpose_ = false;
 	enableAttribute_ = &ShaderInput::enableAttributeMat4;
 	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);

--- a/regen/shader/shader-input.cpp
+++ b/regen/shader/shader-input.cpp
@@ -167,7 +167,7 @@ void ShaderInput::set_buffer(uint32_t buffer, const ref_ptr<BufferReference> &it
 	bufferStamp_ = stampOfReadData();
 }
 
-void ShaderInput::enableAttribute(GLint loc) const {
+void ShaderInput::enableAttribute(int loc) const {
 	// TODO: Avoid writing server data here, this should be handled more centrally e.g. via the staging system.
 	//           - writeServerData can then be removed, it is only used here currently.
 	if (clientBuffer_->stampOfReadData() != bufferStamp_) {
@@ -177,7 +177,7 @@ void ShaderInput::enableAttribute(GLint loc) const {
 	(this->*(this->enableAttribute_))(loc);
 }
 
-void ShaderInput::enableUniform(GLint loc) const {
+void ShaderInput::enableUniform(int loc) const {
 	enableInput_(loc);
 }
 
@@ -445,7 +445,7 @@ ref_ptr<ShaderInput> ShaderInput::copy(const ref_ptr<ShaderInput> &in, bool copy
 /////////////
 /////////////
 
-void ShaderInput::enableAttribute_f(GLint location) const {
+void ShaderInput::enableAttribute_f(int location) const {
 	for (unsigned int i = 0; i < numArrayElements_; ++i) {
 		auto loc = location + i;
 		glEnableVertexAttribArray(loc);
@@ -462,7 +462,7 @@ void ShaderInput::enableAttribute_f(GLint location) const {
 	}
 }
 
-void ShaderInput::enableAttribute_i(GLint location) const {
+void ShaderInput::enableAttribute_i(int location) const {
 	for (unsigned int i = 0; i < numArrayElements_; ++i) {
 		auto loc = location + i;
 		glEnableVertexAttribArray(loc);
@@ -480,7 +480,7 @@ void ShaderInput::enableAttribute_i(GLint location) const {
 	}
 }
 
-void ShaderInput::enableAttributeMat4(GLint location) const {
+void ShaderInput::enableAttributeMat4(int location) const {
 	for (unsigned int i = 0; i < numArrayElements_ * 4; i += 4) {
 		auto loc0 = location + i;
 		auto loc1 = location + i + 1;
@@ -514,7 +514,7 @@ void ShaderInput::enableAttributeMat4(GLint location) const {
 	}
 }
 
-void ShaderInput::enableAttributeMat3(GLint location) const {
+void ShaderInput::enableAttributeMat3(int location) const {
 	for (unsigned int i = 0; i < numArrayElements_ * 3; i += 4) {
 		auto loc0 = location + i;
 		auto loc1 = location + i + 1;
@@ -542,7 +542,7 @@ void ShaderInput::enableAttributeMat3(GLint location) const {
 	}
 }
 
-void ShaderInput::enableAttributeMat2(GLint location) const {
+void ShaderInput::enableAttributeMat2(int location) const {
 	for (unsigned int i = 0; i < numArrayElements_ * 2; i += 4) {
 		auto loc0 = location + i;
 		auto loc1 = location + i + 1;
@@ -573,7 +573,7 @@ ShaderInput1f::ShaderInput1f(
 		uint32_t numArrayElements,
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform1fv(loc, numElements_i_, (float *) mapped.r);
 	};
@@ -584,7 +584,7 @@ ShaderInput2f::ShaderInput2f(
 		uint32_t numArrayElements,
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform2fv(loc, numElements_i_, (float *) mapped.r);
 	};
@@ -595,7 +595,7 @@ ShaderInput3f::ShaderInput3f(
 		uint32_t numArrayElements,
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform3fv(loc, numElements_i_, (float *) mapped.r);
 	};
@@ -606,7 +606,7 @@ ShaderInput4f::ShaderInput4f(
 		uint32_t numArrayElements,
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform4fv(loc, numElements_i_, (float *) mapped.r);
 	};
@@ -619,7 +619,7 @@ ShaderInputMat3::ShaderInputMat3(
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	transpose_ = GL_FALSE;
 	enableAttribute_ = &ShaderInput::enableAttributeMat3;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniformMatrix3fv(loc, numElements_i_, transpose_, (float *) mapped.r);
 	};
@@ -632,7 +632,7 @@ ShaderInputMat4::ShaderInputMat4(
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	transpose_ = GL_FALSE;
 	enableAttribute_ = &ShaderInput::enableAttributeMat4;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniformMatrix4fv(loc, numElements_i_, transpose_, (float *) mapped.r);
 	};
@@ -643,7 +643,7 @@ ShaderInput1d::ShaderInput1d(
 		uint32_t numArrayElements,
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform1dv(loc, numElements_i_, (double *) mapped.r);
 	};
@@ -654,7 +654,7 @@ ShaderInput2d::ShaderInput2d(
 		uint32_t numArrayElements,
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform2dv(loc, numElements_i_, (double *) mapped.r);
 	};
@@ -665,7 +665,7 @@ ShaderInput3d::ShaderInput3d(
 		uint32_t numArrayElements,
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform3dv(loc, numElements_i_, (double *) mapped.r);
 	};
@@ -676,7 +676,7 @@ ShaderInput4d::ShaderInput4d(
 		uint32_t numArrayElements,
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform4dv(loc, numElements_i_, (double *) mapped.r);
 	};
@@ -688,7 +688,7 @@ ShaderInput1i::ShaderInput1i(
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	enableAttribute_ = &ShaderInput::enableAttribute_i;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform1iv(loc, numElements_i_, (int *) mapped.r);
 	};
@@ -700,7 +700,7 @@ ShaderInput2i::ShaderInput2i(
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	enableAttribute_ = &ShaderInput::enableAttribute_i;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform2iv(loc, numElements_i_, (int *) mapped.r);
 	};
@@ -712,7 +712,7 @@ ShaderInput3i::ShaderInput3i(
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	enableAttribute_ = &ShaderInput::enableAttribute_i;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform3iv(loc, numElements_i_, (int *) mapped.r);
 	};
@@ -724,7 +724,7 @@ ShaderInput4i::ShaderInput4i(
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	enableAttribute_ = &ShaderInput::enableAttribute_i;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform4iv(loc, numElements_i_, (int *) mapped.r);
 	};
@@ -736,7 +736,7 @@ ShaderInput1ui::ShaderInput1ui(
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	enableAttribute_ = &ShaderInput::enableAttribute_i;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform1uiv(loc, numElements_i_, (unsigned int *) mapped.r);
 	};
@@ -748,7 +748,7 @@ ShaderInput1ui_16::ShaderInput1ui_16(
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	enableAttribute_ = &ShaderInput::enableAttribute_i;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform1uiv(loc, numElements_i_, (unsigned int *) mapped.r);
 	};
@@ -760,7 +760,7 @@ ShaderInput1ui_8::ShaderInput1ui_8(
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	enableAttribute_ = &ShaderInput::enableAttribute_i;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform1uiv(loc, numElements_i_, (unsigned int *) mapped.r);
 	};
@@ -772,7 +772,7 @@ ShaderInput2ui::ShaderInput2ui(
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	enableAttribute_ = &ShaderInput::enableAttribute_i;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform2uiv(loc, numElements_i_, (unsigned int *) mapped.r);
 	};
@@ -784,7 +784,7 @@ ShaderInput3ui::ShaderInput3ui(
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	enableAttribute_ = &ShaderInput::enableAttribute_i;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform3uiv(loc, numElements_i_, (unsigned int *) mapped.r);
 	};
@@ -796,7 +796,7 @@ ShaderInput4ui::ShaderInput4ui(
 		bool normalize)
 		: ShaderInputTyped(name, numArrayElements, normalize) {
 	enableAttribute_ = &ShaderInput::enableAttribute_i;
-	enableInput_ = [this](GLint loc) {
+	enableInput_ = [this](int loc) {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_READ);
 		glUniform4uiv(loc, numElements_i_, (unsigned int *) mapped.r);
 	};

--- a/regen/shader/shader-input.h
+++ b/regen/shader/shader-input.h
@@ -571,39 +571,39 @@ namespace regen {
 		 * Binds vertex attribute for active buffer to the
 		 * given shader location.
 		 */
-		void enableAttribute(GLint loc) const;
+		void enableAttribute(int loc) const;
 
 		/**
 		 * Binds uniform to the given shader location.
 		 */
-		void enableUniform(GLint loc) const;
+		void enableUniform(int loc) const;
 
 		/**
 		 * Bind the attribute to the given shader location.
 		 */
-		void enableAttribute_f(GLint location) const;
+		void enableAttribute_f(int location) const;
 
 		/**
 		 * Only the integer types GL_BYTE, GL_UNSIGNED_BYTE, GL_SHORT,
 		 * GL_UNSIGNED_SHORT, GL_INT, GL_UNSIGNED_INT are accepted.
 		 * Values are always left as integer values.
 		 */
-		void enableAttribute_i(GLint location) const;
+		void enableAttribute_i(int location) const;
 
 		/**
 		 * Matrix attributes have special enable functions.
 		 */
-		void enableAttributeMat4(GLint location) const;
+		void enableAttributeMat4(int location) const;
 
 		/**
 		 * Matrix attributes have special enable functions.
 		 */
-		void enableAttributeMat3(GLint location) const;
+		void enableAttributeMat3(int location) const;
 
 		/**
 		 * Matrix attributes have special enable functions.
 		 */
-		void enableAttributeMat2(GLint location) const;
+		void enableAttributeMat2(int location) const;
 
 		/**
 		 * @return the input schema.
@@ -671,9 +671,9 @@ namespace regen {
 
 		const InputSchema *schema_ = InputSchema::unknown();
 
-		void (ShaderInput::*enableAttribute_)(GLint loc) const;
+		void (ShaderInput::*enableAttribute_)(int loc) const;
 
-		std::function<void(GLint)> enableInput_;
+		std::function<void(int)> enableInput_;
 
 		ShaderInput(const ShaderInput &);
 

--- a/regen/shader/shader-input.h
+++ b/regen/shader/shader-input.h
@@ -311,15 +311,15 @@ namespace regen {
 		void set_isVertexAttribute(bool isVertexAttribute);
 
 		/**
-		 * Specifies whether fixed-point data values should be normalized (GL_TRUE)
-		 * or converted directly as fixed-point values (GL_FALSE) when they are accessed.
+		 * Specifies whether fixed-point data values should be normalized (true)
+		 * or converted directly as fixed-point values (false) when they are accessed.
 		 */
 		bool normalize() const { return normalize_; }
 
 		/**
 		 * @param transpose transpose the data.
 		 */
-		void set_transpose(GLboolean transpose) { transpose_ = transpose; }
+		void set_transpose(bool transpose) { transpose_ = transpose; }
 
 		/**
 		 * @return transpose the data.
@@ -336,7 +336,7 @@ namespace regen {
 		 * Constants can not change the value during the lifetime
 		 * of the shader program.
 		 */
-		void set_isConstant(GLboolean isConstant) { isConstant_ = isConstant; }
+		void set_isConstant(bool isConstant) { isConstant_ = isConstant; }
 
 		/**
 		 * Constants can not change the value during the lifetime
@@ -359,7 +359,7 @@ namespace regen {
 		 * with [1] in the generated shader if forceArray is true.
 		 * Note: attributes can not be arrays.
 		 */
-		void set_forceArray(GLboolean forceArray) { forceArray_ = forceArray; }
+		void set_forceArray(bool forceArray) { forceArray_ = forceArray; }
 
 		/**
 		 * Uniforms with a single array element will appear
@@ -726,7 +726,7 @@ namespace regen {
 				const std::string &name,
 				uint32_t structSize,
 				uint32_t numArrayElements,
-				GLboolean normalize)
+				bool normalize)
 				: ShaderInput(name, GL_NONE, structSize, 1, numArrayElements, normalize),
 				  structTypeName_(structTypeName) {
 			isStruct_ = true;
@@ -757,7 +757,7 @@ namespace regen {
 				const std::string &typeName,
 				const std::string &name,
 				uint32_t numArrayElements,
-				GLboolean normalize = GL_FALSE)
+				bool normalize = false)
 				: ShaderStructBase(typeName, name, sizeof(StructType), numArrayElements, normalize) {}
 
 		~ShaderInputStruct() override = default;
@@ -815,7 +815,7 @@ namespace regen {
 		ShaderInputTyped(
 				const std::string &name,
 				uint32_t numArrayElements,
-				GLboolean normalize)
+				bool normalize)
 				: ShaderInput(name,
 							  TypeValue,
 							  sizeof(BaseType),

--- a/regen/shader/shader-input.h
+++ b/regen/shader/shader-input.h
@@ -999,7 +999,7 @@ namespace regen {
 	/**
 	 * \brief Provides 1D double input to shader programs.
 	 */
-	class ShaderInput1d : public ShaderInputTyped<GLdouble, double, GL_DOUBLE> {
+	class ShaderInput1d : public ShaderInputTyped<double, double, GL_DOUBLE> {
 	public:
 		/**
 		 * @param name the input name.

--- a/regen/shader/shader-state.cpp
+++ b/regen/shader/shader-state.cpp
@@ -43,14 +43,14 @@ void ShaderState::loadStage(
 	if (code[stage].empty()) { code.erase(stage); }
 }
 
-GLboolean ShaderState::createShader(const StateConfig &cfg, const std::string &shaderKey) {
+bool ShaderState::createShader(const StateConfig &cfg, const std::string &shaderKey) {
 	std::map<GLenum, std::string> unprocessedCode;
 	for (int i = 0; i < glenum::glslStageCount(); ++i) {
 		loadStage(cfg.defines_, shaderKey, unprocessedCode, glenum::glslStages()[i]);
 	}
 	if (unprocessedCode.empty()) {
 		REGEN_ERROR("Failed to load shader with key '" << shaderKey << "'");
-		return GL_FALSE;
+		return false;
 	}
 	if(createShader(cfg, unprocessedCode)) {
 		REGEN_INFO("Shader [" << shader_->id() << "] successfully loaded from '" << shaderKey << "'.");
@@ -60,7 +60,7 @@ GLboolean ShaderState::createShader(const StateConfig &cfg, const std::string &s
 	}
 }
 
-GLboolean ShaderState::createShader(const StateConfig &cfg, const std::vector<std::string> &shaderKeys) {
+bool ShaderState::createShader(const StateConfig &cfg, const std::vector<std::string> &shaderKeys) {
 	std::map<GLenum, std::string> unprocessedCode;
 	for (uint32_t i = 0u; i < shaderKeys.size(); ++i) {
 		auto stage = glenum::glslStages()[i];
@@ -70,7 +70,7 @@ GLboolean ShaderState::createShader(const StateConfig &cfg, const std::vector<st
 	}
 	if (unprocessedCode.empty()) {
 		REGEN_ERROR("Failed to load shader with key '" << shaderKeys[0] << "'");
-		return GL_FALSE;
+		return false;
 	}
 	if(createShader(cfg, unprocessedCode)) {
 		REGEN_INFO("Shader [" << shader_->id() << "] successfully loaded from '" << shaderKeys[0] << ", ...'");
@@ -80,7 +80,7 @@ GLboolean ShaderState::createShader(const StateConfig &cfg, const std::vector<st
 	}
 }
 
-GLboolean ShaderState::createShader(const StateConfig &cfg, const std::map<GLenum, std::string> &unprocessedCode) {
+bool ShaderState::createShader(const StateConfig &cfg, const std::map<GLenum, std::string> &unprocessedCode) {
 	std::map<GLenum, std::string> processedCode;
 
 	PreProcessorConfig preProcessCfg(
@@ -101,7 +101,7 @@ GLboolean ShaderState::createShader(const StateConfig &cfg, const std::map<GLenu
 		for (auto it = processedCode.begin(); it != processedCode.end(); ++it) {
 			REGEN_DEBUG("Shader code failed to compile:\n" << it->second);
 		}
-		return GL_FALSE;
+		return false;
 	}
 	if (!shader_->link()) {
 		REGEN_ERROR("Shader failed to link.");
@@ -116,7 +116,7 @@ GLboolean ShaderState::createShader(const StateConfig &cfg, const std::map<GLenu
 		shader_->setTexture(texture.second.first, texture.first);
 	}
 
-	return GL_TRUE;
+	return true;
 }
 
 const ref_ptr<Shader> &ShaderState::shader() const { return shader_; }

--- a/regen/shader/shader-state.cpp
+++ b/regen/shader/shader-state.cpp
@@ -45,7 +45,7 @@ void ShaderState::loadStage(
 
 GLboolean ShaderState::createShader(const StateConfig &cfg, const std::string &shaderKey) {
 	std::map<GLenum, std::string> unprocessedCode;
-	for (GLint i = 0; i < glenum::glslStageCount(); ++i) {
+	for (int i = 0; i < glenum::glslStageCount(); ++i) {
 		loadStage(cfg.defines_, shaderKey, unprocessedCode, glenum::glslStages()[i]);
 	}
 	if (unprocessedCode.empty()) {

--- a/regen/shader/shader-state.h
+++ b/regen/shader/shader-state.h
@@ -25,11 +25,11 @@ namespace regen {
 		 * Load, compile and link shader with given include key.
 		 * @param cfg the shader config.
 		 * @param shaderKey the shader include key.
-		 * @return GL_TRUE on success.
+		 * @return true on success.
 		 */
-		GLboolean createShader(const StateConfig &cfg, const std::string &shaderKey);
+		bool createShader(const StateConfig &cfg, const std::string &shaderKey);
 
-		GLboolean createShader(const StateConfig &cfg, const std::vector<std::string> &shaderKeys);
+		bool createShader(const StateConfig &cfg, const std::vector<std::string> &shaderKeys);
 
 		/**
 		 * @return the shader object.
@@ -51,7 +51,7 @@ namespace regen {
 	protected:
 		ref_ptr<Shader> shader_;
 
-		GLboolean createShader(const StateConfig &cfg, const std::map<GLenum, std::string> &unprocessedCode);
+		bool createShader(const StateConfig &cfg, const std::map<GLenum, std::string> &unprocessedCode);
 
 		void loadStage(
 				const std::map<std::string, std::string> &shaderConfig,

--- a/regen/shader/shader.cpp
+++ b/regen/shader/shader.cpp
@@ -86,7 +86,7 @@ void Shader::printLog(
 		uint32_t shader,
 		GLenum shaderType,
 		const char *shaderCode,
-		GLboolean success) {
+		bool success) {
 	Logging::LogLevel logLevel;
 	if (shaderCode != nullptr) {
 		std::string shaderName = glenum::glslStageName(shaderType);
@@ -325,7 +325,7 @@ bool Shader::link() {
 	int status;
 	glGetProgramiv(id(), GL_LINK_STATUS, &status);
 	GL_ERROR_LOG();
-	if (status == GL_FALSE) {
+	if (status == false) {
 		for (auto &shaderCode: shaderCodes_) {
 			const char *source = shaderCode.second.c_str();
 			printLog(id(), shaderCode.first, source, false);
@@ -343,7 +343,7 @@ bool Shader::validate() {
 	glValidateProgram(id());
 	int status;
 	glGetProgramiv(id(), GL_VALIDATE_STATUS, &status);
-	if (status == GL_FALSE) {
+	if (status == false) {
 		int length;
 		glGetProgramiv(id(), GL_INFO_LOG_LENGTH, &length);
 		char *log = new char[length];

--- a/regen/shader/shader.cpp
+++ b/regen/shader/shader.cpp
@@ -240,17 +240,17 @@ ref_ptr<ShaderInput> Shader::input(const std::string &name) {
 	}
 }
 
-GLint Shader::samplerLocation(const std::string &name) {
+int Shader::samplerLocation(const std::string &name) {
 	auto it = samplerLocations_.find(name);
 	return (it != samplerLocations_.end()) ? it->second : -1;
 }
 
-GLint Shader::attributeLocation(const std::string &name) {
+int Shader::attributeLocation(const std::string &name) {
 	auto it = attributeLocations_.find(name);
 	return (it != attributeLocations_.end()) ? it->second : -1;
 }
 
-GLint Shader::uniformLocation(const std::string &name) {
+int Shader::uniformLocation(const std::string &name) {
 	auto it = uniformLocations_.find(name);
 	return (it != uniformLocations_.end()) ? it->second : -1;
 }
@@ -265,8 +265,8 @@ bool Shader::compile() {
 		ref_ptr<uint32_t> shaderStage = ref_ptr<uint32_t>::alloc();
 		uint32_t &stage = *shaderStage.get();
 		stage = glCreateShader(shaderCode.first);
-		GLint length = -1;
-		GLint status;
+		int length = -1;
+		int status;
 
 		glShaderSource(stage, 1, &source, &length);
 		glCompileShader(stage);
@@ -292,12 +292,12 @@ bool Shader::link() {
 		int validCounter = 0;
 
 		GLenum stage = feedbackStage_;
-		GLint i = 0;
+		int i = 0;
 		for (; glenum::glslStages()[i] != stage; ++i) {}
 
 		// find next stage
 		std::string nextStagePrefix = "out";
-		for (GLint j = i + 1; j < glenum::glslStageCount(); ++j) {
+		for (int j = i + 1; j < glenum::glslStageCount(); ++j) {
 			GLenum nextStage = glenum::glslStages()[j];
 			if (shaders_.count(nextStage) != 0) {
 				nextStagePrefix = glenum::glslStagePrefix(nextStage);
@@ -341,7 +341,7 @@ bool Shader::link() {
 
 bool Shader::validate() {
 	glValidateProgram(id());
-	GLint status;
+	int status;
 	glGetProgramiv(id(), GL_VALIDATE_STATUS, &status);
 	if (status == GL_FALSE) {
 		int length;
@@ -357,8 +357,8 @@ bool Shader::validate() {
 }
 
 void Shader::setupInputLocations() {
-	GLint count;
-	GLint arraySize;
+	int count;
+	int arraySize;
 	GLenum type;
 	char nameC[320];
 
@@ -565,7 +565,7 @@ ref_ptr<ShaderInput> Shader::createUniform(const std::string &name) {
 		return {};
 	}
 
-	GLint arraySize;
+	int arraySize;
 	GLenum type;
 	char nameC[320];
 	glGetActiveUniform(id(), loc, 320, nullptr, &arraySize, &type, nameC);

--- a/regen/shader/shader.h
+++ b/regen/shader/shader.h
@@ -53,7 +53,7 @@ namespace regen {
 				uint32_t shader,
 				GLenum shaderType,
 				const char *shaderCode,
-				GLboolean success);
+				bool success);
 
 		/////////////
 
@@ -94,7 +94,7 @@ namespace regen {
 		bool link();
 
 		/**
-		 * @return GL_TRUE if the validation was successful.
+		 * @return true if the validation was successful.
 		 */
 		bool validate();
 

--- a/regen/shader/shader.h
+++ b/regen/shader/shader.h
@@ -246,7 +246,7 @@ namespace regen {
 
 		std::list<InputLocation> attributes_;
 		std::list<InputLocation> uniforms_;
-		std::map<GLint, TextureLocation> textures_;
+		std::map<int, TextureLocation> textures_;
 		// available inputs
 		ShaderInputList inputs_;
 		std::map<std::string, ShaderInputList::iterator> inputNames_;

--- a/regen/shapes/lod-state.cpp
+++ b/regen/shapes/lod-state.cpp
@@ -37,7 +37,7 @@ namespace regen {
 				: Animation(false, true),
 				  lodState_(lodState) {}
 
-		void animate(double dt) override {
+		void cpuUpdate(double dt) override {
 			lodState_->resetVisibility();
 			lodState_->traverseCPU();
 		}

--- a/regen/shapes/spatial-index-debug.cpp
+++ b/regen/shapes/spatial-index-debug.cpp
@@ -19,7 +19,7 @@ SpatialIndexDebug::SpatialIndexDebug(const ref_ptr<SpatialIndex> &index)
 	lineVertices_->setVertexData(2);
 	// Create and set up the VAO and VBO
 	vao_ = ref_ptr<VAO>::alloc();
-	bufferSize_ = sizeof(GLfloat) * 3 * lineVertices_->numVertices();
+	bufferSize_ = sizeof(float) * 3 * lineVertices_->numVertices();
 	glGenBuffers(1, &vbo_);
 }
 

--- a/regen/shapes/spatial-index-debug.h
+++ b/regen/shapes/spatial-index-debug.h
@@ -38,7 +38,7 @@ namespace regen {
 		ref_ptr<SpatialIndex> index_;
 		ref_ptr<ShaderInput3f> lineColor_;
 		ref_ptr<ShaderInput3f> lineVertices_;
-		GLint lineLocation_;
+		int lineLocation_;
 
 		void debugFrustum(const Frustum &frustum, const Vec3f &color = Vec3f(0.0f, 1.0f, 0.0f));
 

--- a/regen/simulation/boid-simulation.cpp
+++ b/regen/simulation/boid-simulation.cpp
@@ -141,8 +141,6 @@ void BoidSimulation::updateGridSize() {
 	gridBounds_.min = simMin.r;
 	gridBounds_.max = simMax.r;
 #else
-	// TODO: improve this, e.g. never shrink, but allow to translate in case
-	//        whole swarm moves in a direction
 	gridBounds_.min = Vec3f::min(gridBounds_.min, Vec3f::max(boidBounds_.min, simMin.r));
 	gridBounds_.max = Vec3f::max(gridBounds_.max, Vec3f::min(boidBounds_.max, simMax.r));
 #endif
@@ -306,7 +304,6 @@ void BoidSimulation::loadSettings(LoadingContext &ctx, scene::SceneInputNode &in
 			auto transformID = objectNode->getValue("tf");
 			auto transform = ctx.scene()->getResource<ModelTransformation>(transformID);
 			if (transform.get() != nullptr) {
-				// TODO: Use ModelTransformation instead of ShaderInputMat4 below.
 				entityTF = transform->modelMat();
 			}
 		} else if (objectNode->hasAttribute("point")) {

--- a/regen/simulation/boids-cpu.cpp
+++ b/regen/simulation/boids-cpu.cpp
@@ -279,6 +279,8 @@ void BoidsCPU::cpuUpdate(double dt) {
 	clearGrid();
 	if (priv_->grid_.empty()) { return; }
 
+	// Update boidGridIndex_: per boid grid cell index
+	updateCellIndex();
 	// add boids to the grid and compute their neighborhood relations.
 	updateGrid();
 
@@ -393,20 +395,15 @@ void BoidsCPU::clearGrid() {
 	}
 }
 
-void BoidsCPU::updateGrid() {
+void BoidsCPU::updateCellIndex() {
 	const auto numBoids = static_cast<int32_t>(numBoids_);
 
-	// iterate over all boids and add them to the grid, compute the index
-	// based on the boid position and the grid bounds.
-	// Note: There is quite a bottleneck in updateNeighbours. Probably can only be improved
-	//       by coming up with a more efficient approach.
-	int32_t boidIdx = 0u;
-
-	auto* __restrict boidPosX = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsX_.data(), 32));
-	auto* __restrict boidPosY = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsY_.data(), 32));
-	auto* __restrict boidPosZ = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsZ_.data(), 32));
-	auto* __restrict cellCounts = static_cast<int32_t*>(__builtin_assume_aligned(priv_->cellCounts_.data(), 32));
+	const auto* __restrict boidPosX = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsX_.data(), 32));
+	const auto* __restrict boidPosY = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsY_.data(), 32));
+	const auto* __restrict boidPosZ = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsZ_.data(), 32));
 	auto* __restrict boidGridIndex = static_cast<int32_t*>(__builtin_assume_aligned(priv_->boidGridIndex_.data(), 32));
+
+	int32_t boidIdx = 0u;
 
 	if constexpr (BOID_USE_SIMD) {
 		const BatchOf_Vec3f gridMin = BatchOf_Vec3f::fromScalar(gridBounds_.min);
@@ -449,6 +446,19 @@ void BoidsCPU::updateGrid() {
 		const Vec3i idx3D = getGridIndex3D(boidPos);
 		boidGridIndex[boidIdx] = getGridIndex(idx3D, priv_->gridSize_);
 	}
+}
+
+void BoidsCPU::updateGrid() {
+	const auto numBoids = static_cast<int32_t>(numBoids_);
+
+	// iterate over all boids and add them to the grid, compute the index
+	// based on the boid position and the grid bounds.
+	// Note: There is quite a bottleneck in updateNeighbours. Probably can only be improved
+	//       by coming up with a more efficient approach.
+	int32_t boidIdx = 0u;
+
+	auto* __restrict cellCounts = static_cast<int32_t*>(__builtin_assume_aligned(priv_->cellCounts_.data(), 32));
+	const auto* __restrict boidGridIndex = static_cast<int32_t*>(__builtin_assume_aligned(priv_->boidGridIndex_.data(), 32));
 
 	for (boidIdx = 0; boidIdx < numBoids; ++boidIdx) {
 		const uint32_t cellIndex = boidGridIndex[boidIdx];
@@ -468,9 +478,9 @@ void BoidsCPU::updateGrid() {
 }
 
 void BoidsCPU::updateNeighbours(int32_t boidIdx, const int32_t *neighborIndices, uint32_t neighborCount) {
-	auto* __restrict globalX = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsX_.data(), 32));
-	auto* __restrict globalY = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsY_.data(), 32));
-	auto* __restrict globalZ = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsZ_.data(), 32));
+	const auto* __restrict globalX = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsX_.data(), 32));
+	const auto* __restrict globalY = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsY_.data(), 32));
+	const auto* __restrict globalZ = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsZ_.data(), 32));
 	auto* __restrict queueX = static_cast<float*>(__builtin_assume_aligned(priv_->queuePosX_.data(), 32));
 	auto* __restrict queueY = static_cast<float*>(__builtin_assume_aligned(priv_->queuePosY_.data(), 32));
 	auto* __restrict queueZ = static_cast<float*>(__builtin_assume_aligned(priv_->queuePosZ_.data(), 32));
@@ -522,7 +532,7 @@ void BoidsCPU::updateNeighbours(int32_t boidIdx, const int32_t *neighborIndices,
 
 	// Fallback to scalar loop for remaining elements
 	for (; queueIdx < neighborCount; queueIdx++) {
-		const Vec3f dx = {
+		const Vec3f dx {
 			queueX[queueIdx] - boidPosX,
 			queueY[queueIdx] - boidPosY,
 			queueZ[queueIdx] - boidPosZ };
@@ -578,6 +588,7 @@ Vec3f BoidsCPU::accumulateForce(BoidData &boid, const Vec3f &boidPos, const Vec3
 	auto* __restrict neighborIndices = boid.neighbors.data();
 
 	const uint32_t numNeighbors = boid.numNeighbors;
+	const float alpha = 1.0f / static_cast<float>(std::max(numNeighbors,1u));
 
 	// Load the neighbor positions into local SOA arrays
 	for (uint32_t i = 0; i < numNeighbors; ++i) {
@@ -596,49 +607,54 @@ Vec3f BoidsCPU::accumulateForce(BoidData &boid, const Vec3f &boidPos, const Vec3
 	size_t startIdx = 0;
 
 	if constexpr (BOID_USE_SIMD) {
-		{ // pass 1: compute average position and velocity
+		{ // pass 1:
+			const BatchOf_Vec3f fixedPos = BatchOf_Vec3f::fromScalar(boidPos);
+			const BatchOf_float avoidance = BatchOf_float::fromScalar(priv_->avoidanceDistanceSq_);
+			const BatchOf_float allOnes = BatchOf_float::fromScalar(1.0f);
+
 			BatchOf_Vec3f sumPosVec = BatchOf_Vec3f::fromScalar(Vec3f::zero());
-			BatchOf_Vec3f sumVelVec = BatchOf_Vec3f::fromScalar(Vec3f::zero());
+			BatchOf_Vec3f separation = BatchOf_Vec3f::fromScalar(Vec3f::zero());
+
 			for (; startIdx + simd::RegisterWidth <= numNeighbors; startIdx += simd::RegisterWidth) {
-				sumPosVec += BatchOf_Vec3f::loadAligned(
-					queuePosX + startIdx,
-					queuePosY + startIdx,
-					queuePosZ + startIdx);
+				// load the positions of the neighbors into a SIMD register
+				BatchOf_Vec3f x = BatchOf_Vec3f::loadAligned(
+						queuePosX + startIdx,
+						queuePosY + startIdx,
+						queuePosZ + startIdx);
+				// Accumulate position for the cohesion term.
+				sumPosVec += x;
+				// Compute vector from neighbor (x) to boid (fixedPos) for the separation term.
+				x = fixedPos - x;
+				// Compute distance squared which is used for weighting the separation force
+				// (closer neighbors contribute more).
+				BatchOf_float distSq = x.lengthSquared();
+				// Compute weight: if distance squared is below avoidance threshold,
+				// weight = 1 / distSq, else weight = 0
+				// note: (allOnes - allOnes) = allZeroes, we do this to reduce register pressure
+				// TODO: handle case when distSq == 0, not sure why it works like this. when eg doing
+				//          distSq = (distSq < avoidance) / distSq;
+				//       it crashes.
+				distSq = (allOnes - allOnes).blend(allOnes / distSq, distSq < avoidance);
+				// Finally, accumulate the separation force.
+				// TODO: push into random direction if distance below threshold?
+				separation += x * distSq;
+			}
+			// Horizontal sum of SIMD registers to get final results
+			sumSep += separation.hsum();
+			sumPos += sumPosVec.hsum();
+		}
+
+		{ // pass 2: Compute average velocity of neighbors (alignment term)
+			// note: we do this separately because the number of available registers is limited,
+			//       and we might not have the 6 additional registers needed to do this in one pass.
+			BatchOf_Vec3f sumVelVec = BatchOf_Vec3f::fromScalar(Vec3f::zero());
+			for (startIdx=0; startIdx + simd::RegisterWidth <= numNeighbors; startIdx += simd::RegisterWidth) {
 				sumVelVec += BatchOf_Vec3f::loadAligned(
 					queueVelX + startIdx,
 					queueVelY + startIdx,
 					queueVelZ + startIdx);
 			}
-			sumPos += sumPosVec.hsum();
 			sumVel += sumVelVec.hsum();
-		}
-
-		{ // pass 2: compute separation term
-			const BatchOf_Vec3f boidPos_SIMD = BatchOf_Vec3f::fromScalar(boidPos);
-			const BatchOf_float avoidance = BatchOf_float::fromScalar(priv_->avoidanceDistanceSq_);
-			const BatchOf_float allOnes = BatchOf_float::fromScalar(1.0f);
-			const BatchOf_float allZeros{ _mm256_setzero_ps() };
-
-			BatchOf_Vec3f separation = BatchOf_Vec3f::fromScalar(Vec3f::zero());
-
-			for (startIdx = 0; startIdx + simd::RegisterWidth <= numNeighbors; startIdx += simd::RegisterWidth) {
-				// load the positions of the neighbors into a SIMD register
-				BatchOf_Vec3f dir = BatchOf_Vec3f::loadAligned(
-						queuePosX + startIdx,
-						queuePosY + startIdx,
-						queuePosZ + startIdx);
-				dir = boidPos_SIMD - dir;
-
-				const BatchOf_float distSq = dir.lengthSquared();
-				BatchOf_float invDistSq = allOnes / distSq;
-				invDistSq.c = _mm256_blendv_ps(
-					allZeros.c,
-					invDistSq.c,
-					(distSq < avoidance).c);
-				// TODO: push into random direction if distance below threshold?
-				separation += dir * invDistSq;
-			}
-			sumSep += separation.hsum();
 		}
 	}
 
@@ -647,27 +663,19 @@ Vec3f BoidsCPU::accumulateForce(BoidData &boid, const Vec3f &boidPos, const Vec3
 		sumPos.x += queuePosX[startIdx];
 		sumPos.y += queuePosY[startIdx];
 		sumPos.z += queuePosZ[startIdx];
-		sumVel.x += queueVelX[startIdx];
-		sumVel.y += queueVelY[startIdx];
-		sumVel.z += queueVelZ[startIdx];
 
-		Vec3f boidDirection {
+		const Vec3f boidDirection {
 			boidPos.x - queuePosX[startIdx],
 			boidPos.y - queuePosY[startIdx],
 			boidPos.z - queuePosZ[startIdx] };
 		const float dSq = boidDirection.lengthSquared();
-		if (dSq < priv_->avoidanceDistanceSq_) {
-			if (dSq < 0.001f) {
-				boidDirection = Vec3f::random();
-				boidDirection.normalize();
-			} else {
-				boidDirection /= dSq;
-			}
-			sumSep += boidDirection;
-		}
+		sumSep += boidDirection / (dSq + 0.001f); // avoid division by zero
+
+		sumVel.x += queueVelX[startIdx];
+		sumVel.y += queueVelY[startIdx];
+		sumVel.z += queueVelZ[startIdx];
 	}
 
-	float alpha = 1.0f / static_cast<float>(std::max(numNeighbors,1u));
 	return
 		(sumSep * priv_->separationWeight_) +
 		(sumVel*alpha - boidVel) * priv_->alignmentWeight_ +

--- a/regen/simulation/boids-cpu.cpp
+++ b/regen/simulation/boids-cpu.cpp
@@ -7,43 +7,46 @@
 using namespace regen;
 
 namespace regen {
-	static constexpr bool BOID_USE_SORTED_GRID = false;
 	static constexpr bool BOID_USE_SIMD = true;
 }
 
 // private data struct
 struct BoidsCPU::Private {
-	// Note: SoA data layout for SIMD-friendly processing
-	// Note: vectorSIMD is used to ensure 32-bit alignment which is good for SIMD operations.
-	AlignedArray<int32_t> sortedGridIndices_; // size = numBoids_
-	AlignedArray<int32_t> cellCounts_;  // size = numCells
-	AlignedArray<int32_t> cellOffsets_; // size = numCells
 	// Boid spatial grid. A cell in a 3D grid with edge length equal to boid visual range.
 	struct Cell {
 		vectorSIMD<int32_t> elements; // size = maxNumNeighbors
-		uint32_t numElements = 0;     // (capped) number of boids in this cell
 	};
 	std::vector<Cell> grid_;
+	// (capped) number of boids per cell
+	AlignedArray<int32_t> cellCounts_; // size = numCells
 	// Per-boid data
-	AlignedArray<int32_t> boidGridIndex_;   // size = numBoids_
-	AlignedArray<float> boidPositionsX_;  // size = numBoids_
-	AlignedArray<float> boidPositionsY_;  // size = numBoids_
-	AlignedArray<float> boidPositionsZ_;  // size = numBoids_
-	AlignedArray<float> boidVelocityX_;   // size = numBoids_
-	AlignedArray<float> boidVelocityY_;   // size = numBoids_
-	AlignedArray<float> boidVelocityZ_;   // size = numBoids_
-	AlignedArray<float> boidOrientW_;   // size = numBoids_
-	AlignedArray<float> boidOrientX_;   // size = numBoids_
-	AlignedArray<float> boidOrientY_;   // size = numBoids_
-	AlignedArray<float> boidOrientZ_;   // size = numBoids_
+	AlignedArray<int32_t> boidGridIndex_; // size = numBoids
+	AlignedArray<float> boidPositionsX_;  // size = numBoids
+	AlignedArray<float> boidPositionsY_;  // size = numBoids
+	AlignedArray<float> boidPositionsZ_;  // size = numBoids
+	AlignedArray<float> boidVelocityX_;   // size = numBoids
+	AlignedArray<float> boidVelocityY_;   // size = numBoids
+	AlignedArray<float> boidVelocityZ_;   // size = numBoids
+	AlignedArray<float> boidOrientW_;   // size = numBoids
+	AlignedArray<float> boidOrientX_;   // size = numBoids
+	AlignedArray<float> boidOrientY_;   // size = numBoids
+	AlignedArray<float> boidOrientZ_;   // size = numBoids
 	// Temporary queue for boid indices
 	AlignedArray<uint32_t> boidQueue_;
+	// Temporary position queue for SIMD processing, used for neighbor testing
+	AlignedArray<float> queuePosX_; // size = maxNumNeighbors
+	AlignedArray<float> queuePosY_; // size = maxNumNeighbors
+	AlignedArray<float> queuePosZ_; // size = maxNumNeighbors
+	AlignedArray<float> queueVelX_; // size = maxNumNeighbors
+	AlignedArray<float> queueVelY_; // size = maxNumNeighbors
+	AlignedArray<float> queueVelZ_; // size = maxNumNeighbors
 
 	// Configuration parameters
 	float visualRange_ = 1.6f;
 	float attractionRange_ = 160.0f;
 	float visualRangeSq_ = 0.0f;
 	float avoidanceDistance_ = 0.0f;
+	float avoidanceDistanceSq_ = 0.0f;
 	float avoidanceDistanceHalf_ = 0.0f;
 	float repulsionTimesSeparation_ = 0.0f;
 	float separationWeight_ = 0.0f;
@@ -52,6 +55,7 @@ struct BoidsCPU::Private {
 	float lookAheadDistance_ = 0.0f;
 	float maxBoidSpeed_ = 0.0f;
 	float maxAngularSpeed_ = 0.0f;
+	float cos_maxAngularSpeed_ = 1.0f;
 	float baseOrientation_ = 0.0f;
 	float cellSize_ = 3.2f;
 	Vec3i gridSize_ = Vec3i::zero();
@@ -79,10 +83,13 @@ struct BoidsCPU::Private {
 			  boidOrientX_(numBoids),
 			  boidOrientY_(numBoids),
 			  boidOrientZ_(numBoids),
-			  boidQueue_(100) {
-		if constexpr (BOID_USE_SORTED_GRID) {
-			sortedGridIndices_.resize(numBoids);
-		}
+			  boidQueue_(100),
+			  queuePosX_(100),
+			  queuePosY_(100),
+			  queuePosZ_(100),
+			  queueVelX_(100),
+			  queueVelY_(100),
+			  queueVelZ_(100) {
 	}
 };
 
@@ -95,9 +102,6 @@ BoidsCPU::BoidsCPU(const ref_ptr<ModelTransformation> &tf)
 	priv_->boidVelocityY_.setToZero();
 	priv_->boidVelocityZ_.setToZero();
 	priv_->boidGridIndex_.setToZero();
-	if constexpr (BOID_USE_SORTED_GRID) {
-		priv_->sortedGridIndices_.setToZero();
-	}
 	for (uint32_t i = 0; i < numBoids_; ++i) {
 		setBoidPosition(i, tf_->position(i).r);
 	}
@@ -112,9 +116,6 @@ BoidsCPU::BoidsCPU(const ref_ptr<ShaderInput4f> &modelOffset)
 	priv_->boidVelocityY_.setToZero();
 	priv_->boidVelocityZ_.setToZero();
 	priv_->boidGridIndex_.setToZero();
-	if constexpr (BOID_USE_SORTED_GRID) {
-		priv_->sortedGridIndices_.setToZero();
-	}
 	for (uint32_t i = 0; i < numBoids_; ++i) {
 		setBoidPosition(i, modelOffset->getVertex(i).r.xyz());
 	}
@@ -122,6 +123,17 @@ BoidsCPU::BoidsCPU(const ref_ptr<ShaderInput4f> &modelOffset)
 
 BoidsCPU::~BoidsCPU() {
 	delete priv_;
+}
+
+// Use AVX2 to set 8 ints (32 bytes) at a time
+static void zeroAligned(int32_t* __restrict data, size_t size) {
+	size_t i = 0;
+	BatchOf_int32 zero{_mm256_setzero_si256()};
+	for (; i + simd::RegisterWidth <= size; i += simd::RegisterWidth) {
+		zero.storeAligned(data + i);
+	}
+	// Tail loop (in case size is not divisible by 8)
+	for (; i < size; ++i) { data[i] = 0; }
 }
 
 void BoidsCPU::initBoidSimulation() {
@@ -135,19 +147,20 @@ void BoidsCPU::initBoidSimulation() {
 
 	const auto maxNumNeighbors = maxNumNeighbors_->getVertex(0).r;
 	priv_->boidQueue_.resize(maxNumNeighbors + 1);
+	priv_->queuePosX_.resize(maxNumNeighbors + 1);
+	priv_->queuePosY_.resize(maxNumNeighbors + 1);
+	priv_->queuePosZ_.resize(maxNumNeighbors + 1);
+	priv_->queueVelX_.resize(maxNumNeighbors + 1);
+	priv_->queueVelY_.resize(maxNumNeighbors + 1);
+	priv_->queueVelZ_.resize(maxNumNeighbors + 1);
+
+	auto numCells = priv_->gridSize_.x * priv_->gridSize_.y * priv_->gridSize_.z;
 
 	// Initialize grid memory.
-	if constexpr (BOID_USE_SORTED_GRID) {
-		auto numCells = priv_->gridSize_.x * priv_->gridSize_.y * priv_->gridSize_.z;
-		numCells = std::max(numCells, 0);
-		priv_->cellCounts_.resize(numCells);
-		priv_->cellOffsets_.resize(numCells);
-	} else {
-		for (auto &cell : priv_->grid_) {
-			cell.elements.resize(maxNumNeighbors + 1); // +1 to avoid branching
-			cell.numElements = 0;
-		}
+	for (auto &cell : priv_->grid_) {
+		cell.elements.resize(maxNumNeighbors + 1); // +1 to avoid branching
 	}
+	priv_->cellCounts_.resize(numCells);
 
 	// Initialize per-boid memory.
 	for (uint32_t i = 0; i < numBoids_; ++i) {
@@ -233,6 +246,7 @@ void BoidsCPU::cpuUpdate(double dt) {
 	priv_->simBounds_.min = simulationBoundsMin_->getVertex(0).r;
 	priv_->simBounds_.max = simulationBoundsMax_->getVertex(0).r;
 	priv_->avoidanceDistance_ = avoidanceDistance_->getVertex(0).r;
+	priv_->avoidanceDistanceSq_ = priv_->avoidanceDistance_ * priv_->avoidanceDistance_;
 	priv_->avoidanceDistanceHalf_ = priv_->avoidanceDistance_ * 0.5f;
 	priv_->repulsionTimesSeparation_ = repulsionFactor_->getVertex(0).r * separationWeight_->getVertex(0).r;
 	priv_->visualRange_ = visualRange_->getVertex(0).r;
@@ -244,6 +258,7 @@ void BoidsCPU::cpuUpdate(double dt) {
 	priv_->lookAheadDistance_ = lookAheadDistance_->getVertex(0).r;
 	priv_->maxBoidSpeed_ = maxBoidSpeed_->getVertex(0).r;
 	priv_->maxAngularSpeed_ = maxAngularSpeed_->getVertex(0).r;
+	priv_->cos_maxAngularSpeed_ = cosf(priv_->maxAngularSpeed_);
 	priv_->maxNumNeighbors_ = maxNumNeighbors_->getVertex(0).r;
 	priv_->cellSize_ = cellSize_->getVertex(0).r;
 #ifdef REGEN_BOID_DEBUG_TIME
@@ -262,9 +277,7 @@ void BoidsCPU::cpuUpdate(double dt) {
 
 	// resize the grid, and clear all cells
 	clearGrid();
-	if constexpr (!BOID_USE_SORTED_GRID) {
-		if (priv_->grid_.empty()) { return; }
-	}
+	if (priv_->grid_.empty()) { return; }
 
 	// add boids to the grid and compute their neighborhood relations.
 	updateGrid();
@@ -361,43 +374,23 @@ void BoidsCPU::clearGrid() {
 		priv_->gridSize_.z = static_cast<int>(gridSize.z);
 		auto numCells = priv_->gridSize_.x * priv_->gridSize_.y * priv_->gridSize_.z;
 		numCells = std::max(numCells, 0);
-		if constexpr (BOID_USE_SORTED_GRID) {
-			priv_->cellCounts_.resize(numCells);
-			priv_->cellOffsets_.resize(numCells);
-			priv_->cellOffsets_[0] = 0;
-		} else {
-			auto firstAdded = priv_->grid_.size();
-			priv_->grid_.resize(numCells);
-			// reserve space for the neighbor indices in each cell.
-			// NOTE: we limit to maxNumNeighbors_ to avoid excessive memory usage.
-			auto maxNumNeighbors = maxNumNeighbors_->getVertex(0).r;
-			for (uint32_t i = firstAdded; i < priv_->grid_.size(); ++i) {
-				priv_->grid_[i].elements.resize(maxNumNeighbors + 1);
-			}
+
+		auto firstAdded = priv_->grid_.size();
+		priv_->grid_.resize(numCells);
+		// reserve space for the neighbor indices in each cell.
+		// NOTE: we limit to maxNumNeighbors_ to avoid excessive memory usage.
+		const auto maxNumNeighbors = priv_->maxNumNeighbors_;
+		for (uint32_t i = firstAdded; i < priv_->grid_.size(); ++i) {
+			priv_->grid_[i].elements.resize(maxNumNeighbors + 1);
 		}
 	}
 
-	if constexpr (!BOID_USE_SORTED_GRID) {
-		if (priv_->grid_.empty()) { return; }
-
-		// clear all cells, removing the old boids.
-		for (auto &cell: priv_->grid_) {
-			cell.numElements = 0;
-		}
+	if (!priv_->grid_.empty()) {
+		const uint32_t numCells = priv_->grid_.size();
+		priv_->cellCounts_.resize(numCells);
+		// Reset the cell counts to zero
+		zeroAligned(priv_->cellCounts_.data(), numCells);
 	}
-}
-
-static void zeroAligned(AlignedArray<int32_t> &vec) {
-    size_t size = vec.size();
-    int* data = vec.data();
-    size_t i = 0;
-    // Use AVX2 to set 8 ints (32 bytes) at a time
-    __m256i zero = _mm256_setzero_si256();
-    for (; i + 8 <= size; i += 8) {
-        _mm256_store_si256(reinterpret_cast<__m256i*>(data + i), zero);
-    }
-    // Tail loop (in case size is not divisible by 8)
-    for (; i < size; ++i) { data[i] = 0; }
 }
 
 void BoidsCPU::updateGrid() {
@@ -405,22 +398,26 @@ void BoidsCPU::updateGrid() {
 
 	// iterate over all boids and add them to the grid, compute the index
 	// based on the boid position and the grid bounds.
+	// Note: There is quite a bottleneck in updateNeighbours. Probably can only be improved
+	//       by coming up with a more efficient approach.
 	int32_t boidIdx = 0u;
 
-	const float* __restrict boidPosX = priv_->boidPositionsX_.data();
-	const float* __restrict boidPosY = priv_->boidPositionsY_.data();
-	const float* __restrict boidPosZ = priv_->boidPositionsZ_.data();
-	int32_t* __restrict boidGridIndex = priv_->boidGridIndex_.data();
+	auto* __restrict boidPosX = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsX_.data(), 32));
+	auto* __restrict boidPosY = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsY_.data(), 32));
+	auto* __restrict boidPosZ = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsZ_.data(), 32));
+	auto* __restrict cellCounts = static_cast<int32_t*>(__builtin_assume_aligned(priv_->cellCounts_.data(), 32));
+	auto* __restrict boidGridIndex = static_cast<int32_t*>(__builtin_assume_aligned(priv_->boidGridIndex_.data(), 32));
 
 	if constexpr (BOID_USE_SIMD) {
 		const BatchOf_Vec3f gridMin = BatchOf_Vec3f::fromScalar(gridBounds_.min);
 		const BatchOf_Vec3i gridSize = BatchOf_Vec3i::fromScalar(priv_->gridSize_);
 		const BatchOf_int32 allOne = BatchOf_int32::fromScalar(1);
+		const BatchOf_float allZero{ _mm256_setzero_ps() };
 		const BatchOf_float simd_cellSize = BatchOf_float::fromScalar(priv_->cellSize_);
 
 		BatchOf_Vec3f boidBatch; // NOLINT(cppcoreguidelines-pro-type-member-init)
 		// we compute the grid index in batches
-		for (; boidIdx +  simd::RegisterWidth <= numBoids; boidIdx += simd::RegisterWidth) {
+		for (; boidIdx + simd::RegisterWidth <= numBoids; boidIdx += simd::RegisterWidth) {
 			// load the boid positions into a SIMD register
 			boidBatch.setAligned(
 					boidPosX + boidIdx,
@@ -429,9 +426,9 @@ void BoidsCPU::updateGrid() {
 			// x = (x - gridBounds_.min) / cellSize
 			boidBatch = (boidBatch - gridMin) / simd_cellSize;
 			// clamp to 0+
-			boidBatch.x.c = simd::max_ps(boidBatch.x.c, _mm256_setzero_ps());
-			boidBatch.y.c = simd::max_ps(boidBatch.y.c, _mm256_setzero_ps());
-			boidBatch.z.c = simd::max_ps(boidBatch.z.c, _mm256_setzero_ps());
+			boidBatch.x = BatchOf_float::max(boidBatch.x, allZero);
+			boidBatch.y = BatchOf_float::max(boidBatch.y, allZero);
+			boidBatch.z = BatchOf_float::max(boidBatch.z, allZero);
 
 			// floor to integer grid indices using cvttps_epi32 + clamp to max grid bounds
 			BatchOf_Vec3i gridIndices = boidBatch.floor().min(gridSize - allOne);
@@ -442,7 +439,7 @@ void BoidsCPU::updateGrid() {
 				(gridIndices.y * gridSize.x) +
 				(gridIndices.z * gridSize.x * gridSize.y));
 			// store results in local array
-			simd::storeu_epi32(boidGridIndex + boidIdx, i_f.c);
+			i_f.storeAligned(boidGridIndex + boidIdx);
 		}
 	}
 
@@ -453,149 +450,98 @@ void BoidsCPU::updateGrid() {
 		boidGridIndex[boidIdx] = getGridIndex(idx3D, priv_->gridSize_);
 	}
 
-	if constexpr (BOID_USE_SORTED_GRID) {
-		const int32_t numCells = priv_->cellOffsets_.size();
-		// Reset the cell counts to zero
-		priv_->cellOffsets_[0] = 0;
-		zeroAligned(priv_->cellCounts_);
-		// Count how many boids are in each cell
-		for (uint32_t i = 0; i < numBoids_; ++i) {
-			priv_->cellCounts_[boidGridIndex[i]] += 1;
-		}
-		// Compute prefix sum to get starting offsets
-		for (int32_t i = 1; i < numCells; ++i) {
-			priv_->cellOffsets_[i] = priv_->cellOffsets_[i - 1] + priv_->cellCounts_[i - 1];
-		}
+	for (boidIdx = 0; boidIdx < numBoids; ++boidIdx) {
+		const uint32_t cellIndex = boidGridIndex[boidIdx];
+		const uint32_t numElements = cellCounts[cellIndex];
+		auto* __restrict cell = priv_->grid_[cellIndex].elements.data();
 
-		// Write sorted indices to buffer
-		for (boidIdx = 0; boidIdx < numBoids; ++boidIdx) {
-			// cell of i'th boid
-			int32_t cell_idx = boidGridIndex[boidIdx];
-			// the start of the cell in the sorted grid indices
-			int32_t cell_offset = priv_->cellOffsets_[cell_idx];
-			priv_->cellOffsets_[cell_idx] += 1;
-			priv_->sortedGridIndices_[cell_offset] = boidIdx;
-		}
-		// Finally iterate over the grid cells and update neighbors
-		int32_t* cellElements = priv_->sortedGridIndices_.data();
+		updateNeighbours(boidIdx, cell, numElements);
 
-		for (int32_t cellIdx = 0; cellIdx < numCells; ++cellIdx) {
-			int32_t count = priv_->cellCounts_[cellIdx];
-			if (count == 0) continue; // skip empty cells
-
-			for (int32_t i= 0; i + 1 < count; ++i) {
-				boidIdx = cellElements[i];
-				auto &boid = boidData_[boidIdx];
-				auto boidPos = getBoidPosition(boidIdx);
-				updateNeighbours(boid, boidPos, boidIdx,
-					cellElements + i + 1,
-					count - i - 1);
-			}
-
-			cellElements += count;
-		}
-	} else {
-		// First pass: bin the boids into the grid cells
-		for (boidIdx = 0; boidIdx < numBoids; ++boidIdx) {
-			const uint32_t cellIndex = boidGridIndex[boidIdx];
-			auto &cell = priv_->grid_[cellIndex];
-
-#if 1
-			auto &boid = boidData_[boidIdx];
-			auto boidPos = getBoidPosition(boidIdx);
-			updateNeighbours(boid, boidPos, boidIdx,
-				cell.elements.data(), cell.numElements);
-#endif
-
-			// add the boid to the grid cell
-			// Note: we can safely write one more element than the maxNumNeighbors_ because
-			//       we reserve one additional element in the cell.elements vector.
-			// Note: this is not entirely accurate. Better would be to also check the
-			//       adjacent cells, but this would cost more performance and results are ok in my opinion.
-			cell.elements[cell.numElements] = boidIdx;
-			cell.numElements += static_cast<uint32_t>(cell.numElements < priv_->maxNumNeighbors_);
-		}
-
-#if 0
-		// Second pass: go over the grid cells and update the neighbor relations
-		for (auto &cell : priv_->grid_) {
-			if (cell.numElements == 0) continue; // skip empty cells
-
-			// TODO: collect pairs across cells, then flush once buffer is full.
-			//   - significant performance boost for large number of boids.
-			//   - probably do in above loop?
-			for (uint32_t i = 0; i + 1 < cell.numElements; ++i) {
-				boidIdx = cell.elements[i];
-				auto &boid = boidData_[boidIdx];
-				auto boidPos = getBoidPosition(boidIdx);
-				updateNeighbours(boid, boidPos, boidIdx,
-					cell.elements.data() + i + 1,
-					cell.numElements - i - 1);
-			}
-		}
-#endif
+		// add the boid to the grid cell
+		// Note: we can safely write one more element than the maxNumNeighbors_ because
+		//       we reserve one additional element in the cell.elements vector.
+		// Note: this is not entirely accurate. Better would be to also check the
+		//       adjacent cells, but this would cost more performance and results are ok in my opinion.
+		cell[numElements] = boidIdx;
+		cellCounts[cellIndex] += static_cast<int32_t>(numElements < priv_->maxNumNeighbors_);
 	}
 }
 
-void BoidsCPU::updateNeighbours(
-		BoidData &boid, const Vec3f &boidPos, int32_t boidIndex,
-		const int32_t *neighborIndices, uint32_t neighborCount) {
-	auto* __restrict boidX = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsX_.data(), 32));
-	auto* __restrict boidY = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsY_.data(), 32));
-	auto* __restrict boidZ = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsZ_.data(), 32));
+void BoidsCPU::updateNeighbours(int32_t boidIdx, const int32_t *neighborIndices, uint32_t neighborCount) {
+	auto* __restrict globalX = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsX_.data(), 32));
+	auto* __restrict globalY = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsY_.data(), 32));
+	auto* __restrict globalZ = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsZ_.data(), 32));
+	auto* __restrict queueX = static_cast<float*>(__builtin_assume_aligned(priv_->queuePosX_.data(), 32));
+	auto* __restrict queueY = static_cast<float*>(__builtin_assume_aligned(priv_->queuePosY_.data(), 32));
+	auto* __restrict queueZ = static_cast<float*>(__builtin_assume_aligned(priv_->queuePosZ_.data(), 32));
 	auto* __restrict boidQueue = static_cast<uint32_t*>(__builtin_assume_aligned(priv_->boidQueue_.data(), 32));
+
+	auto &boidStruct = boidData_[boidIdx];
+	const float boidPosX = globalX[boidIdx];
+	const float boidPosY = globalY[boidIdx];
+	const float boidPosZ = globalZ[boidIdx];
+	const uint32_t maxNumNeighbors = priv_->maxNumNeighbors_;
+
 	uint32_t numHits = 0;
-	uint32_t neighborIdx = 0;
+	uint32_t queueIdx = 0;
+
+	// Load the neighbor positions into local SOA arrays
+	for (uint32_t i = 0; i < neighborCount; ++i) {
+		const int32_t neighborIdx = neighborIndices[i];
+		queueX[i] = globalX[neighborIdx];
+		queueY[i] = globalY[neighborIdx];
+		queueZ[i] = globalZ[neighborIdx];
+	}
 
 	if constexpr (BOID_USE_SIMD) {
-		BatchOf_Vec3f neighborBatch; // NOLINT(cppcoreguidelines-pro-type-member-init)
-		BatchOf_Vec3f b_boidPos       = BatchOf_Vec3f::fromScalar(boidPos);
-		BatchOf_float b_visualRangeSq = BatchOf_float::fromScalar(priv_->visualRangeSq_);
+		const BatchOf_Vec3f b_boidPos{
+			BatchOf_float::fromScalar(boidPosX),
+			BatchOf_float::fromScalar(boidPosY),
+			BatchOf_float::fromScalar(boidPosZ) };
+		const BatchOf_float b_visualRangeSq = BatchOf_float::fromScalar(priv_->visualRangeSq_);
 
-		for (; neighborIdx + simd::RegisterWidth <= neighborCount; neighborIdx += simd::RegisterWidth) {
-			// load the indices of the neighbors into a SIMD register
-			simd::Register_i idx = simd::loadu_si256(neighborIndices + neighborIdx);
+		for (; queueIdx + simd::RegisterWidth <= neighborCount; queueIdx += simd::RegisterWidth) {
 			// load the positions of the neighbors into a SIMD register
-			// TODO: Avoid gather, load aligned load instead.
-			neighborBatch.setGathered(boidX, boidY, boidZ, idx);
+			const BatchOf_Vec3f candidatePos = BatchOf_Vec3f::loadAligned(
+				queueX + queueIdx,
+				queueY + queueIdx,
+				queueZ + queueIdx);
 
 			// finally compute the distance to the boid position for a batch of neighbors
-			const BatchOf_float lengthSq = (neighborBatch - b_boidPos).lengthSquared();
+			const BatchOf_float lengthSq = (candidatePos - b_boidPos).lengthSquared();
 			const BatchOf_float mask     = (lengthSq < b_visualRangeSq);
 
 			// Convert lanes (1/0) to bitmask value
 			uint8_t maskBits = mask.toBitmask8();
 			while (maskBits) {
 				int bitIndex = simd::nextBitIndex<uint8_t>(maskBits);
-				boidQueue[numHits++] = neighborIdx + bitIndex;
+				boidQueue[numHits++] = queueIdx + bitIndex;
 			}
 		}
 	}
 
 	// Fallback to scalar loop for remaining elements
-	for (; neighborIdx < neighborCount &&
-		   boid.numNeighbors < priv_->maxNumNeighbors_;
-		   ++neighborIdx) {
-		auto neighborIndex = neighborIndices[neighborIdx];
-		const Vec3f dx = boidPos - getBoidPosition(neighborIndex);
+	for (; queueIdx < neighborCount; queueIdx++) {
+		const Vec3f dx = {
+			queueX[queueIdx] - boidPosX,
+			queueY[queueIdx] - boidPosY,
+			queueZ[queueIdx] - boidPosZ };
 		if (dx.lengthSquared() <= priv_->visualRangeSq_) {
-			boidQueue[numHits++] = neighborIdx;
+			boidQueue[numHits++] = queueIdx;
 		}
 	}
 
 	// Process the found neighbors
 	for (uint32_t hitIdx = 0; hitIdx < numHits; ++hitIdx) {
-		const int32_t neighborIndex = neighborIndices[boidQueue[hitIdx]];
-		auto &neighbor = boidData_[neighborIndex];
+		const int32_t neighborIdx = neighborIndices[boidQueue[hitIdx]];
+		auto &neighbor = boidData_[neighborIdx];
 
 		// define reflexive neighbor relation
-		boid.neighbors[boid.numNeighbors] = neighborIndex;
-		boid.numNeighbors +=
-			static_cast<uint32_t>(boid.numNeighbors < priv_->maxNumNeighbors_);
+		boidStruct.neighbors[boidStruct.numNeighbors] = neighborIdx;
+		boidStruct.numNeighbors += static_cast<uint32_t>(boidStruct.numNeighbors < maxNumNeighbors);
 
-		neighbor.neighbors[neighbor.numNeighbors] = boidIndex;
-		neighbor.numNeighbors +=
-			static_cast<uint32_t>(neighbor.numNeighbors < priv_->maxNumNeighbors_);
+		neighbor.neighbors[neighbor.numNeighbors] = boidIdx;
+		neighbor.numNeighbors += static_cast<uint32_t>(neighbor.numNeighbors < maxNumNeighbors);
 	}
 }
 
@@ -617,102 +563,115 @@ void BoidsCPU::simulateBoids(float dt) {
 }
 
 Vec3f BoidsCPU::accumulateForce(BoidData &boid, const Vec3f &boidPos, const Vec3f &boidVel) {
+	auto* __restrict globalPosX = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsX_.data(), 32));
+	auto* __restrict globalPosY = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsY_.data(), 32));
+	auto* __restrict globalPosZ = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsZ_.data(), 32));
+	auto* __restrict globalVelX = static_cast<float*>(__builtin_assume_aligned(priv_->boidVelocityX_.data(), 32));
+	auto* __restrict globalVelY = static_cast<float*>(__builtin_assume_aligned(priv_->boidVelocityY_.data(), 32));
+	auto* __restrict globalVelZ = static_cast<float*>(__builtin_assume_aligned(priv_->boidVelocityZ_.data(), 32));
+	auto* __restrict queuePosX = static_cast<float*>(__builtin_assume_aligned(priv_->queuePosX_.data(), 32));
+	auto* __restrict queuePosY = static_cast<float*>(__builtin_assume_aligned(priv_->queuePosY_.data(), 32));
+	auto* __restrict queuePosZ = static_cast<float*>(__builtin_assume_aligned(priv_->queuePosZ_.data(), 32));
+	auto* __restrict queueVelX = static_cast<float*>(__builtin_assume_aligned(priv_->queueVelX_.data(), 32));
+	auto* __restrict queueVelY = static_cast<float*>(__builtin_assume_aligned(priv_->queueVelY_.data(), 32));
+	auto* __restrict queueVelZ = static_cast<float*>(__builtin_assume_aligned(priv_->queueVelZ_.data(), 32));
+	auto* __restrict neighborIndices = boid.neighbors.data();
+
+	const uint32_t numNeighbors = boid.numNeighbors;
+
+	// Load the neighbor positions into local SOA arrays
+	for (uint32_t i = 0; i < numNeighbors; ++i) {
+		const int32_t neighborIdx = neighborIndices[i];
+		queuePosX[i] = globalPosX[neighborIdx];
+		queuePosY[i] = globalPosY[neighborIdx];
+		queuePosZ[i] = globalPosZ[neighborIdx];
+		queueVelX[i] = globalVelX[neighborIdx];
+		queueVelY[i] = globalVelY[neighborIdx];
+		queueVelZ[i] = globalVelZ[neighborIdx];
+	}
+
+	Vec3f sumPos = Vec3f::zero();
+	Vec3f sumVel = Vec3f::zero();
+	Vec3f sumSep = Vec3f::zero();
 	size_t startIdx = 0;
-	boid.sumPos = Vec3f::zero();
-	boid.sumVel = Vec3f::zero();
-	boid.sumSep = Vec3f::zero();
 
 	if constexpr (BOID_USE_SIMD) {
-		// NOTE: unfortunately, this does not buy us much as num neighbors is usually capped
-		//       to rather small values, e.g. 100.
 		{ // pass 1: compute average position and velocity
-			BatchOf_Vec3f avgPosition_SIMD = BatchOf_Vec3f::fromScalar(Vec3f::zero());
-			BatchOf_Vec3f avgVelocity_SIMD = BatchOf_Vec3f::fromScalar(Vec3f::zero());
-			BatchOf_Vec3f neighborVel_SIMD; // NOLINT(cppcoreguidelines-pro-type-member-init)
-			BatchOf_Vec3f neighborPos_SIMD; // NOLINT(cppcoreguidelines-pro-type-member-init)
-			for (; startIdx + simd::RegisterWidth <= boid.numNeighbors; startIdx += simd::RegisterWidth) {
-				// load the neighbor indices into a SIMD register
-				simd::Register_i idx = simd::loadu_si256(boid.neighbors.data() + startIdx);
-				// load the positions of the neighbors into a SIMD register
-				neighborPos_SIMD.setGathered(
-						priv_->boidPositionsX_.data(),
-						priv_->boidPositionsY_.data(),
-						priv_->boidPositionsZ_.data(),
-						idx);
-				neighborVel_SIMD.setGathered(
-						priv_->boidVelocityX_.data(),
-						priv_->boidVelocityY_.data(),
-						priv_->boidVelocityZ_.data(),
-						idx);
-				avgPosition_SIMD += neighborPos_SIMD;
-				avgVelocity_SIMD += neighborVel_SIMD;
+			BatchOf_Vec3f sumPosVec = BatchOf_Vec3f::fromScalar(Vec3f::zero());
+			BatchOf_Vec3f sumVelVec = BatchOf_Vec3f::fromScalar(Vec3f::zero());
+			for (; startIdx + simd::RegisterWidth <= numNeighbors; startIdx += simd::RegisterWidth) {
+				sumPosVec += BatchOf_Vec3f::loadAligned(
+					queuePosX + startIdx,
+					queuePosY + startIdx,
+					queuePosZ + startIdx);
+				sumVelVec += BatchOf_Vec3f::loadAligned(
+					queueVelX + startIdx,
+					queueVelY + startIdx,
+					queueVelZ + startIdx);
 			}
-			boid.sumPos += avgPosition_SIMD.hsum();
-			boid.sumVel += avgVelocity_SIMD.hsum();
+			sumPos += sumPosVec.hsum();
+			sumVel += sumVelVec.hsum();
 		}
 
 		{ // pass 2: compute separation term
-			startIdx = 0;
-			const BatchOf_Vec3f boidPos_SIMD =
-				BatchOf_Vec3f::fromScalar(boidPos);
-			BatchOf_Vec3f separation_SIMD =
-				BatchOf_Vec3f::fromScalar(Vec3f::zero());
-			const BatchOf_float avoidanceDistanceSq_SIMD =
-				BatchOf_float::fromScalar(priv_->avoidanceDistance_ * priv_->avoidanceDistance_);
-			const BatchOf_float one_SIMD =
-				BatchOf_float::fromScalar(1.0f);
-			BatchOf_Vec3f dir; // NOLINT(cppcoreguidelines-pro-type-member-init)
+			const BatchOf_Vec3f boidPos_SIMD = BatchOf_Vec3f::fromScalar(boidPos);
+			const BatchOf_float avoidance = BatchOf_float::fromScalar(priv_->avoidanceDistanceSq_);
+			const BatchOf_float allOnes = BatchOf_float::fromScalar(1.0f);
+			const BatchOf_float allZeros{ _mm256_setzero_ps() };
 
-			for (; startIdx + simd::RegisterWidth <= boid.numNeighbors; startIdx += simd::RegisterWidth) {
-				// load the neighbor indices into a SIMD register
-				simd::Register_i idx = simd::loadu_si256(boid.neighbors.data() + startIdx);
+			BatchOf_Vec3f separation = BatchOf_Vec3f::fromScalar(Vec3f::zero());
+
+			for (startIdx = 0; startIdx + simd::RegisterWidth <= numNeighbors; startIdx += simd::RegisterWidth) {
 				// load the positions of the neighbors into a SIMD register
-				dir.setGathered(
-						priv_->boidPositionsX_.data(),
-						priv_->boidPositionsY_.data(),
-						priv_->boidPositionsZ_.data(),
-						idx);
+				BatchOf_Vec3f dir = BatchOf_Vec3f::loadAligned(
+						queuePosX + startIdx,
+						queuePosY + startIdx,
+						queuePosZ + startIdx);
 				dir = boidPos_SIMD - dir;
 
 				const BatchOf_float distSq = dir.lengthSquared();
-				BatchOf_float invDistSq = one_SIMD / distSq;
+				BatchOf_float invDistSq = allOnes / distSq;
 				invDistSq.c = _mm256_blendv_ps(
-					_mm256_setzero_ps(),
+					allZeros.c,
 					invDistSq.c,
-					(distSq < avoidanceDistanceSq_SIMD).c);
+					(distSq < avoidance).c);
 				// TODO: push into random direction if distance below threshold?
-				separation_SIMD += dir * invDistSq;
+				separation += dir * invDistSq;
 			}
-			boid.sumSep += separation_SIMD.hsum();
+			sumSep += separation.hsum();
 		}
 	}
 
 	// Fallback to scalar loop for remaining elements
-	for (; startIdx<boid.numNeighbors; startIdx++) {
-		auto neighborIdx = boid.neighbors[startIdx];
-		auto neighborPos = getBoidPosition(neighborIdx);
+	for (; startIdx < numNeighbors; startIdx++) {
+		sumPos.x += queuePosX[startIdx];
+		sumPos.y += queuePosY[startIdx];
+		sumPos.z += queuePosZ[startIdx];
+		sumVel.x += queueVelX[startIdx];
+		sumVel.y += queueVelY[startIdx];
+		sumVel.z += queueVelZ[startIdx];
 
-		boid.sumPos += neighborPos;
-		boid.sumVel += getBoidVelocity(neighborIdx);
-
-		auto boidDirection = boidPos - neighborPos;
-		float distance = boidDirection.length();
-		if (distance < priv_->avoidanceDistance_) {
-			if (distance < 0.001f) {
+		Vec3f boidDirection {
+			boidPos.x - queuePosX[startIdx],
+			boidPos.y - queuePosY[startIdx],
+			boidPos.z - queuePosZ[startIdx] };
+		const float dSq = boidDirection.lengthSquared();
+		if (dSq < priv_->avoidanceDistanceSq_) {
+			if (dSq < 0.001f) {
 				boidDirection = Vec3f::random();
 				boidDirection.normalize();
 			} else {
-				boidDirection /= distance * distance;
+				boidDirection /= dSq;
 			}
-			boid.sumSep += boidDirection;
+			sumSep += boidDirection;
 		}
 	}
 
-	float alpha = 1.0f / static_cast<float>(std::max(boid.numNeighbors,1u));
+	float alpha = 1.0f / static_cast<float>(std::max(numNeighbors,1u));
 	return
-		(boid.sumSep * priv_->separationWeight_) +
-		(boid.sumVel*alpha - boidVel) * priv_->alignmentWeight_ +
-		(boid.sumPos*alpha - boidPos) * priv_->coherenceWeight_;
+		(sumSep * priv_->separationWeight_) +
+		(sumVel*alpha - boidVel) * priv_->alignmentWeight_ +
+		(sumPos*alpha - boidPos) * priv_->coherenceWeight_;
 }
 
 void BoidsCPU::simulateBoid(int32_t boidIdx, float dt) {
@@ -767,8 +726,7 @@ Vec3f BoidsCPU::limitVelocity(const Vec3f &lastVelNorm, const Vec3f &nextVel, fl
 	Vec3f limitedVel = nextVelNorm * boidSpeed;
 
 	// limit angular speed
-	// TODO: avoid acos here, use dot product thresholding instead
-	if (acos(nextVelNorm.dot(lastVelNorm)) > priv_->maxAngularSpeed_) {
+	if (nextVelNorm.dot(lastVelNorm) < priv_->cos_maxAngularSpeed_) {
 		auto axis = nextVelNorm.cross(lastVelNorm);
 		axis.normalize();
 		priv_->boidRotation_.setAxisAngle(axis, priv_->maxAngularSpeed_);

--- a/regen/simulation/boids-cpu.cpp
+++ b/regen/simulation/boids-cpu.cpp
@@ -3,41 +3,41 @@
 #include "regen/utility/aligned-array.h"
 
 //#define REGEN_BOID_DEBUG_TIME
-//#define REGEN_BOID_USE_SORTED_GRID
-#define REGEN_BOID_USE_GRID_SIMD
-#define REGEN_BOID_USE_NEIGHBOR_SIMD
-#define REGEN_BOID_USE_FORCE_SIMD
 
 using namespace regen;
+
+namespace regen {
+	static constexpr bool BOID_USE_SORTED_GRID = false;
+	static constexpr bool BOID_USE_SIMD = true;
+}
 
 // private data struct
 struct BoidsCPU::Private {
 	// Note: SoA data layout for SIMD-friendly processing
 	// Note: vectorSIMD is used to ensure 32-bit alignment which is good for SIMD operations.
-#ifdef REGEN_BOID_USE_SORTED_GRID
 	AlignedArray<int32_t> sortedGridIndices_; // size = numBoids_
 	AlignedArray<int32_t> cellCounts_;  // size = numCells
 	AlignedArray<int32_t> cellOffsets_; // size = numCells
-#else
 	// Boid spatial grid. A cell in a 3D grid with edge length equal to boid visual range.
 	struct Cell {
 		vectorSIMD<int32_t> elements; // size = maxNumNeighbors
 		uint32_t numElements = 0;     // (capped) number of boids in this cell
 	};
 	std::vector<Cell> grid_;
-#endif
 	// Per-boid data
 	AlignedArray<int32_t> boidGridIndex_;   // size = numBoids_
-	AlignedArray<float>   boidPositionsX_;  // size = numBoids_
-	AlignedArray<float>   boidPositionsY_;  // size = numBoids_
-	AlignedArray<float>   boidPositionsZ_;  // size = numBoids_
-	AlignedArray<float>   boidVelocityX_;   // size = numBoids_
-	AlignedArray<float>   boidVelocityY_;   // size = numBoids_
-	AlignedArray<float>   boidVelocityZ_;   // size = numBoids_
-	AlignedArray<float>   boidOrientW_;   // size = numBoids_
-	AlignedArray<float>   boidOrientX_;   // size = numBoids_
-	AlignedArray<float>   boidOrientY_;   // size = numBoids_
-	AlignedArray<float>   boidOrientZ_;   // size = numBoids_
+	AlignedArray<float> boidPositionsX_;  // size = numBoids_
+	AlignedArray<float> boidPositionsY_;  // size = numBoids_
+	AlignedArray<float> boidPositionsZ_;  // size = numBoids_
+	AlignedArray<float> boidVelocityX_;   // size = numBoids_
+	AlignedArray<float> boidVelocityY_;   // size = numBoids_
+	AlignedArray<float> boidVelocityZ_;   // size = numBoids_
+	AlignedArray<float> boidOrientW_;   // size = numBoids_
+	AlignedArray<float> boidOrientX_;   // size = numBoids_
+	AlignedArray<float> boidOrientY_;   // size = numBoids_
+	AlignedArray<float> boidOrientZ_;   // size = numBoids_
+	// Temporary queue for boid indices
+	AlignedArray<uint32_t> boidQueue_;
 
 	// Configuration parameters
 	float visualRange_ = 1.6f;
@@ -68,9 +68,6 @@ struct BoidsCPU::Private {
 	Quaternion boidRotation_;
 
 	explicit Private(uint32_t numBoids) :
-#ifdef REGEN_BOID_USE_SORTED_GRID
-			  sortedGridIndices_(numBoids),
-#endif
 			  boidGridIndex_(numBoids),
 			  boidPositionsX_(numBoids),
 			  boidPositionsY_(numBoids),
@@ -81,8 +78,12 @@ struct BoidsCPU::Private {
 			  boidOrientW_(numBoids),
 			  boidOrientX_(numBoids),
 			  boidOrientY_(numBoids),
-			  boidOrientZ_(numBoids)
-			  {}
+			  boidOrientZ_(numBoids),
+			  boidQueue_(100) {
+		if constexpr (BOID_USE_SORTED_GRID) {
+			sortedGridIndices_.resize(numBoids);
+		}
+	}
 };
 
 BoidsCPU::BoidsCPU(const ref_ptr<ModelTransformation> &tf)
@@ -94,9 +95,9 @@ BoidsCPU::BoidsCPU(const ref_ptr<ModelTransformation> &tf)
 	priv_->boidVelocityY_.setToZero();
 	priv_->boidVelocityZ_.setToZero();
 	priv_->boidGridIndex_.setToZero();
-#ifdef REGEN_BOID_USE_SORTED_GRID
-	priv_->sortedGridIndices_.setToZero();
-#endif
+	if constexpr (BOID_USE_SORTED_GRID) {
+		priv_->sortedGridIndices_.setToZero();
+	}
 	for (uint32_t i = 0; i < numBoids_; ++i) {
 		setBoidPosition(i, tf_->position(i).r);
 	}
@@ -111,9 +112,9 @@ BoidsCPU::BoidsCPU(const ref_ptr<ShaderInput4f> &modelOffset)
 	priv_->boidVelocityY_.setToZero();
 	priv_->boidVelocityZ_.setToZero();
 	priv_->boidGridIndex_.setToZero();
-#ifdef REGEN_BOID_USE_SORTED_GRID
-	priv_->sortedGridIndices_.setToZero();
-#endif
+	if constexpr (BOID_USE_SORTED_GRID) {
+		priv_->sortedGridIndices_.setToZero();
+	}
 	for (uint32_t i = 0; i < numBoids_; ++i) {
 		setBoidPosition(i, modelOffset->getVertex(i).r.xyz());
 	}
@@ -132,25 +133,28 @@ void BoidsCPU::initBoidSimulation() {
 	priv_->yawAdjust_.setAxisAngle(Vec3f(0, 1, 0), priv_->baseOrientation_);
 	priv_->boidsScale_ = boidsScale_->getVertex(0).r;
 
+	const auto maxNumNeighbors = maxNumNeighbors_->getVertex(0).r;
+	priv_->boidQueue_.resize(maxNumNeighbors + 1);
+
 	// Initialize grid memory.
-#ifdef REGEN_BOID_USE_SORTED_GRID
-	auto numCells = priv_->gridSize_.x * priv_->gridSize_.y * priv_->gridSize_.z;
-	numCells = std::max(numCells, 0);
-	priv_->cellCounts_.resize(numCells);
-	priv_->cellOffsets_.resize(numCells);
-#else
-	for (auto &cell : priv_->grid_) {
-		cell.elements.resize(maxNumNeighbors_->getVertex(0).r + 1); // +1 to avoid branching
-		cell.numElements = 0;
+	if constexpr (BOID_USE_SORTED_GRID) {
+		auto numCells = priv_->gridSize_.x * priv_->gridSize_.y * priv_->gridSize_.z;
+		numCells = std::max(numCells, 0);
+		priv_->cellCounts_.resize(numCells);
+		priv_->cellOffsets_.resize(numCells);
+	} else {
+		for (auto &cell : priv_->grid_) {
+			cell.elements.resize(maxNumNeighbors + 1); // +1 to avoid branching
+			cell.numElements = 0;
+		}
 	}
-#endif
 
 	// Initialize per-boid memory.
 	for (uint32_t i = 0; i < numBoids_; ++i) {
 		auto &d = boidData_[i];
 		// note: an additional element is added to the end of the vector which is used
 		//       to avoid branching.
-		d.neighbors.resize(maxNumNeighbors_->getVertex(0).r + 1);
+		d.neighbors.resize(maxNumNeighbors + 1);
 		d.numNeighbors = 0;
 	}
 
@@ -258,9 +262,9 @@ void BoidsCPU::animate(double dt) {
 
 	// resize the grid, and clear all cells
 	clearGrid();
-#ifndef REGEN_BOID_USE_SORTED_GRID
-	if (priv_->grid_.empty()) { return; }
-#endif
+	if constexpr (!BOID_USE_SORTED_GRID) {
+		if (priv_->grid_.empty()) { return; }
+	}
 
 	// add boids to the grid and compute their neighborhood relations.
 	updateGrid();
@@ -357,34 +361,33 @@ void BoidsCPU::clearGrid() {
 		priv_->gridSize_.z = static_cast<int>(gridSize.z);
 		auto numCells = priv_->gridSize_.x * priv_->gridSize_.y * priv_->gridSize_.z;
 		numCells = std::max(numCells, 0);
-#ifdef REGEN_BOID_USE_SORTED_GRID
-		priv_->cellCounts_.resize(numCells);
-		priv_->cellOffsets_.resize(numCells);
-		priv_->cellOffsets_[0] = 0;
-#else
-		auto firstAdded = priv_->grid_.size();
-		priv_->grid_.resize(numCells);
-		// reserve space for the neighbor indices in each cell.
-		// NOTE: we limit to maxNumNeighbors_ to avoid excessive memory usage.
-		auto maxNumNeighbors = maxNumNeighbors_->getVertex(0).r;
-		for (uint32_t i = firstAdded; i < priv_->grid_.size(); ++i) {
-			priv_->grid_[i].elements.resize(maxNumNeighbors + 1);
+		if constexpr (BOID_USE_SORTED_GRID) {
+			priv_->cellCounts_.resize(numCells);
+			priv_->cellOffsets_.resize(numCells);
+			priv_->cellOffsets_[0] = 0;
+		} else {
+			auto firstAdded = priv_->grid_.size();
+			priv_->grid_.resize(numCells);
+			// reserve space for the neighbor indices in each cell.
+			// NOTE: we limit to maxNumNeighbors_ to avoid excessive memory usage.
+			auto maxNumNeighbors = maxNumNeighbors_->getVertex(0).r;
+			for (uint32_t i = firstAdded; i < priv_->grid_.size(); ++i) {
+				priv_->grid_[i].elements.resize(maxNumNeighbors + 1);
+			}
 		}
-#endif
 	}
 
-#ifndef REGEN_BOID_USE_SORTED_GRID
-	if (priv_->grid_.empty()) { return; }
+	if constexpr (!BOID_USE_SORTED_GRID) {
+		if (priv_->grid_.empty()) { return; }
 
-	// clear all cells, removing the old boids.
-	for (auto &cell: priv_->grid_) {
-		cell.numElements = 0;
+		// clear all cells, removing the old boids.
+		for (auto &cell: priv_->grid_) {
+			cell.numElements = 0;
+		}
 	}
-#endif
 }
 
-#ifdef REGEN_BOID_USE_SORTED_GRID
-void zeroAligned(AlignedArray<int32_t> &vec) {
+static void zeroAligned(AlignedArray<int32_t> &vec) {
     size_t size = vec.size();
     int* data = vec.data();
     size_t i = 0;
@@ -396,15 +399,20 @@ void zeroAligned(AlignedArray<int32_t> &vec) {
     // Tail loop (in case size is not divisible by 8)
     for (; i < size; ++i) { data[i] = 0; }
 }
-#endif
 
 void BoidsCPU::updateGrid() {
+	const auto numBoids = static_cast<int32_t>(numBoids_);
+
 	// iterate over all boids and add them to the grid, compute the index
 	// based on the boid position and the grid bounds.
-	int32_t startIdx = 0u;
+	int32_t boidIdx = 0u;
 
-#ifdef REGEN_BOID_USE_GRID_SIMD
-	{
+	const float* __restrict boidPosX = priv_->boidPositionsX_.data();
+	const float* __restrict boidPosY = priv_->boidPositionsY_.data();
+	const float* __restrict boidPosZ = priv_->boidPositionsZ_.data();
+	int32_t* __restrict boidGridIndex = priv_->boidGridIndex_.data();
+
+	if constexpr (BOID_USE_SIMD) {
 		const BatchOf_Vec3f gridMin = BatchOf_Vec3f::fromScalar(gridBounds_.min);
 		const BatchOf_Vec3i gridSize = BatchOf_Vec3i::fromScalar(priv_->gridSize_);
 		const BatchOf_int32 allOne = BatchOf_int32::fromScalar(1);
@@ -412,12 +420,12 @@ void BoidsCPU::updateGrid() {
 
 		BatchOf_Vec3f boidBatch; // NOLINT(cppcoreguidelines-pro-type-member-init)
 		// we compute the grid index in batches
-		for (; startIdx +  simd::RegisterWidth <= static_cast<int32_t>(numBoids_); startIdx += simd::RegisterWidth) {
+		for (; boidIdx +  simd::RegisterWidth <= numBoids; boidIdx += simd::RegisterWidth) {
 			// load the boid positions into a SIMD register
 			boidBatch.setAligned(
-					priv_->boidPositionsX_.data() + startIdx,
-					priv_->boidPositionsY_.data() + startIdx,
-					priv_->boidPositionsZ_.data() + startIdx);
+					boidPosX + boidIdx,
+					boidPosY + boidIdx,
+					boidPosZ + boidIdx);
 			// x = (x - gridBounds_.min) / cellSize
 			boidBatch = (boidBatch - gridMin) / simd_cellSize;
 			// clamp to 0+
@@ -425,10 +433,8 @@ void BoidsCPU::updateGrid() {
 			boidBatch.y.c = simd::max_ps(boidBatch.y.c, _mm256_setzero_ps());
 			boidBatch.z.c = simd::max_ps(boidBatch.z.c, _mm256_setzero_ps());
 
-			// floor to integer grid indices
-			BatchOf_Vec3i gridIndices = boidBatch.floor();
-			// clamp to max grid bounds
-			gridIndices = gridIndices.min(gridSize - allOne);
+			// floor to integer grid indices using cvttps_epi32 + clamp to max grid bounds
+			BatchOf_Vec3i gridIndices = boidBatch.floor().min(gridSize - allOne);
 			// i_f = ix + iy_f + iz_f;
 			//    - iy_f = iy * gridSize.x
 			//    - iz_f = iz * gridSize.x * gridSize.y;
@@ -436,151 +442,160 @@ void BoidsCPU::updateGrid() {
 				(gridIndices.y * gridSize.x) +
 				(gridIndices.z * gridSize.x * gridSize.y));
 			// store results in local array
-			//simd::storeu_epi32(boidGridIndicesX_.data() + startIdx, gridIndices.x);
-			//simd::storeu_epi32(boidGridIndicesY_.data() + startIdx, gridIndices.y);
-			//simd::storeu_epi32(boidGridIndicesZ_.data() + startIdx, gridIndices.z);
-			simd::storeu_epi32(priv_->boidGridIndex_.data() + startIdx, i_f.c);
+			simd::storeu_epi32(boidGridIndex + boidIdx, i_f.c);
 		}
 	}
-#endif // REGEN_USE_SIMD_GRID_UPDATE
 
 	// Fallback to scalar loop for grid index computation
-	for (; startIdx < static_cast<int32_t>(numBoids_);  ++startIdx) {
-		const Vec3f boidPos = getBoidPosition(startIdx);
+	for (; boidIdx < numBoids;  ++boidIdx) {
+		const Vec3f boidPos = getBoidPosition(boidIdx);
 		const Vec3i idx3D = getGridIndex3D(boidPos);
-		priv_->boidGridIndex_[startIdx] = getGridIndex(idx3D, priv_->gridSize_);
+		boidGridIndex[boidIdx] = getGridIndex(idx3D, priv_->gridSize_);
 	}
 
-#ifdef REGEN_BOID_USE_SORTED_GRID
-	const int32_t numCells = priv_->cellOffsets_.size();
-	// Reset the cell counts to zero
-	priv_->cellOffsets_[0] = 0;
-	zeroAligned(priv_->cellCounts_);
-	// Count how many boids are in each cell
-	for (uint32_t i = 0; i < numBoids_; ++i) {
-		priv_->cellCounts_[priv_->boidGridIndex_[i]] += 1;
-	}
-	// Compute prefix sum to get starting offsets
-	for (int32_t i = 1; i < numCells; ++i) {
-		priv_->cellOffsets_[i] = priv_->cellOffsets_[i - 1] + priv_->cellCounts_[i - 1];
-	}
+	if constexpr (BOID_USE_SORTED_GRID) {
+		const int32_t numCells = priv_->cellOffsets_.size();
+		// Reset the cell counts to zero
+		priv_->cellOffsets_[0] = 0;
+		zeroAligned(priv_->cellCounts_);
+		// Count how many boids are in each cell
+		for (uint32_t i = 0; i < numBoids_; ++i) {
+			priv_->cellCounts_[boidGridIndex[i]] += 1;
+		}
+		// Compute prefix sum to get starting offsets
+		for (int32_t i = 1; i < numCells; ++i) {
+			priv_->cellOffsets_[i] = priv_->cellOffsets_[i - 1] + priv_->cellCounts_[i - 1];
+		}
 
-	// Write sorted indices to buffer
-	for (int32_t boidIdx = 0; boidIdx < static_cast<int32_t>(numBoids_); ++boidIdx) {
-		// cell of i'th boid
-		int32_t cell_idx = priv_->boidGridIndex_[boidIdx];
-		// the start of the cell in the sorted grid indices
-		int32_t cell_offset = priv_->cellOffsets_[cell_idx];
-		priv_->cellOffsets_[cell_idx] += 1;
-		priv_->sortedGridIndices_[cell_offset] = boidIdx;
-	}
-	// Finally iterate over the grid cells and update neighbors
-	int32_t* cellElements = priv_->sortedGridIndices_.data();
+		// Write sorted indices to buffer
+		for (boidIdx = 0; boidIdx < numBoids; ++boidIdx) {
+			// cell of i'th boid
+			int32_t cell_idx = boidGridIndex[boidIdx];
+			// the start of the cell in the sorted grid indices
+			int32_t cell_offset = priv_->cellOffsets_[cell_idx];
+			priv_->cellOffsets_[cell_idx] += 1;
+			priv_->sortedGridIndices_[cell_offset] = boidIdx;
+		}
+		// Finally iterate over the grid cells and update neighbors
+		int32_t* cellElements = priv_->sortedGridIndices_.data();
 
-	for (int32_t cellIdx = 0; cellIdx < numCells; ++cellIdx) {
-		int32_t count = priv_->cellCounts_[cellIdx];
-		if (count == 0) continue; // skip empty cells
+		for (int32_t cellIdx = 0; cellIdx < numCells; ++cellIdx) {
+			int32_t count = priv_->cellCounts_[cellIdx];
+			if (count == 0) continue; // skip empty cells
 
-		for (int32_t i= 0; i + 1 < count; ++i) {
-			int32_t boidIdx = cellElements[i];
+			for (int32_t i= 0; i + 1 < count; ++i) {
+				boidIdx = cellElements[i];
+				auto &boid = boidData_[boidIdx];
+				auto boidPos = getBoidPosition(boidIdx);
+				updateNeighbours(boid, boidPos, boidIdx,
+					cellElements + i + 1,
+					count - i - 1);
+			}
+
+			cellElements += count;
+		}
+	} else {
+		// First pass: bin the boids into the grid cells
+		for (boidIdx = 0; boidIdx < numBoids; ++boidIdx) {
+			const uint32_t cellIndex = boidGridIndex[boidIdx];
+			auto &cell = priv_->grid_[cellIndex];
+
+#if 1
 			auto &boid = boidData_[boidIdx];
 			auto boidPos = getBoidPosition(boidIdx);
 			updateNeighbours(boid, boidPos, boidIdx,
-				cellElements + i + 1,
-				count - i - 1);
+				cell.elements.data(), cell.numElements);
+#endif
+
+			// add the boid to the grid cell
+			// Note: we can safely write one more element than the maxNumNeighbors_ because
+			//       we reserve one additional element in the cell.elements vector.
+			// Note: this is not entirely accurate. Better would be to also check the
+			//       adjacent cells, but this would cost more performance and results are ok in my opinion.
+			cell.elements[cell.numElements] = boidIdx;
+			cell.numElements += static_cast<uint32_t>(cell.numElements < priv_->maxNumNeighbors_);
 		}
 
-		cellElements += count;
-	}
+#if 0
+		// Second pass: go over the grid cells and update the neighbor relations
+		for (auto &cell : priv_->grid_) {
+			if (cell.numElements == 0) continue; // skip empty cells
 
-#else
-	for (int32_t boidIdx = 0; boidIdx < static_cast<int32_t>(numBoids_); ++boidIdx) {
-		auto &boid = boidData_[boidIdx];
-		const uint32_t cellIndex = priv_->boidGridIndex_[boidIdx];
-		auto &cell = priv_->grid_[cellIndex];
-		auto boidPos = getBoidPosition(boidIdx);
-		updateNeighbours(boid, boidPos, boidIdx,
-			cell.elements.data(), cell.numElements);
-		// add the boid to the grid cell
-		// Note: we can safely write one more element than the maxNumNeighbors_ because
-		//       we reserve one additional element in the cell.elements vector.
-		// Note: this is not entirely accurate. Better would be to also check the
-		//       adjacent cells, but this would cost more performance and results are ok in my opinion.
-		cell.elements[cell.numElements] = boidIdx;
-		cell.numElements += static_cast<uint32_t>(cell.numElements < priv_->maxNumNeighbors_);
-	}
+			// TODO: collect pairs across cells, then flush once buffer is full.
+			//   - significant performance boost for large number of boids.
+			//   - probably do in above loop?
+			for (uint32_t i = 0; i + 1 < cell.numElements; ++i) {
+				boidIdx = cell.elements[i];
+				auto &boid = boidData_[boidIdx];
+				auto boidPos = getBoidPosition(boidIdx);
+				updateNeighbours(boid, boidPos, boidIdx,
+					cell.elements.data() + i + 1,
+					cell.numElements - i - 1);
+			}
+		}
 #endif
+	}
 }
 
 void BoidsCPU::updateNeighbours(
-		BoidData &boid,
-		const Vec3f &boidPos,
-		int32_t boidIndex,
-		const int32_t *neighborIndices,
-		uint32_t neighborCount) {
-	size_t startIdx = 0;
+		BoidData &boid, const Vec3f &boidPos, int32_t boidIndex,
+		const int32_t *neighborIndices, uint32_t neighborCount) {
+	auto* __restrict boidX = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsX_.data(), 32));
+	auto* __restrict boidY = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsY_.data(), 32));
+	auto* __restrict boidZ = static_cast<float*>(__builtin_assume_aligned(priv_->boidPositionsZ_.data(), 32));
+	auto* __restrict boidQueue = static_cast<uint32_t*>(__builtin_assume_aligned(priv_->boidQueue_.data(), 32));
+	uint32_t numHits = 0;
+	uint32_t neighborIdx = 0;
 
-#ifdef REGEN_BOID_USE_NEIGHBOR_SIMD
-	if (neighborCount >= simd::RegisterWidth) {
-		// NOTE: unfortunately, this does not buy us much as num neighbors is usually capped
-		//       to rather small values, e.g. 100.
+	if constexpr (BOID_USE_SIMD) {
 		BatchOf_Vec3f neighborBatch; // NOLINT(cppcoreguidelines-pro-type-member-init)
-		BatchOf_Vec3f boidPos_SIMD =
-			BatchOf_Vec3f::fromScalar(boidPos);
-		BatchOf_float visualRangeSq_SIMD =
-			BatchOf_float::fromScalar(priv_->visualRangeSq_);
+		BatchOf_Vec3f b_boidPos       = BatchOf_Vec3f::fromScalar(boidPos);
+		BatchOf_float b_visualRangeSq = BatchOf_float::fromScalar(priv_->visualRangeSq_);
 
-		for (; startIdx + simd::RegisterWidth <= neighborCount; startIdx += simd::RegisterWidth) {
+		for (; neighborIdx + simd::RegisterWidth <= neighborCount; neighborIdx += simd::RegisterWidth) {
 			// load the indices of the neighbors into a SIMD register
-			simd::Register_i idx = simd::loadu_si256(neighborIndices + startIdx);
+			simd::Register_i idx = simd::loadu_si256(neighborIndices + neighborIdx);
 			// load the positions of the neighbors into a SIMD register
-			neighborBatch.setGathered(
-					priv_->boidPositionsX_.data(),
-					priv_->boidPositionsY_.data(),
-					priv_->boidPositionsZ_.data(),
-					idx);
+			// TODO: Avoid gather, load aligned load instead.
+			neighborBatch.setGathered(boidX, boidY, boidZ, idx);
 
 			// finally compute the distance to the boid position for a batch of neighbors
-			neighborBatch -= boidPos_SIMD;
-			const BatchOf_float lengthSq = neighborBatch.lengthSquared();
-			const BatchOf_float mask = (lengthSq < visualRangeSq_SIMD);
-			// use the result as a bit mask to filter neighbors
-			int maskBits = simd::movemask_ps(mask.c);
+			const BatchOf_float lengthSq = (neighborBatch - b_boidPos).lengthSquared();
+			const BatchOf_float mask     = (lengthSq < b_visualRangeSq);
 
+			// Convert lanes (1/0) to bitmask value
+			uint8_t maskBits = mask.toBitmask8();
 			while (maskBits) {
-				// find the first bit set in the mask, which indicates a neighbor in range
-				int32_t batchLane = __builtin_ctz(maskBits);
-				maskBits &= maskBits - 1; // clear lowest set bit
-
-				int32_t neighborIndex = neighborIndices[startIdx + batchLane];
-				auto &neighbor = boidData_[neighborIndex];
-
-				// define reflexive neighbor relation
-				boid.neighbors[boid.numNeighbors] = neighborIndex;
-				boid.numNeighbors += static_cast<uint32_t>(boid.numNeighbors < priv_->maxNumNeighbors_);
-				neighbor.neighbors[neighbor.numNeighbors] = boidIndex;
-				neighbor.numNeighbors += static_cast<uint32_t>(neighbor.numNeighbors < priv_->maxNumNeighbors_);
+				int bitIndex = simd::nextBitIndex<uint8_t>(maskBits);
+				boidQueue[numHits++] = neighborIdx + bitIndex;
 			}
 		}
 	}
-#endif // REGEN_USE_SIMD_NEIGHBOR_UPDATE
 
 	// Fallback to scalar loop for remaining elements
-	for (; startIdx < neighborCount &&
+	for (; neighborIdx < neighborCount &&
 		   boid.numNeighbors < priv_->maxNumNeighbors_;
-		   ++startIdx) {
-		auto neighborIndex = neighborIndices[startIdx];
-		auto &neighbor = boidData_[neighborIndex];
-
-		// make distance check
+		   ++neighborIdx) {
+		auto neighborIndex = neighborIndices[neighborIdx];
 		const Vec3f dx = boidPos - getBoidPosition(neighborIndex);
-		uint32_t isNeighbor(dx.lengthSquared() <= priv_->visualRangeSq_);
+		if (dx.lengthSquared() <= priv_->visualRangeSq_) {
+			boidQueue[numHits++] = neighborIdx;
+		}
+	}
+
+	// Process the found neighbors
+	for (uint32_t hitIdx = 0; hitIdx < numHits; ++hitIdx) {
+		const int32_t neighborIndex = neighborIndices[boidQueue[hitIdx]];
+		auto &neighbor = boidData_[neighborIndex];
 
 		// define reflexive neighbor relation
 		boid.neighbors[boid.numNeighbors] = neighborIndex;
-		boid.numNeighbors += isNeighbor;
+		boid.numNeighbors +=
+			static_cast<uint32_t>(boid.numNeighbors < priv_->maxNumNeighbors_);
+
 		neighbor.neighbors[neighbor.numNeighbors] = boidIndex;
-		neighbor.numNeighbors += isNeighbor*uint32_t(neighbor.numNeighbors < priv_->maxNumNeighbors_);
+		neighbor.numNeighbors +=
+			static_cast<uint32_t>(neighbor.numNeighbors < priv_->maxNumNeighbors_);
 	}
 }
 
@@ -607,8 +622,7 @@ Vec3f BoidsCPU::accumulateForce(BoidData &boid, const Vec3f &boidPos, const Vec3
 	boid.sumVel = Vec3f::zero();
 	boid.sumSep = Vec3f::zero();
 
-#ifdef REGEN_BOID_USE_FORCE_SIMD
-	if (boid.numNeighbors >= simd::RegisterWidth) {
+	if constexpr (BOID_USE_SIMD) {
 		// NOTE: unfortunately, this does not buy us much as num neighbors is usually capped
 		//       to rather small values, e.g. 100.
 		{ // pass 1: compute average position and velocity
@@ -672,26 +686,25 @@ Vec3f BoidsCPU::accumulateForce(BoidData &boid, const Vec3f &boidPos, const Vec3
 			boid.sumSep += separation_SIMD.hsum();
 		}
 	}
-#endif
-	{
-		for (; startIdx<boid.numNeighbors; startIdx++) {
-			auto neighborIdx = boid.neighbors[startIdx];
-			auto neighborPos = getBoidPosition(neighborIdx);
 
-			boid.sumPos += neighborPos;
-			boid.sumVel += getBoidVelocity(neighborIdx);
+	// Fallback to scalar loop for remaining elements
+	for (; startIdx<boid.numNeighbors; startIdx++) {
+		auto neighborIdx = boid.neighbors[startIdx];
+		auto neighborPos = getBoidPosition(neighborIdx);
 
-			auto boidDirection = boidPos - neighborPos;
-			float distance = boidDirection.length();
-			if (distance < priv_->avoidanceDistance_) {
-				if (distance < 0.001f) {
-					boidDirection = Vec3f::random();
-					boidDirection.normalize();
-				} else {
-					boidDirection /= distance * distance;
-				}
-				boid.sumSep += boidDirection;
+		boid.sumPos += neighborPos;
+		boid.sumVel += getBoidVelocity(neighborIdx);
+
+		auto boidDirection = boidPos - neighborPos;
+		float distance = boidDirection.length();
+		if (distance < priv_->avoidanceDistance_) {
+			if (distance < 0.001f) {
+				boidDirection = Vec3f::random();
+				boidDirection.normalize();
+			} else {
+				boidDirection /= distance * distance;
 			}
+			boid.sumSep += boidDirection;
 		}
 	}
 
@@ -745,20 +758,17 @@ void BoidsCPU::simulateBoid(int32_t boidIdx, float dt) {
 	boid.numNeighbors = 0;
 }
 
-Vec3f BoidsCPU::limitVelocity(
-		const Vec3f &lastVelNorm,
-		const Vec3f &nextVel,
-		float &boidSpeed) {
+Vec3f BoidsCPU::limitVelocity(const Vec3f &lastVelNorm, const Vec3f &nextVel, float &boidSpeed) {
 	boidSpeed = nextVel.length();
-	Vec3f nextVelNorm = nextVel / boidSpeed;
+	const Vec3f nextVelNorm = nextVel / boidSpeed;
 
 	// limit translation speed
 	boidSpeed = std::min(boidSpeed, priv_->maxBoidSpeed_);
 	Vec3f limitedVel = nextVelNorm * boidSpeed;
 
 	// limit angular speed
-	auto angle = acos(nextVelNorm.dot(lastVelNorm));
-	if (angle > priv_->maxAngularSpeed_) {
+	// TODO: avoid acos here, use dot product thresholding instead
+	if (acos(nextVelNorm.dot(lastVelNorm)) > priv_->maxAngularSpeed_) {
 		auto axis = nextVelNorm.cross(lastVelNorm);
 		axis.normalize();
 		priv_->boidRotation_.setAxisAngle(axis, priv_->maxAngularSpeed_);
@@ -770,29 +780,21 @@ Vec3f BoidsCPU::limitVelocity(
 }
 
 void BoidsCPU::homesickness(const Vec3f &boidPos, Vec3f &boidForce) {
+	static constexpr float MaxFloat = std::numeric_limits<float>::max();
+	if (homePoints_.empty()) { return; }
+
 	// a boid seems to have lost track, and wants to go home!
 	// first find closest home point...
 	const Vec3f *closestHomePoint = &Vec3f::zero();
-	float minDistance;
-	if (!homePoints_.empty()) {
-		minDistance = std::numeric_limits<float>::max();
-		for (auto &home: homePoints_) {
-			auto distance = (boidPos - home).length();
-			if (distance < minDistance) {
-				minDistance = distance;
-				closestHomePoint = &home;
-			}
+	float minDistance = MaxFloat;
+	for (auto &home: homePoints_) {
+		auto distance = (boidPos - home).lengthSquared();
+		if (distance < minDistance) {
+			minDistance = distance;
+			closestHomePoint = &home;
 		}
-	} else {
-		minDistance = (boidPos - *closestHomePoint).length();
 	}
-	// second steer towards the closest home point ...
-	if (minDistance < 0.001f) {
-		priv_->boidDirection_ = Vec3f::random();
-		priv_->boidDirection_.normalize();
-	} else {
-		priv_->boidDirection_ = (*closestHomePoint - boidPos) / minDistance;
-	}
+	priv_->boidDirection_ = (*closestHomePoint - boidPos) / sqrt(minDistance);
 	boidForce += priv_->boidDirection_ * priv_->repulsionTimesSeparation_ * 0.1;
 }
 
@@ -809,13 +811,13 @@ bool BoidsCPU::avoidDanger(const Vec3f &boidPos, Vec3f &boidForce) {
 			dir += danger.tf.get()->getVertex(0).r.position();
 		}
 		dir -= boidPos;
-		auto distance = dir.length();
-		if (distance < priv_->visualRange_) {
+		auto distance = dir.lengthSquared();
+		if (distance < priv_->visualRangeSq_) {
 			if (distance < 0.001f) {
 				dir = Vec3f::random();
 				dir.normalize();
 			} else {
-				dir /= distance;
+				dir /= sqrt(distance);
 			}
 			boidForce += dir * priv_->repulsionTimesSeparation_;
 			isInDanger = true;
@@ -885,8 +887,8 @@ bool BoidsCPU::avoidCollisions(
 		uv1.y = math::clamp(uv1.y, 0.0f, 1.0f);
 
 		if (collisionMapType_ == COLLISION_VECTOR_FIELD) {
-			Vec3f sample0 = collisionMap_->sampleLinear<Vec3f,3>(uv0, collisionMap_->textureData());
-			Vec3f sample1 = collisionMap_->sampleLinear<Vec3f,3>(uv1, collisionMap_->textureData());
+			auto sample0 = collisionMap_->sampleLinear<Vec3f,3>(uv0, collisionMap_->textureData());
+			auto sample1 = collisionMap_->sampleLinear<Vec3f,3>(uv1, collisionMap_->textureData());
 			Vec2f collisionFlow = sample0.xy();
 			float collisionStrength = sample0.z;
 			if (sample1.z > collisionStrength) {
@@ -905,9 +907,9 @@ bool BoidsCPU::avoidCollisions(
 		} else {
 			// Sample at current and lookahead positions
 			float collisionValue = 0.0f;
-			const int samples = 3; // sample along velocity
-			for (int i = 0; i < samples; ++i) {
-				float t = (float)i / (samples - 1);
+			static constexpr int NumSamples = 3; // sample along velocity
+			for (int i = 0; i < NumSamples; ++i) {
+				float t = (float)i / (NumSamples - 1);
 				Vec3f pos = boidPos + nextVelocity * t;
 				auto uvSample = computeUV(pos, collisionMapCenter_, collisionMapSize_);
 				uvSample.x = 1.0f - std::clamp(uvSample.x, 0.0f, 1.0f);
@@ -918,7 +920,7 @@ bool BoidsCPU::avoidCollisions(
 
 			if (collisionValue > 0.05f) {
 				const float eps = 1.0f / float(collisionMap_->width());
-				uv0.x = 1.0f - uv0.x; // flip x for sampling
+				uv0.x = 1.0f - uv0.x; // HACK: flip x for sampling
 				float c = collisionMap_->sampleLinear<float,1>(uv0, collisionMap_->textureData()); // central sample
 				float dx = collisionMap_->sampleLinear<float,1>(uv0 + Vec2f(eps,0), collisionMap_->textureData())
 						 - collisionMap_->sampleLinear<float,1>(uv0 - Vec2f(eps,0), collisionMap_->textureData());
@@ -926,11 +928,13 @@ bool BoidsCPU::avoidCollisions(
 						 - collisionMap_->sampleLinear<float,1>(uv0 - Vec2f(0,eps), collisionMap_->textureData());
 
 				Vec3f normal(dx, 0.0f, dy);
-				if (normal.lengthSquared() > 1e-8f) normal.normalize();
+				float normalLength = normal.lengthSquared();
+				if (normalLength > 1e-8f) normal /= sqrt(normalLength);
 				else {
 					Vec3f up(0,1,0);
 					normal = nextVelocity.cross(up);
-					if (normal.lengthSquared() > 1e-8f) normal.normalize();
+					normalLength = normal.lengthSquared();
+					if (normalLength > 1e-8f) normal /= sqrt(normalLength);
 				}
 
 				// use both the max along lookahead and the center sample to compute final strength

--- a/regen/simulation/boids-cpu.cpp
+++ b/regen/simulation/boids-cpu.cpp
@@ -604,23 +604,24 @@ Vec3f BoidsCPU::accumulateForce(BoidData &boid, const Vec3f &boidPos, const Vec3
 	Vec3f sumPos = Vec3f::zero();
 	Vec3f sumVel = Vec3f::zero();
 	Vec3f sumSep = Vec3f::zero();
-	size_t startIdx = 0;
+	size_t queueIdx = 0;
 
 	if constexpr (BOID_USE_SIMD) {
 		{ // pass 1:
 			const BatchOf_Vec3f fixedPos = BatchOf_Vec3f::fromScalar(boidPos);
 			const BatchOf_float avoidance = BatchOf_float::fromScalar(priv_->avoidanceDistanceSq_);
-			const BatchOf_float allOnes = BatchOf_float::fromScalar(1.0f);
+			//const BatchOf_float allOnes = BatchOf_float::fromScalar(1.0f);
+			const BatchOf_float epsilon = BatchOf_float::fromScalar(0.0001f);
 
 			BatchOf_Vec3f sumPosVec = BatchOf_Vec3f::fromScalar(Vec3f::zero());
 			BatchOf_Vec3f separation = BatchOf_Vec3f::fromScalar(Vec3f::zero());
 
-			for (; startIdx + simd::RegisterWidth <= numNeighbors; startIdx += simd::RegisterWidth) {
+			for (; queueIdx + simd::RegisterWidth <= numNeighbors; queueIdx += simd::RegisterWidth) {
 				// load the positions of the neighbors into a SIMD register
 				BatchOf_Vec3f x = BatchOf_Vec3f::loadAligned(
-						queuePosX + startIdx,
-						queuePosY + startIdx,
-						queuePosZ + startIdx);
+						queuePosX + queueIdx,
+						queuePosY + queueIdx,
+						queuePosZ + queueIdx);
 				// Accumulate position for the cohesion term.
 				sumPosVec += x;
 				// Compute vector from neighbor (x) to boid (fixedPos) for the separation term.
@@ -628,15 +629,11 @@ Vec3f BoidsCPU::accumulateForce(BoidData &boid, const Vec3f &boidPos, const Vec3
 				// Compute distance squared which is used for weighting the separation force
 				// (closer neighbors contribute more).
 				BatchOf_float distSq = x.lengthSquared();
-				// Compute weight: if distance squared is below avoidance threshold,
-				// weight = 1 / distSq, else weight = 0
-				// note: (allOnes - allOnes) = allZeroes, we do this to reduce register pressure
-				// TODO: handle case when distSq == 0, not sure why it works like this. when eg doing
-				//          distSq = (distSq < avoidance) / distSq;
-				//       it crashes.
-				distSq = (allOnes - allOnes).blend(allOnes / distSq, distSq < avoidance);
+				// Use masking to only consider neighbors within the avoidance distance.
+				distSq = (distSq < avoidance).maskToFloat() / (distSq + epsilon);
+				//distSq = (allOnes - allOnes).blend(
+				//	allOnes / (distSq + epsilon), distSq < avoidance);
 				// Finally, accumulate the separation force.
-				// TODO: push into random direction if distance below threshold?
 				separation += x * distSq;
 			}
 			// Horizontal sum of SIMD registers to get final results
@@ -646,43 +643,35 @@ Vec3f BoidsCPU::accumulateForce(BoidData &boid, const Vec3f &boidPos, const Vec3
 
 		{ // pass 2: Compute average velocity of neighbors (alignment term)
 			// note: we do this separately because the number of available registers is limited,
-			//       and we might not have the 6 additional registers needed to do this in one pass.
+			//       and we might create too much register pressure otherwise.
 			BatchOf_Vec3f sumVelVec = BatchOf_Vec3f::fromScalar(Vec3f::zero());
-			for (startIdx=0; startIdx + simd::RegisterWidth <= numNeighbors; startIdx += simd::RegisterWidth) {
+			for (queueIdx=0; queueIdx + simd::RegisterWidth <= numNeighbors; queueIdx += simd::RegisterWidth) {
 				sumVelVec += BatchOf_Vec3f::loadAligned(
-					queueVelX + startIdx,
-					queueVelY + startIdx,
-					queueVelZ + startIdx);
+					queueVelX + queueIdx,
+					queueVelY + queueIdx,
+					queueVelZ + queueIdx);
 			}
 			sumVel += sumVelVec.hsum();
 		}
 	}
 
 	// Fallback to scalar loop for remaining elements
-	for (; startIdx < numNeighbors; startIdx++) {
-		sumPos.x += queuePosX[startIdx];
-		sumPos.y += queuePosY[startIdx];
-		sumPos.z += queuePosZ[startIdx];
+	for (; queueIdx < numNeighbors; queueIdx++) {
+		sumPos.x += queuePosX[queueIdx];
+		sumPos.y += queuePosY[queueIdx];
+		sumPos.z += queuePosZ[queueIdx];
 
-		Vec3f boidDirection {
-			boidPos.x - queuePosX[startIdx],
-			boidPos.y - queuePosY[startIdx],
-			boidPos.z - queuePosZ[startIdx] };
+		const Vec3f boidDirection {
+			boidPos.x - queuePosX[queueIdx],
+			boidPos.y - queuePosY[queueIdx],
+			boidPos.z - queuePosZ[queueIdx] };
 		const float dSq = boidDirection.lengthSquared();
-		if (dSq < priv_->avoidanceDistanceSq_) {
-			if (dSq < 0.001f) {
-				boidDirection = Vec3f::random();
-				boidDirection.normalize();
-			} else {
-				boidDirection /= dSq;
-			}
-			sumSep += boidDirection;
-		}
-		//sumSep += boidDirection / (dSq + 0.001f); // avoid division by zero
+		const auto mask = static_cast<float>(dSq < priv_->avoidanceDistanceSq_);
+		sumSep += boidDirection * mask / (dSq + 0.0001f); // avoid division by zero
 
-		sumVel.x += queueVelX[startIdx];
-		sumVel.y += queueVelY[startIdx];
-		sumVel.z += queueVelZ[startIdx];
+		sumVel.x += queueVelX[queueIdx];
+		sumVel.y += queueVelY[queueIdx];
+		sumVel.z += queueVelZ[queueIdx];
 	}
 
 	return

--- a/regen/simulation/boids-cpu.cpp
+++ b/regen/simulation/boids-cpu.cpp
@@ -228,7 +228,7 @@ Vec3i BoidsCPU::getGridIndex3D(const Vec3f &x) const {
 					  priv_->gridSize_ - Vec3i::one());
 }
 
-void BoidsCPU::animate(double dt) {
+void BoidsCPU::cpuUpdate(double dt) {
 	auto dt_f = static_cast<float>(dt) * 0.001f;
 	priv_->simBounds_.min = simulationBoundsMin_->getVertex(0).r;
 	priv_->simBounds_.max = simulationBoundsMax_->getVertex(0).r;

--- a/regen/simulation/boids-cpu.cpp
+++ b/regen/simulation/boids-cpu.cpp
@@ -664,12 +664,21 @@ Vec3f BoidsCPU::accumulateForce(BoidData &boid, const Vec3f &boidPos, const Vec3
 		sumPos.y += queuePosY[startIdx];
 		sumPos.z += queuePosZ[startIdx];
 
-		const Vec3f boidDirection {
+		Vec3f boidDirection {
 			boidPos.x - queuePosX[startIdx],
 			boidPos.y - queuePosY[startIdx],
 			boidPos.z - queuePosZ[startIdx] };
 		const float dSq = boidDirection.lengthSquared();
-		sumSep += boidDirection / (dSq + 0.001f); // avoid division by zero
+		if (dSq < priv_->avoidanceDistanceSq_) {
+			if (dSq < 0.001f) {
+				boidDirection = Vec3f::random();
+				boidDirection.normalize();
+			} else {
+				boidDirection /= dSq;
+			}
+			sumSep += boidDirection;
+		}
+		//sumSep += boidDirection / (dSq + 0.001f); // avoid division by zero
 
 		sumVel.x += queueVelX[startIdx];
 		sumVel.y += queueVelY[startIdx];

--- a/regen/simulation/boids-cpu.h
+++ b/regen/simulation/boids-cpu.h
@@ -45,7 +45,7 @@ namespace regen {
 			std::vector<int32_t> neighbors; // size = maxNumNeighbors
 			uint32_t numNeighbors = 0;
 			Vec3f force;
-			Vec3f sumPos, sumVel, sumSep;
+			//Vec3f sumPos, sumVel, sumSep;
 		};
 		std::vector<BoidData> boidData_;   // size = numBoids_
 
@@ -87,18 +87,11 @@ namespace regen {
 				Vec3f &boidForce,
 				float dt);
 
-		bool avoidDanger(
-				const Vec3f &boidPos, Vec3f &boidForce);
+		bool avoidDanger(const Vec3f &boidPos, Vec3f &boidForce);
 
-		void attract(
-				const Vec3f &boidPos, Vec3f &boidForce);
+		void attract(const Vec3f &boidPos, Vec3f &boidForce);
 
-		void updateNeighbours(
-				BoidData &boid,
-				const Vec3f &boidPos,
-				int32_t boidIndex,
-				const int32_t *neighborIndices,
-				uint32_t neighborCount);
+		void updateNeighbours(int32_t boidIdx, const int32_t *neighborIndices, uint32_t neighborCount);
 
 		void clearGrid();
 

--- a/regen/simulation/boids-cpu.h
+++ b/regen/simulation/boids-cpu.h
@@ -91,6 +91,8 @@ namespace regen {
 
 		void attract(const Vec3f &boidPos, Vec3f &boidForce);
 
+		void updateCellIndex();
+
 		void updateNeighbours(int32_t boidIdx, const int32_t *neighborIndices, uint32_t neighborCount);
 
 		void clearGrid();

--- a/regen/simulation/boids-cpu.h
+++ b/regen/simulation/boids-cpu.h
@@ -33,7 +33,7 @@ namespace regen {
 		static ref_ptr<BoidsCPU> load(LoadingContext &ctx, scene::SceneInputNode &input, const ref_ptr<ModelTransformation> &tf);
 
 		// Animation interface
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 		void initBoidSimulation() override;
 

--- a/regen/simulation/boids-gpu.cpp
+++ b/regen/simulation/boids-gpu.cpp
@@ -289,7 +289,7 @@ ref_ptr<BoidsGPU> BoidsGPU::load(
 	return boids;
 }
 
-void BoidsGPU::glAnimate(RenderState *rs, GLdouble dt) {
+void BoidsGPU::glAnimate(RenderState *rs, double dt) {
 	// limit FPS to 60
 	time_ += dt;
 	bbox_time_ += dt;

--- a/regen/simulation/boids-gpu.cpp
+++ b/regen/simulation/boids-gpu.cpp
@@ -289,7 +289,7 @@ ref_ptr<BoidsGPU> BoidsGPU::load(
 	return boids;
 }
 
-void BoidsGPU::glAnimate(RenderState *rs, double dt) {
+void BoidsGPU::gpuUpdate(RenderState *rs, double dt) {
 	// limit FPS to 60
 	time_ += dt;
 	bbox_time_ += dt;

--- a/regen/simulation/boids-gpu.h
+++ b/regen/simulation/boids-gpu.h
@@ -26,7 +26,7 @@ namespace regen {
 		static ref_ptr<BoidsGPU> load(LoadingContext &ctx, scene::SceneInputNode &input, const ref_ptr<ModelTransformation> &tf);
 
 		// override Animation
-		void glAnimate(RenderState *rs, double dt) override;
+		void gpuUpdate(RenderState *rs, double dt) override;
 
 		void initBoidSimulation() override;
 

--- a/regen/simulation/boids-gpu.h
+++ b/regen/simulation/boids-gpu.h
@@ -26,7 +26,7 @@ namespace regen {
 		static ref_ptr<BoidsGPU> load(LoadingContext &ctx, scene::SceneInputNode &input, const ref_ptr<ModelTransformation> &tf);
 
 		// override Animation
-		void glAnimate(RenderState *rs, GLdouble dt) override;
+		void glAnimate(RenderState *rs, double dt) override;
 
 		void initBoidSimulation() override;
 

--- a/regen/simulation/bullet-debug-drawer.cpp
+++ b/regen/simulation/bullet-debug-drawer.cpp
@@ -17,7 +17,7 @@ BulletDebugDrawer::BulletDebugDrawer(const ref_ptr<BulletPhysics> &physics)
 	lineVertices_->setVertexData(2);
 	// Create and set up the VAO and VBO
 	vao_ = ref_ptr<VAO>::alloc();
-	bufferSize_ = sizeof(GLfloat) * 3 * lineVertices_->numVertices();
+	bufferSize_ = sizeof(float) * 3 * lineVertices_->numVertices();
 	glGenBuffers(1, &vbo_);
 }
 

--- a/regen/simulation/bullet-physics.cpp
+++ b/regen/simulation/bullet-physics.cpp
@@ -60,7 +60,7 @@ void BulletPhysics::addObject(const ref_ptr<PhysicalObject> &object) {
 	objects_.push_back(object);
 }
 
-void BulletPhysics::animate(GLdouble dt) {
+void BulletPhysics::animate(double dt) {
 	auto timeStep = btScalar(dt / 1000.0);
 	auto fixedTimeStep = btScalar(1.0 / 60.0);
 	int maxSubSteps = 5;

--- a/regen/simulation/bullet-physics.cpp
+++ b/regen/simulation/bullet-physics.cpp
@@ -60,7 +60,7 @@ void BulletPhysics::addObject(const ref_ptr<PhysicalObject> &object) {
 	objects_.push_back(object);
 }
 
-void BulletPhysics::animate(double dt) {
+void BulletPhysics::cpuUpdate(double dt) {
 	auto timeStep = btScalar(dt / 1000.0);
 	auto fixedTimeStep = btScalar(1.0 / 60.0);
 	int maxSubSteps = 5;

--- a/regen/simulation/bullet-physics.h
+++ b/regen/simulation/bullet-physics.h
@@ -37,7 +37,7 @@ namespace regen {
 		auto &dynamicsWorld() { return dynamicsWorld_; }
 
 		// override
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 	protected:
 		std::list<ref_ptr<PhysicalObject> > objects_;

--- a/regen/simulation/bullet-physics.h
+++ b/regen/simulation/bullet-physics.h
@@ -37,7 +37,7 @@ namespace regen {
 		auto &dynamicsWorld() { return dynamicsWorld_; }
 
 		// override
-		void animate(GLdouble dt) override;
+		void animate(double dt) override;
 
 	protected:
 		std::list<ref_ptr<PhysicalObject> > objects_;

--- a/regen/simulation/impulse-controller.cpp
+++ b/regen/simulation/impulse-controller.cpp
@@ -86,11 +86,11 @@ ref_ptr<ImpulseController> ImpulseController::load(
 		ref_ptr<ImpulseController>::alloc(userCamera, physicalObject);
 	controller = impulseController;
 	controller->setMeshEyeOffset(node.getValue<Vec3f>("eye-offset", Vec3f::zero()));
-	controller->set_moveAmount(node.getValue<GLfloat>("speed", 0.01f));
-	controller->setMeshDistance(node.getValue<GLfloat>("mesh-distance", 10.0f));
-	controller->setHorizontalOrientation(node.getValue<GLfloat>("horizontal-orientation", 0.0));
-	controller->setVerticalOrientation(node.getValue<GLfloat>("vertical-orientation", 0.0));
-	controller->setMeshHorizontalOrientation(node.getValue<GLfloat>("mesh-horizontal-orientation", 0.0));
+	controller->set_moveAmount(node.getValue<float>("speed", 0.01f));
+	controller->setMeshDistance(node.getValue<float>("mesh-distance", 10.0f));
+	controller->setHorizontalOrientation(node.getValue<float>("horizontal-orientation", 0.0));
+	controller->setVerticalOrientation(node.getValue<float>("vertical-orientation", 0.0));
+	controller->setMeshHorizontalOrientation(node.getValue<float>("mesh-horizontal-orientation", 0.0));
 	if (controllerMode == "third-person") {
 		controller->setCameraMode(CameraController::THIRD_PERSON);
 	} else {

--- a/regen/simulation/kinematic-controller.cpp
+++ b/regen/simulation/kinematic-controller.cpp
@@ -89,7 +89,7 @@ KinematicPlayerController::~KinematicPlayerController() {
 	}
 }
 
-void KinematicPlayerController::setGravityForce(GLfloat force) {
+void KinematicPlayerController::setGravityForce(float force) {
 	btGravityForce_ = force;
 	if (btController_.get()) {
 		btController_->setGravity(btVector3(0, -btGravityForce_, 0));
@@ -97,7 +97,7 @@ void KinematicPlayerController::setGravityForce(GLfloat force) {
 }
 
 
-void KinematicPlayerController::setMaxSlope(GLfloat maxSlope) {
+void KinematicPlayerController::setMaxSlope(float maxSlope) {
 	btMaxSlope_ = maxSlope;
 	if (btController_.get()) {
 		btController_->setMaxSlope(btMaxSlope_);
@@ -183,7 +183,7 @@ void KinematicPlayerController::applyStep(float dt, const Vec3f &offset) {
 	ghostTransform.getOpenGLMatrix((btScalar *) &matVal_);
 	// decrease the y position by the collision height, else
 	// the character would float above the ground
-	GLfloat heightAdjust = btCollisionHeight_ * 0.5f + btCollisionRadius_;
+	float heightAdjust = btCollisionHeight_ * 0.5f + btCollisionRadius_;
 	matVal_.x[13] -= heightAdjust;
 
 	btVector3 btVelocity = btController_->getLinearVelocity();

--- a/regen/simulation/model-matrix-motion.cpp
+++ b/regen/simulation/model-matrix-motion.cpp
@@ -35,7 +35,7 @@ ModelMatrixUpdater::~ModelMatrixUpdater() {
 	delete[] backBuffer_;
 }
 
-void ModelMatrixUpdater::animate(GLdouble dt) {
+void ModelMatrixUpdater::animate(double dt) {
 	if (stamp_ == tf_->modelMat()->stampOfReadData()) return;
 	stamp_ = tf_->modelMat()->stampOfReadData();
 	auto regenData = tf_->modelMat()->mapClientDataRaw(BUFFER_GPU_WRITE);

--- a/regen/simulation/model-matrix-motion.cpp
+++ b/regen/simulation/model-matrix-motion.cpp
@@ -35,7 +35,7 @@ ModelMatrixUpdater::~ModelMatrixUpdater() {
 	delete[] backBuffer_;
 }
 
-void ModelMatrixUpdater::animate(double dt) {
+void ModelMatrixUpdater::cpuUpdate(double dt) {
 	if (stamp_ == tf_->modelMat()->stampOfReadData()) return;
 	stamp_ = tf_->modelMat()->stampOfReadData();
 	auto regenData = tf_->modelMat()->mapClientDataRaw(BUFFER_GPU_WRITE);

--- a/regen/simulation/model-matrix-motion.h
+++ b/regen/simulation/model-matrix-motion.h
@@ -49,7 +49,7 @@ namespace regen {
 		void nextStamp() { stamp_++; }
 
 		// Override from Animation
-		void animate(GLdouble dt) override;
+		void animate(double dt) override;
 
 	protected:
 		ref_ptr<ModelTransformation> tf_;

--- a/regen/simulation/model-matrix-motion.h
+++ b/regen/simulation/model-matrix-motion.h
@@ -49,7 +49,7 @@ namespace regen {
 		void nextStamp() { stamp_++; }
 
 		// Override from Animation
-		void animate(double dt) override;
+		void cpuUpdate(double dt) override;
 
 	protected:
 		ref_ptr<ModelTransformation> tf_;

--- a/regen/states/atomic-states.cpp
+++ b/regen/states/atomic-states.cpp
@@ -52,5 +52,5 @@ ref_ptr<State> SampleShadingState::load(LoadingContext &ctx, scene::SceneInputNo
 
 ref_ptr<State> ColorMaskState::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 	return ref_ptr<ColorMaskState>::alloc(ColorMask(
-			input.getValue<ColorMask>("mask", ColorMask::create(GL_TRUE))));
+			input.getValue<ColorMask>("mask", ColorMask::create(true))));
 }

--- a/regen/states/atomic-states.h
+++ b/regen/states/atomic-states.h
@@ -409,7 +409,7 @@ namespace regen {
 				fbo_->clearDepthAttachment(defaultClearDepth);
 			}
 			if (clearBits_ & GL_STENCIL_BUFFER_BIT) {
-				static const GLint defaultClearStencil = 0;
+				static const int defaultClearStencil = 0;
 				fbo_->clearStencilAttachment(defaultClearStencil);
 			}
 		}

--- a/regen/states/atomic-states.h
+++ b/regen/states/atomic-states.h
@@ -22,7 +22,7 @@ namespace regen {
 		 * @param key the toggle key.
 		 * @param toggle the toggle value.
 		 */
-		ToggleState(RenderState::Toggle key, GLboolean toggle)
+		ToggleState(RenderState::Toggle key, bool toggle)
 				: ServerSideState(), key_(key), toggle_(toggle) {}
 
 		/**
@@ -33,7 +33,7 @@ namespace regen {
 		/**
 		 * @return the toggle value.
 		 */
-		GLboolean toggle() const { return toggle_; }
+		bool toggle() const { return toggle_; }
 
 		void enable(RenderState *rs) override { rs->toggles().push(key_, toggle_); }
 
@@ -51,7 +51,7 @@ namespace regen {
 
 	protected:
 		RenderState::Toggle key_;
-		GLboolean toggle_;
+		bool toggle_;
 	};
 
 	/**
@@ -104,10 +104,10 @@ namespace regen {
 	class ToggleDepthWriteState : public ServerSideState {
 	public:
 		/**
-		 * If flag is GL_FALSE, depth buffer writing is disabled.
+		 * If flag is false, depth buffer writing is disabled.
 		 * Otherwise, it is enabled. Initially, depth buffer writing is enabled.
 		 */
-		explicit ToggleDepthWriteState(GLboolean toggle)
+		explicit ToggleDepthWriteState(bool toggle)
 				: ServerSideState(), toggle_(toggle) {}
 
 		void enable(RenderState *rs) override { rs->depthMask().push(toggle_); }
@@ -115,7 +115,7 @@ namespace regen {
 		void disable(RenderState *rs) override { rs->depthMask().pop(); }
 
 	protected:
-		GLboolean toggle_;
+		bool toggle_;
 	};
 
 	/**
@@ -264,7 +264,7 @@ namespace regen {
 				: PolygonState(), factor_(factor), units_(units) {}
 
 		void enable(RenderState *rs) override {
-			rs->toggles().push(RenderState::POLYGON_OFFSET_FILL, GL_TRUE);
+			rs->toggles().push(RenderState::POLYGON_OFFSET_FILL, true);
 			rs->polygonOffset().push(Vec2f(factor_, units_));
 		}
 

--- a/regen/states/atomic-states.h
+++ b/regen/states/atomic-states.h
@@ -87,7 +87,7 @@ namespace regen {
 		 * @param farVal specifies the mapping of the far clipping plane to window coordinates.
 		 *    The initial value is 1.
 		 */
-		DepthRangeState(GLdouble nearVal, GLdouble farVal)
+		DepthRangeState(double nearVal, double farVal)
 				: ServerSideState(), nearVal_(nearVal), farVal_(farVal) {}
 
 		void enable(RenderState *rs) override { rs->depthRange().push(DepthRange(nearVal_, farVal_)); }
@@ -95,7 +95,7 @@ namespace regen {
 		void disable(RenderState *rs) override { rs->depthRange().pop(); }
 
 	protected:
-		GLdouble nearVal_, farVal_;
+		double nearVal_, farVal_;
 	};
 
 	/**

--- a/regen/states/atomic-states.h
+++ b/regen/states/atomic-states.h
@@ -260,7 +260,7 @@ namespace regen {
 		 * @param units is multiplied by an implementation-specific value to
 		 *    create a constant depth offset. The initial value is 0.
 		 */
-		PolygonOffsetState(GLfloat factor, GLfloat units)
+		PolygonOffsetState(float factor, float units)
 				: PolygonState(), factor_(factor), units_(units) {}
 
 		void enable(RenderState *rs) override {
@@ -274,7 +274,7 @@ namespace regen {
 		}
 
 	protected:
-		GLfloat factor_, units_;
+		float factor_, units_;
 	};
 
 	/**

--- a/regen/states/blend-state.cpp
+++ b/regen/states/blend-state.cpp
@@ -103,7 +103,7 @@ namespace regen {
 	}
 
 	BlendState::BlendState(BlendMode blendMode) : ServerSideState() {
-		joinStates(ref_ptr<ToggleState>::alloc(RenderState::BLEND, GL_TRUE));
+		joinStates(ref_ptr<ToggleState>::alloc(RenderState::BLEND, true));
 
 		switch (blendMode) {
 			case BLEND_MODE_ALPHA:
@@ -189,7 +189,7 @@ namespace regen {
 	}
 
 	BlendState::BlendState(GLenum sfactor, GLenum dfactor) : ServerSideState() {
-		joinStates(ref_ptr<ToggleState>::alloc(RenderState::BLEND, GL_TRUE));
+		joinStates(ref_ptr<ToggleState>::alloc(RenderState::BLEND, true));
 		setBlendFunc(sfactor, dfactor);
 	}
 

--- a/regen/states/blit-state.cpp
+++ b/regen/states/blit-state.cpp
@@ -7,7 +7,7 @@ BlitToFBO::BlitToFBO(
 		const ref_ptr<FBO> &dst,
 		GLenum srcAttachment,
 		GLenum dstAttachment,
-		GLboolean keepRatio)
+		bool keepRatio)
 		: BlitState(),
 		  src_(src),
 		  dst_(dst),
@@ -40,7 +40,7 @@ BlitToScreen::BlitToScreen(
 		const ref_ptr<FBO> &fbo,
 		const ref_ptr<Screen> &screen,
 		GLenum attachment,
-		GLboolean keepRatio)
+		bool keepRatio)
 		: BlitState(),
 		  fbo_(fbo),
 		  screen_(screen),

--- a/regen/states/blit-state.h
+++ b/regen/states/blit-state.h
@@ -29,7 +29,7 @@ namespace regen {
 				const ref_ptr<FBO> &dst,
 				GLenum srcAttachment = GL_COLOR_ATTACHMENT0,
 				GLenum dstAttachment = GL_COLOR_ATTACHMENT0,
-				GLboolean keepRatio = GL_FALSE);
+				bool keepRatio = false);
 
 		/**
 		 * filterMode must be GL_NEAREST or GL_LINEAR.
@@ -53,7 +53,7 @@ namespace regen {
 		GLenum dstAttachment_;
 		GLenum filterMode_;
 		GLenum sourceBuffer_;
-		GLboolean keepRatio_;
+		bool keepRatio_;
 	};
 
 	/**
@@ -71,7 +71,7 @@ namespace regen {
 				const ref_ptr<FBO> &fbo,
 				const ref_ptr<Screen> &screen,
 				GLenum attachment = GL_COLOR_ATTACHMENT0,
-				GLboolean keepRatio = GL_FALSE);
+				bool keepRatio = false);
 
 		/**
 		 * filterMode must be GL_NEAREST or GL_LINEAR.
@@ -109,7 +109,7 @@ namespace regen {
 		GLenum attachment_;
 		GLenum filterMode_;
 		GLenum sourceBuffer_;
-		GLboolean keepRatio_;
+		bool keepRatio_;
 	};
 
 	/**

--- a/regen/states/depth-state.cpp
+++ b/regen/states/depth-state.cpp
@@ -12,7 +12,7 @@
 
 using namespace regen;
 
-void DepthState::set_useDepthWrite(GLboolean useDepthWrite) {
+void DepthState::set_useDepthWrite(bool useDepthWrite) {
 	if (depthWriteToggle_.get()) {
 		disjoinStates(depthWriteToggle_);
 	}
@@ -20,14 +20,14 @@ void DepthState::set_useDepthWrite(GLboolean useDepthWrite) {
 	joinStates(depthWriteToggle_);
 }
 
-void DepthState::set_useDepthTest(GLboolean useDepthTest) {
+void DepthState::set_useDepthTest(bool useDepthTest) {
 	if (depthTestToggle_.get()) {
 		disjoinStates(depthTestToggle_);
 	}
 	if (useDepthTest) {
-		depthTestToggle_ = ref_ptr<ToggleState>::alloc(RenderState::DEPTH_TEST, GL_TRUE);
+		depthTestToggle_ = ref_ptr<ToggleState>::alloc(RenderState::DEPTH_TEST, true);
 	} else {
-		depthTestToggle_ = ref_ptr<ToggleState>::alloc(RenderState::DEPTH_TEST, GL_FALSE);
+		depthTestToggle_ = ref_ptr<ToggleState>::alloc(RenderState::DEPTH_TEST, false);
 	}
 	joinStates(depthTestToggle_);
 }

--- a/regen/states/depth-state.cpp
+++ b/regen/states/depth-state.cpp
@@ -40,7 +40,7 @@ void DepthState::set_depthFunc(GLenum depthFunc) {
 	joinStates(depthFunc_);
 }
 
-void DepthState::set_depthRange(GLdouble nearVal, GLdouble farVal) {
+void DepthState::set_depthRange(double nearVal, double farVal) {
 	if (depthRange_.get()) {
 		disjoinStates(depthRange_);
 	}

--- a/regen/states/depth-state.h
+++ b/regen/states/depth-state.h
@@ -41,7 +41,7 @@ namespace regen {
 		 * nearVal specifies the mapping of the near clipping plane to window coordinates. The initial value is 0.
 		 * farVal specifies the mapping of the far clipping plane to window coordinates. The initial value is 1.
 		 */
-		void set_depthRange(GLdouble nearVal = 0.0, GLdouble farVal = 1.0);
+		void set_depthRange(double nearVal = 0.0, double farVal = 1.0);
 
 	protected:
 		ref_ptr<State> depthTestToggle_;

--- a/regen/states/depth-state.h
+++ b/regen/states/depth-state.h
@@ -21,12 +21,12 @@ namespace regen {
 		/**
 		 * Enable or disable depth testing with this state.
 		 */
-		void set_useDepthTest(GLboolean useDepthTest);
+		void set_useDepthTest(bool useDepthTest);
 
 		/**
 		 * Enable or disable depth writing with this state.
 		 */
-		void set_useDepthWrite(GLboolean useDepthTest);
+		void set_useDepthWrite(bool useDepthTest);
 
 		/**
 		 * Specifies the depth comparison function. Symbolic constants

--- a/regen/states/direct-shading.h
+++ b/regen/states/direct-shading.h
@@ -56,7 +56,7 @@ namespace regen {
 		void removeLight(const ref_ptr<Light> &l);
 
 	protected:
-		GLint idCounter_;
+		int idCounter_;
 
 		struct DirectLight {
 			uint32_t id_;

--- a/regen/states/feedback-state.cpp
+++ b/regen/states/feedback-state.cpp
@@ -47,7 +47,7 @@ ref_ptr<ShaderInput> FeedbackSpecification::getFeedback(const std::string &name)
 	return *(it->second);
 }
 
-GLboolean FeedbackSpecification::hasFeedback(const std::string &name) const {
+bool FeedbackSpecification::hasFeedback(const std::string &name) const {
 	return feedbackAttributeMap_.count(name) > 0;
 }
 

--- a/regen/states/feedback-state.cpp
+++ b/regen/states/feedback-state.cpp
@@ -94,7 +94,7 @@ void FeedbackState::enable(RenderState *rs) {
 		rs->beginTransformFeedback(feedbackPrimitive_);
 	} else {
 		if (!rs->isTransformFeedbackAcive()) {
-			GLint bufferIndex = 0;
+			int bufferIndex = 0;
 			for (auto & att : feedbackAttributes_) {
 				bufferRange_.offset_ = att->offset();
 				bufferRange_.size_ = att->inputSize();

--- a/regen/states/feedback-state.h
+++ b/regen/states/feedback-state.h
@@ -56,7 +56,7 @@ namespace regen {
 		 * @param name name of an attribute.
 		 * @return true if there is a feedback attribute with given name.
 		 */
-		GLboolean hasFeedback(const std::string &name) const;
+		bool hasFeedback(const std::string &name) const;
 
 		/**
 		 * @param name feedback name

--- a/regen/states/geometric-picking.cpp
+++ b/regen/states/geometric-picking.cpp
@@ -24,7 +24,7 @@ GeomPicking::GeomPicking(const ref_ptr<Camera> &camera, const ref_ptr<ShaderInpu
 	state_->setInput(mouseDirVS_);
 
 	// skip fragment shader, only up to geometry shader is needed
-	state_->joinStates(ref_ptr<ToggleState>::alloc(RenderState::RASTERIZER_DISCARD, GL_TRUE));
+	state_->joinStates(ref_ptr<ToggleState>::alloc(RenderState::RASTERIZER_DISCARD, true));
 
 	// create attributes used for picking
 	pickObjectID_ = ref_ptr<ShaderInput1i>::alloc("pickObjectID");

--- a/regen/states/geometric-picking.h
+++ b/regen/states/geometric-picking.h
@@ -26,7 +26,7 @@ namespace regen {
 		/**
 		 * @return true if an object has been picked.
 		 */
-		auto hasPickedObject() const -> GLboolean { return hasPickedObject_; }
+		auto hasPickedObject() const -> bool { return hasPickedObject_; }
 
 		/**
 		 * @return the picked object.
@@ -40,7 +40,7 @@ namespace regen {
 		ref_ptr<Camera> camera_;
 		uint32_t maxPickedObjects_;
 
-		GLboolean hasPickedObject_;
+		bool hasPickedObject_;
 		PickData pickedObject_;
 
 		ref_ptr<ShaderInput2f> mouseTexco_;

--- a/regen/states/light-pass.cpp
+++ b/regen/states/light-pass.cpp
@@ -185,7 +185,7 @@ void LightPass::addLightInput(LightPassLight &light) {
 void LightPass::addInputLocation(LightPassLight &l,
 								 const ref_ptr<ShaderInput> &in, const std::string &name) {
 	Shader *s = shader_->shader().get();
-	GLint loc = s->uniformLocation(name);
+	int loc = s->uniformLocation(name);
 	if (loc > 0) {
 		l.inputLocations.emplace_back(in, loc);
 	}

--- a/regen/states/light-pass.cpp
+++ b/regen/states/light-pass.cpp
@@ -17,13 +17,13 @@ LightPass::LightPass(Light::Type type, std::string_view shaderKey)
 			mesh_ = ConeClosed::getBaseCone();
 			joinStates(ref_ptr<CullFaceState>::alloc(GL_FRONT));
 			// enable depth clamping to avoid faces to be clipped away when out of depth range.
-			joinStates(ref_ptr<ToggleState>::alloc(RenderState::DEPTH_CLAMP, GL_TRUE));
+			joinStates(ref_ptr<ToggleState>::alloc(RenderState::DEPTH_CLAMP, true));
 			break;
 		case Light::POINT:
 			mesh_ = Box::getUnitCube();
 			joinStates(ref_ptr<CullFaceState>::alloc(GL_FRONT));
 			// enable depth clamping to avoid faces to be clipped away when out of depth range.
-			joinStates(ref_ptr<ToggleState>::alloc(RenderState::DEPTH_CLAMP, GL_TRUE));
+			joinStates(ref_ptr<ToggleState>::alloc(RenderState::DEPTH_CLAMP, true));
 			break;
 	}
 	shadowFiltering_ = SHADOW_FILTERING_NONE;

--- a/regen/states/light-state.cpp
+++ b/regen/states/light-state.cpp
@@ -10,7 +10,7 @@ namespace regen {
 		explicit SpotConeAnimation(Light *light)
 				: Animation(false, true), light_(light) {}
 
-		void animate(double dt) override {
+		void cpuUpdate(double dt) override {
 			light_->updateConeMatrix();
 		}
 

--- a/regen/states/light-state.cpp
+++ b/regen/states/light-state.cpp
@@ -81,7 +81,7 @@ bool Light::updateConeMatrix() {
 	if (lightConeStamp_ == stamp) return false; // no update needed
 
 	// Note: cone opens in positive z direction.
-	auto numInstances = this->numInstances();
+	auto numInstances = static_cast<uint32_t>(this->numInstances());
 	if (coneMatrix_->numInstances() != numInstances) {
 		// ensure cone matrix has numInstances
 		coneMatrix_->setInstanceData(numInstances, 1, nullptr);

--- a/regen/states/light-state.cpp
+++ b/regen/states/light-state.cpp
@@ -81,9 +81,7 @@ bool Light::updateConeMatrix() {
 	if (lightConeStamp_ == stamp) return false; // no update needed
 
 	// Note: cone opens in positive z direction.
-	// FIXME: where are num instances set for light? probably best to hook resize there!
-	//         here is too late!
-	auto numInstances = std::max(lightPosition_->numInstances(), lightDirection_->numInstances());
+	auto numInstances = this->numInstances();
 	if (coneMatrix_->numInstances() != numInstances) {
 		// ensure cone matrix has numInstances
 		coneMatrix_->setInstanceData(numInstances, 1, nullptr);
@@ -181,6 +179,8 @@ ref_ptr<Light> Light::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 	updateFlags.scope = input.getValue<BufferUpdateScope>(
 		"update-scope", BUFFER_UPDATE_FULLY);
 
+	uint32_t numInstances = input.getValue<uint32_t>("num-instances", 1u);
+
 	auto lightType = input.getValue<Light::Type>("type", Light::SPOT);
 	ref_ptr<Light> light = ref_ptr<Light>::alloc(lightType, updateFlags);
 	light->set_isAttenuated(
@@ -212,12 +212,13 @@ ref_ptr<Light> Light::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 				continue;
 			}
 			auto setTarget = target_opt.value().in;
-			auto numInstances = std::max(
+			auto numInstances0 = std::max(
 					child->getValue<uint32_t>("num-instances", 1u),
 					setTarget->numInstances());
+			numInstances = std::max(numInstances, numInstances0);
 			// allocate memory for the shader input
-			setTarget->setInstanceData(numInstances, 1, nullptr);
-			scene::ShaderInputProcessor::setInput(*child.get(), setTarget.get(), numInstances);
+			setTarget->setInstanceData(numInstances0, 1, nullptr);
+			scene::ShaderInputProcessor::setInput(*child.get(), setTarget.get(), numInstances0);
 		}
 		if (child->getCategory() == "animation") {
 			auto animationType = child->getValue("type");
@@ -228,7 +229,7 @@ ref_ptr<Light> Light::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 				// TODO: this will update position, without updating the light!
 				//   Which is fine in most cases, but eg. in case of spot light,
 				//   the cone matrix may need to be updated.
-				// TODO: also attach orientation for spot cameras.
+				//   - also attach orientation for spot cameras.
 				auto boids = ref_ptr<BoidsCPU>::alloc(light->position());
 				boids->loadSettings(ctx, *child.get());
 
@@ -239,6 +240,8 @@ ref_ptr<Light> Light::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 			}
 		}
 	}
+	light->set_numInstances(numInstances);
+
 	// remove visited children
 	for (auto &child : visited) {
 		input.removeChild(child);

--- a/regen/states/light-state.cpp
+++ b/regen/states/light-state.cpp
@@ -10,7 +10,7 @@ namespace regen {
 		explicit SpotConeAnimation(Light *light)
 				: Animation(false, true), light_(light) {}
 
-		void animate(GLdouble dt) override {
+		void animate(double dt) override {
 			light_->updateConeMatrix();
 		}
 

--- a/regen/states/material-state.cpp
+++ b/regen/states/material-state.cpp
@@ -102,7 +102,7 @@ void Material::set_twoSided(GLboolean twoSided) {
 	shaderDefine("HAS_TWO_SIDES", twoSided ? "TRUE" : "FALSE");
 }
 
-void Material::set_maxOffset(GLfloat offset) {
+void Material::set_maxOffset(float offset) {
 	maxOffset_ = offset;
 	auto heightMaps = textures_.find(TextureState::MAP_TO_HEIGHT);
 	if (heightMaps != textures_.end()) {
@@ -456,7 +456,7 @@ ref_ptr<Material> Material::load(LoadingContext &ctx, scene::SceneInputNode &inp
 	ref_ptr<Material> mat = ref_ptr<Material>::alloc(updateFlags);
 
 	if (input.hasAttribute("max-offset")) {
-		mat->set_maxOffset(input.getValue<GLfloat>("max-offset", 0.1f));
+		mat->set_maxOffset(input.getValue<float>("max-offset", 0.1f));
 	}
 	if (input.hasAttribute("height-map-mode")) {
 		mat->set_heightMapMode(input.getValue<Material::HeightMapMode>("height-map-mode",
@@ -466,7 +466,7 @@ ref_ptr<Material> Material::load(LoadingContext &ctx, scene::SceneInputNode &inp
 		mat->set_colorBlendMode(input.getValue<BlendMode>("color-blend-mode", BLEND_MODE_SRC));
 	}
 	if (input.hasAttribute("color-blend-factor")) {
-		mat->set_colorBlendFactor(input.getValue<GLfloat>("color-blending-factor", 1.0f));
+		mat->set_colorBlendFactor(input.getValue<float>("color-blending-factor", 1.0f));
 	}
 
 	if (input.hasAttribute("asset")) {
@@ -513,7 +513,7 @@ ref_ptr<Material> Material::load(LoadingContext &ctx, scene::SceneInputNode &inp
 								   input.getValue<Vec3f>("specular", Vec3f::zero()));
 	if (input.hasAttribute("shininess"))
 		mat->shininess()->setVertex(0,
-									input.getValue<GLfloat>("shininess", 1.0f));
+									input.getValue<float>("shininess", 1.0f));
 	if (input.hasAttribute("emission"))
 		mat->set_emission(input.getValue<Vec3f>("emission", Vec3f::zero()));
 	if (input.hasAttribute("textures")) {
@@ -523,9 +523,9 @@ ref_ptr<Material> Material::load(LoadingContext &ctx, scene::SceneInputNode &inp
 	}
 
 	mat->alpha()->setVertex(0,
-							input.getValue<GLfloat>("alpha", 1.0f));
+							input.getValue<float>("alpha", 1.0f));
 	mat->refractionIndex()->setVertex(0,
-									  input.getValue<GLfloat>("refractionIndex", 0.95f));
+									  input.getValue<float>("refractionIndex", 0.95f));
 	mat->set_fillMode(glenum::fillMode(
 			input.getValue<std::string>("fill-mode", "FILL")));
 	if (input.getValue<bool>("two-sided", false)) {

--- a/regen/states/material-state.cpp
+++ b/regen/states/material-state.cpp
@@ -93,7 +93,7 @@ void Material::set_fillMode(GLenum fillMode) {
 	joinStates(fillModeState_);
 }
 
-void Material::set_twoSided(GLboolean twoSided) {
+void Material::set_twoSided(bool twoSided) {
 	if (twoSidedState_.get()) {
 		disjoinStates(twoSidedState_);
 	}

--- a/regen/states/material-state.h
+++ b/regen/states/material-state.h
@@ -160,12 +160,12 @@ namespace regen {
 		 * Sets the blending factor for color and diffuse maps
 		 * added to this material.
 		 */
-		void set_colorBlendFactor(GLfloat factor) { colorBlendFactor_ = factor; }
+		void set_colorBlendFactor(float factor) { colorBlendFactor_ = factor; }
 
 		/**
 		 * Sets the maximum height offset for height and displacement maps.
 		 */
-		void set_maxOffset(GLfloat offset);
+		void set_maxOffset(float offset);
 
 		/**
 		 * Sets the height map mode.

--- a/regen/states/material-state.h
+++ b/regen/states/material-state.h
@@ -143,7 +143,7 @@ namespace regen {
 		/**
 		 * Indicates if the material should be rendered two-sided.
 		 */
-		void set_twoSided(GLboolean v);
+		void set_twoSided(bool v);
 
 		/**
 		 * Sets the wrapping mode for all textures.
@@ -175,7 +175,7 @@ namespace regen {
 		/**
 		 * Indicates if the material should be rendered two-sided.
 		 */
-		GLboolean twoSided() const { return twoSidedState_.get() != nullptr; }
+		bool twoSided() const { return twoSidedState_.get() != nullptr; }
 
 		/**
 		 * Sets default material colors for jade.

--- a/regen/states/state-node-comparator.cpp
+++ b/regen/states/state-node-comparator.cpp
@@ -8,7 +8,7 @@ NodeEyeDepthComparator::NodeEyeDepthComparator(
 		  mode_(((int) frontToBack) * 2 - 1) {
 }
 
-GLfloat NodeEyeDepthComparator::getEyeDepth(const Vec3f &p) const {
+float NodeEyeDepthComparator::getEyeDepth(const Vec3f &p) const {
 	auto &mat = cam_->view()[0];
 	return mat.x[2] * p.x + mat.x[6] * p.y + mat.x[10] * p.z + mat.x[14];
 }

--- a/regen/states/state-node-comparator.cpp
+++ b/regen/states/state-node-comparator.cpp
@@ -3,7 +3,7 @@
 using namespace regen;
 
 NodeEyeDepthComparator::NodeEyeDepthComparator(
-		const ref_ptr<Camera> &cam, GLboolean frontToBack)
+		const ref_ptr<Camera> &cam, bool frontToBack)
 		: cam_(cam),
 		  mode_(((int) frontToBack) * 2 - 1) {
 }

--- a/regen/states/state-node-comparator.cpp
+++ b/regen/states/state-node-comparator.cpp
@@ -5,7 +5,7 @@ using namespace regen;
 NodeEyeDepthComparator::NodeEyeDepthComparator(
 		const ref_ptr<Camera> &cam, GLboolean frontToBack)
 		: cam_(cam),
-		  mode_(((GLint) frontToBack) * 2 - 1) {
+		  mode_(((int) frontToBack) * 2 - 1) {
 }
 
 GLfloat NodeEyeDepthComparator::getEyeDepth(const Vec3f &p) const {

--- a/regen/states/state-node-comparator.h
+++ b/regen/states/state-node-comparator.h
@@ -43,7 +43,7 @@ namespace regen {
 	protected:
 		mutable std::map<StateNode*, ModelTransformation*> modelTransformations_;
 		ref_ptr<Camera> cam_;
-		GLint mode_;
+		int mode_;
 	};
 } // namespace
 

--- a/regen/states/state-node-comparator.h
+++ b/regen/states/state-node-comparator.h
@@ -21,7 +21,7 @@ namespace regen {
 		 * @param worldPosition the world position.
 		 * @return world position camera distance.
 		 */
-		GLfloat getEyeDepth(const Vec3f &worldPosition) const;
+		float getEyeDepth(const Vec3f &worldPosition) const;
 
 		/**
 		 * @param n a node.

--- a/regen/states/state-node-comparator.h
+++ b/regen/states/state-node-comparator.h
@@ -15,7 +15,7 @@ namespace regen {
 		 * @param cam the perspective camera.
 		 * @param frontToBack sort front to back or back to front
 		 */
-		NodeEyeDepthComparator(const ref_ptr<Camera> &cam, GLboolean frontToBack);
+		NodeEyeDepthComparator(const ref_ptr<Camera> &cam, bool frontToBack);
 
 		/**
 		 * @param worldPosition the world position.

--- a/regen/states/state-node.cpp
+++ b/regen/states/state-node.cpp
@@ -142,7 +142,7 @@ void RootNode::render(float /* dt */) {
 	traverse(rs);
 }
 
-void RootNode::postRender(GLdouble dt) {
+void RootNode::postRender(double dt) {
 	//AnimationManager::get().nextFrame();
 	// some animations modify the vertex data,
 	// updating the vbo needs a context so we do it here in the main thread..

--- a/regen/states/state-node.cpp
+++ b/regen/states/state-node.cpp
@@ -146,7 +146,7 @@ void RootNode::postRender(GLdouble dt) {
 	//AnimationManager::get().nextFrame();
 	// some animations modify the vertex data,
 	// updating the vbo needs a context so we do it here in the main thread..
-	AnimationManager::get().updateGraphics(RenderState::get(), dt);
+	AnimationManager::get().updateSynchronized_GPU(dt);
 }
 
 //////////////

--- a/regen/states/state-node.cpp
+++ b/regen/states/state-node.cpp
@@ -146,7 +146,7 @@ void RootNode::postRender(double dt) {
 	//AnimationManager::get().nextFrame();
 	// some animations modify the vertex data,
 	// updating the vbo needs a context so we do it here in the main thread..
-	AnimationManager::get().updateSynchronized_GPU(dt);
+	AnimationManager::get().gpuUpdateStep(dt);
 }
 
 //////////////

--- a/regen/states/state-node.h
+++ b/regen/states/state-node.h
@@ -43,12 +43,12 @@ namespace regen {
 		/**
 		 * @return is the node hidden.
 		 */
-		GLboolean isHidden() const { return isHidden_; }
+		bool isHidden() const { return isHidden_; }
 
 		/**
 		 * @param isHidden is the node hidden.
 		 */
-		void set_isHidden(GLboolean isHidden) { isHidden_ = isHidden; }
+		void set_isHidden(bool isHidden) { isHidden_ = isHidden; }
 
 		/**
 		 * @return true if a parent is set.

--- a/regen/states/state-node.h
+++ b/regen/states/state-node.h
@@ -206,7 +206,7 @@ namespace regen {
 		 * Do something after render call.
 		 * @param dt time difference to last traversal.
 		 */
-		static void postRender(GLdouble dt);
+		static void postRender(double dt);
 	};
 } // namespace
 

--- a/regen/states/stencil-state.cpp
+++ b/regen/states/stencil-state.cpp
@@ -39,9 +39,9 @@ void StencilState::set_useStencilTest(bool useStencilTest) {
 		disjoinStates(stencilTestToggle_);
 	}
 	if (useStencilTest) {
-		stencilTestToggle_ = ref_ptr<ToggleState>::alloc(RenderState::STENCIL_TEST, GL_TRUE);
+		stencilTestToggle_ = ref_ptr<ToggleState>::alloc(RenderState::STENCIL_TEST, true);
 	} else {
-		stencilTestToggle_ = ref_ptr<ToggleState>::alloc(RenderState::STENCIL_TEST, GL_FALSE);
+		stencilTestToggle_ = ref_ptr<ToggleState>::alloc(RenderState::STENCIL_TEST, false);
 	}
 	joinStates(stencilTestToggle_);
 }

--- a/regen/states/tesselation-state.cpp
+++ b/regen/states/tesselation-state.cpp
@@ -114,7 +114,7 @@ ref_ptr<TesselationState> TesselationState::load(LoadingContext &ctx, scene::Sce
 	tess->outerLevel()->setVertex(0,
 								  input.getValue<Vec4f>("outer-level", Vec4f::create(8.0f)));
 	tess->lodFactor()->setVertex(0,
-								 input.getValue<GLfloat>("lod-factor", 4.0f));
+								 input.getValue<float>("lod-factor", 4.0f));
 	tess->set_lodMetric(input.getValue<TesselationState::LoDMetric>(
 			"lod-metric", TesselationState::CAMERA_DISTANCE));
 

--- a/regen/textures/fbo-state.cpp
+++ b/regen/textures/fbo-state.cpp
@@ -160,7 +160,7 @@ static std::vector<GLenum> getFBOAttachments_(scene::SceneInputNode &input, cons
 			attachments[i] = GL_BACK_RIGHT;
 		}
 		else {
-			GLint v;
+			int v;
 			std::stringstream ss(attachments_str[i]);
 			ss >> v;
 			attachments[i] = GL_COLOR_ATTACHMENT0 + v;

--- a/regen/textures/fbo.cpp
+++ b/regen/textures/fbo.cpp
@@ -312,7 +312,7 @@ void FBO::blitCopy(
 		GLenum writeAttachment,
 		GLbitfield mask,
 		GLenum filter,
-		GLboolean keepRatio) {
+		bool keepRatio) {
 	if (readAttachment != GL_DEPTH_ATTACHMENT) {
 		applyReadBuffer(readAttachment);
 	}
@@ -363,7 +363,7 @@ void FBO::blitCopyToScreen(
 		GLenum readAttachment,
 		GLbitfield mask,
 		GLenum filter,
-		GLboolean keepRatio) {
+		bool keepRatio) {
 	applyReadBuffer(readAttachment);
 	glNamedFramebufferDrawBuffer(0, GL_FRONT);
 	if (keepRatio) {

--- a/regen/textures/fbo.cpp
+++ b/regen/textures/fbo.cpp
@@ -195,7 +195,7 @@ ref_ptr<Texture> FBO::createTexture(
 		uint32_t count,
 		GLenum targetType,
 		GLenum format,
-		GLint internalFormat,
+		int internalFormat,
 		GLenum pixelType,
 		uint32_t numSamples) {
 	ref_ptr<Texture> tex;
@@ -268,7 +268,7 @@ ref_ptr<Texture> FBO::addTexture(
 		uint32_t count,
 		GLenum targetType,
 		GLenum format,
-		GLint internalFormat,
+		int internalFormat,
 		GLenum pixelType,
 		uint32_t numSamples) {
 	ref_ptr<Texture> tex = createTexture(width(), height(), depth_,
@@ -430,7 +430,7 @@ void FBO::clearDepthAttachment(GLfloat depth) {
 			&depth);
 }
 
-void FBO::clearStencilAttachment(GLint stencil) {
+void FBO::clearStencilAttachment(int stencil) {
 	glClearNamedFramebufferiv(
 			id(),
 			GL_STENCIL,
@@ -589,7 +589,7 @@ ref_ptr<FBO> FBO::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 							<< ", depth attachment already present.");
 			} else {
 				hasDepthAttachment = true;
-				auto depthSize = n->getValue<GLint>("pixel-size", 16);
+				auto depthSize = n->getValue<int>("pixel-size", 16);
 				GLenum depthType = glenum::pixelType(
 						n->getValue<std::string>("pixel-type", "UNSIGNED_BYTE"));
 				GLenum textureTarget = glenum::textureTarget(
@@ -654,7 +654,7 @@ ref_ptr<FBO> FBO::load(LoadingContext &ctx, scene::SceneInputNode &input) {
 						n->getValue<std::string>("target", "TEXTURE_2D"));
 
 				GLenum stencilFormat;
-				auto stencilSize = n->getValue<GLint>("pixel-size", 8);
+				auto stencilSize = n->getValue<int>("pixel-size", 8);
 				if (stencilSize < 8) stencilFormat = GL_STENCIL_INDEX1;
 				else if (stencilSize < 16) stencilFormat = GL_STENCIL_INDEX4;
 				else stencilFormat = GL_STENCIL_INDEX8;

--- a/regen/textures/fbo.cpp
+++ b/regen/textures/fbo.cpp
@@ -49,11 +49,11 @@ FBO::FBO(uint32_t width, uint32_t height, uint32_t depth)
 	viewport_ = ref_ptr<ShaderInput2f>::alloc("viewport");
 	viewport_->setEditable(false);
 	viewport_->setUniformData(
-			Vec2f((GLfloat) width, (GLfloat) height));
+			Vec2f((float) width, (float) height));
 	inverseViewport_ = ref_ptr<ShaderInput2f>::alloc("inverseViewport");
 	inverseViewport_->setEditable(false);
 	inverseViewport_->setUniformData(
-			Vec2f(1.0 / (GLfloat) width, 1.0 / (GLfloat) height));
+			Vec2f(1.0 / (float) width, 1.0 / (float) height));
 	glViewport_ = Vec4ui(0, 0, width, height);
 
 	applyReadBuffer(GL_COLOR_ATTACHMENT0);
@@ -321,11 +321,11 @@ void FBO::blitCopy(
 	}
 	if (keepRatio) {
 		uint32_t dstWidth = dst.width();
-		uint32_t dstHeight = dst.width() * ((GLfloat) width() / height());
+		uint32_t dstHeight = dst.width() * ((float) width() / height());
 		uint32_t offsetX, offsetY;
 		if (dstHeight > dst.height()) {
 			dstHeight = dst.height();
-			dstWidth = dst.height() * ((GLfloat) height() / width());
+			dstWidth = dst.height() * ((float) height() / width());
 			offsetX = (dst.width() - dstWidth) / 2;
 			offsetY = 0;
 		} else {
@@ -368,11 +368,11 @@ void FBO::blitCopyToScreen(
 	glNamedFramebufferDrawBuffer(0, GL_FRONT);
 	if (keepRatio) {
 		uint32_t dstWidth = screenWidth;
-		uint32_t dstHeight = screenWidth * ((GLfloat) width() / height());
+		uint32_t dstHeight = screenWidth * ((float) width() / height());
 		uint32_t offsetX, offsetY;
 		if (dstHeight > screenHeight) {
 			dstHeight = screenHeight;
-			dstWidth = screenHeight * ((GLfloat) height() / width());
+			dstWidth = screenHeight * ((float) height() / width());
 			offsetX = (screenWidth - dstWidth) / 2;
 			offsetY = 0;
 		} else {
@@ -422,7 +422,7 @@ void FBO::clearColorAttachment(uint32_t attachmentIdx, const Vec4f &color) {
 			&color.x);
 }
 
-void FBO::clearDepthAttachment(GLfloat depth) {
+void FBO::clearDepthAttachment(float depth) {
 	glClearNamedFramebufferfv(
 			id(),
 			GL_DEPTH,
@@ -447,9 +447,9 @@ void FBO::resize(uint32_t w, uint32_t h, uint32_t depth) {
 	depth_ = depth;
 
 	viewport_->setVertex(0,
-		Vec2f((GLfloat) w, (GLfloat) h));
+		Vec2f((float) w, (float) h));
 	inverseViewport_->setVertex(0,
-		Vec2f(1.0f / (GLfloat) w, 1.0f / (GLfloat) h));
+		Vec2f(1.0f / (float) w, 1.0f / (float) h));
 	glViewport_ = Vec4ui(0, 0, w, h);
 
 	// resize depth attachment
@@ -528,7 +528,7 @@ namespace regen {
 		FBOResizer(Scene *scene,
 			const ref_ptr<FBO> &fbo,
 			const ref_ptr<Screen> &screen,
-			GLfloat wScale, GLfloat hScale)
+			float wScale, float hScale)
 				: EventHandler(),
 				  scene_(scene),
 				  fbo_(fbo),
@@ -549,7 +549,7 @@ namespace regen {
 		Scene *scene_;
 		ref_ptr<FBO> fbo_;
 		ref_ptr<Screen> screen_;
-		GLfloat wScale_, hScale_;
+		float wScale_, hScale_;
 	};
 }
 

--- a/regen/textures/fbo.h
+++ b/regen/textures/fbo.h
@@ -261,7 +261,7 @@ namespace regen {
 				uint32_t count,
 				GLenum targetType,
 				GLenum format,
-				GLint internalFormat,
+				int internalFormat,
 				GLenum pixelType,
 				uint32_t numSamples=1);
 
@@ -272,7 +272,7 @@ namespace regen {
 				uint32_t count,
 				GLenum targetType,
 				GLenum format,
-				GLint internalFormat,
+				int internalFormat,
 				GLenum pixelType,
 				uint32_t numSamples=1);
 

--- a/regen/textures/fbo.h
+++ b/regen/textures/fbo.h
@@ -324,7 +324,7 @@ namespace regen {
 				GLenum writeAttachment,
 				GLbitfield mask = GL_COLOR_BUFFER_BIT,
 				GLenum filter = GL_NEAREST,
-				GLboolean keepRatio = GL_FALSE);
+				bool keepRatio = false);
 
 		/**
 		 * Blit fbo attachment into screen back buffer.
@@ -334,7 +334,7 @@ namespace regen {
 				GLenum readAttachment,
 				GLbitfield mask = GL_COLOR_BUFFER_BIT,
 				GLenum filter = GL_NEAREST,
-				GLboolean keepRatio = GL_FALSE);
+				bool keepRatio = false);
 
 		/**
 		 * Clear the FBO color attachments to the given color.

--- a/regen/textures/noise-texture.cpp
+++ b/regen/textures/noise-texture.cpp
@@ -7,7 +7,7 @@
 using namespace regen;
 using namespace noise;
 
-static GLfloat sampleNoise(
+static float sampleNoise(
 		const NoiseGenerator &noiseGen,
 		double x, double y, double z,
 		bool isSeamless2D,
@@ -69,7 +69,7 @@ void NoiseTexture2D::updateNoise() {
 		for (uint32_t y = 0u; y < height(); ++y) {
 			float fx = noiseScale_ * float(x) / float(width());
 			float fy = noiseScale_ * float(y) / float(height());
-			GLfloat val = sampleNoise(gen, fx, fy, 0.0, isSeamless_, false);
+			float val = sampleNoise(gen, fx, fy, 0.0, isSeamless_, false);
 			*dataPtr = static_cast<GLubyte>(val * 255.0f);
 			++dataPtr;
 		}
@@ -106,7 +106,7 @@ void NoiseTexture3D::updateNoise() {
 				float fx = noiseScale_ * float(x) / float(width());
 				float fy = noiseScale_ * float(y) / float(height());
 				float fz = noiseScale_ * float(z) / float(depth());
-				GLfloat val = sampleNoise(gen, fx, fy, fz, false, isSeamless_);
+				float val = sampleNoise(gen, fx, fy, fz, false, isSeamless_);
 				*dataPtr = static_cast<GLubyte>(val * 255.0f);
 				++dataPtr;
 			}

--- a/regen/textures/noise-texture.cpp
+++ b/regen/textures/noise-texture.cpp
@@ -147,7 +147,7 @@ GLdouble NoiseGenerator::GetValue(GLdouble x, GLdouble y, GLdouble z) const {
 	return handle_->GetValue(x, y, z);
 }
 
-ref_ptr<NoiseGenerator> NoiseGenerator::preset_perlin(GLint randomSeed) {
+ref_ptr<NoiseGenerator> NoiseGenerator::preset_perlin(int randomSeed) {
 	auto perlin = ref_ptr<module::Perlin>::alloc();
 	if (randomSeed != 0) perlin->SetSeed(randomSeed);
 	perlin->SetFrequency(4.0);
@@ -157,7 +157,7 @@ ref_ptr<NoiseGenerator> NoiseGenerator::preset_perlin(GLint randomSeed) {
 	return ref_ptr<NoiseGenerator>::alloc("perlin", perlin);
 }
 
-ref_ptr<NoiseGenerator> NoiseGenerator::preset_clouds(GLint randomSeed) {
+ref_ptr<NoiseGenerator> NoiseGenerator::preset_clouds(int randomSeed) {
 	// Base of the cloud texture.
 	// The billowy noise produces the basic shape of soft, fluffy clouds.
 	auto cloudBase = ref_ptr<module::Billow>::alloc();
@@ -180,7 +180,7 @@ ref_ptr<NoiseGenerator> NoiseGenerator::preset_clouds(GLint randomSeed) {
 	return finalGen;
 }
 
-ref_ptr<NoiseGenerator> NoiseGenerator::preset_wood(GLint randomSeed) {
+ref_ptr<NoiseGenerator> NoiseGenerator::preset_wood(int randomSeed) {
 	// Base wood texture.  The base texture uses concentric cylinders aligned
 	// on the z axis, like a log.
 	auto baseWood = ref_ptr<module::Cylinders>::alloc();
@@ -252,7 +252,7 @@ ref_ptr<NoiseGenerator> NoiseGenerator::preset_wood(GLint randomSeed) {
 	return finalGen;
 }
 
-ref_ptr<NoiseGenerator> NoiseGenerator::preset_granite(GLint randomSeed) {
+ref_ptr<NoiseGenerator> NoiseGenerator::preset_granite(int randomSeed) {
 	// Primary granite texture.  This generates the "roughness" of the texture
 	// when lit by a light source.
 	auto primaryGranite = ref_ptr<module::Billow>::alloc();
@@ -409,7 +409,7 @@ ref_ptr<NoiseGenerator> loadGenerator(
 }
 
 ref_ptr<NoiseGenerator> NoiseGenerator::load(LoadingContext &ctx, scene::SceneInputNode &input) {
-	auto randomSeed = input.getValue<GLint>("random-seed", math::randomInt());
+	auto randomSeed = input.getValue<int>("random-seed", math::randomInt());
 
 	if (input.hasAttribute("preset")) {
 		auto preset = input.getValue("preset");

--- a/regen/textures/noise-texture.cpp
+++ b/regen/textures/noise-texture.cpp
@@ -143,7 +143,7 @@ void NoiseGenerator::removeSource(const ref_ptr<NoiseGenerator> &source) {
 	}
 }
 
-GLdouble NoiseGenerator::GetValue(GLdouble x, GLdouble y, GLdouble z) const {
+double NoiseGenerator::GetValue(double x, double y, double z) const {
 	return handle_->GetValue(x, y, z);
 }
 

--- a/regen/textures/noise-texture.cpp
+++ b/regen/textures/noise-texture.cpp
@@ -51,7 +51,7 @@ void NoiseTexture::setNoiseGenerator(const ref_ptr<NoiseGenerator> &generator) {
 	updateNoise();
 }
 
-NoiseTexture2D::NoiseTexture2D(uint32_t width, uint32_t height, GLboolean isSeamless)
+NoiseTexture2D::NoiseTexture2D(uint32_t width, uint32_t height, bool isSeamless)
 		: Texture2D(), NoiseTexture(isSeamless) {
 	set_rectangleSize(width, height);
 	set_pixelType(GL_UNSIGNED_BYTE);
@@ -84,7 +84,7 @@ void NoiseTexture2D::updateNoise() {
 	set_wrapping(TextureWrapping::create(GL_MIRRORED_REPEAT));
 }
 
-NoiseTexture3D::NoiseTexture3D(uint32_t width, uint32_t height, uint32_t depth, GLboolean isSeamless)
+NoiseTexture3D::NoiseTexture3D(uint32_t width, uint32_t height, uint32_t depth, bool isSeamless)
 		: Texture3D(), NoiseTexture(isSeamless) {
 	set_rectangleSize(width, height);
 	set_depth(depth);

--- a/regen/textures/noise-texture.h
+++ b/regen/textures/noise-texture.h
@@ -50,7 +50,7 @@ namespace regen {
 		 * @param z the z coordinate.
 		 * @return the noise value.
 		 */
-		GLdouble GetValue(GLdouble x, GLdouble y, GLdouble z) const;
+		double GetValue(double x, double y, double z) const;
 
 		/**
 		 * @param randomSeed the random seed.

--- a/regen/textures/noise-texture.h
+++ b/regen/textures/noise-texture.h
@@ -128,7 +128,7 @@ namespace regen {
 		 * @param height the height of the texture.
 		 * @param isSeamless true if the texture should be seamless.
 		 */
-		NoiseTexture2D(uint32_t width, uint32_t height, GLboolean isSeamless = GL_FALSE);
+		NoiseTexture2D(uint32_t width, uint32_t height, bool isSeamless = false);
 
 		~NoiseTexture2D() override = default;
 
@@ -146,7 +146,7 @@ namespace regen {
 		 * @param depth the depth of the texture.
 		 * @param isSeamless true if the texture should be seamless.
 		 */
-		NoiseTexture3D(uint32_t width, uint32_t height, uint32_t depth, GLboolean isSeamless = GL_FALSE);
+		NoiseTexture3D(uint32_t width, uint32_t height, uint32_t depth, bool isSeamless = false);
 
 		~NoiseTexture3D() override = default;
 

--- a/regen/textures/noise-texture.h
+++ b/regen/textures/noise-texture.h
@@ -55,22 +55,22 @@ namespace regen {
 		/**
 		 * @param randomSeed the random seed.
 		 */
-		static ref_ptr<NoiseGenerator> preset_perlin(GLint randomSeed);
+		static ref_ptr<NoiseGenerator> preset_perlin(int randomSeed);
 
 		/**
 		 * @param randomSeed the random seed.
 		 */
-		static ref_ptr<NoiseGenerator> preset_wood(GLint randomSeed);
+		static ref_ptr<NoiseGenerator> preset_wood(int randomSeed);
 
 		/**
 		 * @param randomSeed the random seed.
 		 */
-		static ref_ptr<NoiseGenerator> preset_granite(GLint randomSeed);
+		static ref_ptr<NoiseGenerator> preset_granite(int randomSeed);
 
 		/**
 		 * @param randomSeed the random seed.
 		 */
-		static ref_ptr<NoiseGenerator> preset_clouds(GLint randomSeed);
+		static ref_ptr<NoiseGenerator> preset_clouds(int randomSeed);
 
 		/**
 		 * Load noise generator from a scene input node.

--- a/regen/textures/texture-loader.cpp
+++ b/regen/textures/texture-loader.cpp
@@ -308,7 +308,7 @@ ref_ptr<TextureCube> textures::loadCube(
 	} else {
 		faceWidth = firstImage->width / 3;
 		faceHeight = firstImage->height / 4;
-		GLint faces_[12] = {
+		int faces_[12] = {
 				-1, TextureCube::TOP, -1,
 				TextureCube::LEFT, TextureCube::BACK, TextureCube::RIGHT,
 				-1, TextureCube::BOTTOM, -1,

--- a/regen/textures/texture-location.h
+++ b/regen/textures/texture-location.h
@@ -13,15 +13,15 @@ namespace regen {
 	 */
 	struct TextureLocation {
 		std::string name;    /**< name in shader. **/
-		GLint location; /**< the texture location. */
+		int location; /**< the texture location. */
 		ref_ptr<Texture> tex; /**< the texture. */
-		GLint uploadChannel; /**< last uploaded channel. */
+		int uploadChannel; /**< last uploaded channel. */
 		/**
 		 * @param _name texture name.
 		 * @param _tex the texture.
 		 * @param _location texture location in shader.
 		 */
-		TextureLocation(const std::string &_name, const ref_ptr<Texture> &_tex, GLint _location)
+		TextureLocation(const std::string &_name, const ref_ptr<Texture> &_tex, int _location)
 				: name(_name), location(_location), tex(_tex), uploadChannel(-1) {}
 
 		TextureLocation()

--- a/regen/textures/texture-state.cpp
+++ b/regen/textures/texture-state.cpp
@@ -223,7 +223,7 @@ TextureState::TextureState(const ref_ptr<Texture> &texture, const std::string &n
 		: State(),
 		  stateID_(++idCounter_),
 		  texcoChannel_(0u),
-		  ignoreAlpha_(GL_FALSE) {
+		  ignoreAlpha_(false) {
 	set_blendMode(BLEND_MODE_SRC);
 	set_blendFactor(1.0f);
 	set_mapping(MAPPING_TEXCO);
@@ -239,7 +239,7 @@ TextureState::TextureState()
 		  stateID_(++idCounter_),
 		  samplerType_("sampler2D"),
 		  texcoChannel_(0u),
-		  ignoreAlpha_(GL_FALSE) {
+		  ignoreAlpha_(false) {
 	set_blendMode(BLEND_MODE_SRC);
 	set_blendFactor(1.0f);
 	set_mapping(MAPPING_TEXCO);
@@ -277,7 +277,7 @@ void TextureState::set_texcoChannel(uint32_t texcoChannel) {
 	shaderDefine(REGEN_TEX_NAME("TEX_TEXCO"), REGEN_STRING("texco" << texcoChannel_));
 }
 
-void TextureState::set_ignoreAlpha(GLboolean v) {
+void TextureState::set_ignoreAlpha(bool v) {
 	ignoreAlpha_ = v;
 	shaderDefine(REGEN_TEX_NAME("TEX_IGNORE_ALPHA"), v ? "TRUE" : "FALSE");
 }

--- a/regen/textures/texture-state.cpp
+++ b/regen/textures/texture-state.cpp
@@ -282,7 +282,7 @@ void TextureState::set_ignoreAlpha(GLboolean v) {
 	shaderDefine(REGEN_TEX_NAME("TEX_IGNORE_ALPHA"), v ? "TRUE" : "FALSE");
 }
 
-void TextureState::set_blendFactor(GLfloat blendFactor) {
+void TextureState::set_blendFactor(float blendFactor) {
 	blendFactor_ = blendFactor;
 	shaderDefine(REGEN_TEX_NAME("TEX_BLEND_FACTOR"), REGEN_STRING(blendFactor_));
 }
@@ -502,7 +502,7 @@ ref_ptr<TextureState> TextureState::load(LoadingContext &ctx, scene::SceneInputN
 				input.getValue<BlendMode>("blend-mode", BLEND_MODE_SRC));
 	}
 	texState->set_blendFactor(
-			input.getValue<GLfloat>("blend-factor", 1.0f));
+			input.getValue<float>("blend-factor", 1.0f));
 
 	// Defines how a texture should be mapped on geometry.
 	auto customMapping = ShaderFunction::load(input, "mapping-function");
@@ -537,7 +537,7 @@ ref_ptr<TextureState> TextureState::load(LoadingContext &ctx, scene::SceneInputN
 	}
 
 	if (input.hasAttribute("texco-scale")) {
-		auto scale = input.getValue<GLfloat>("texco-scale", 1.0f);
+		auto scale = input.getValue<float>("texco-scale", 1.0f);
 		texState->set_texcoScale(scale);
 	}
 

--- a/regen/textures/texture-state.h
+++ b/regen/textures/texture-state.h
@@ -267,7 +267,7 @@ namespace regen {
 		 * Explicit request to the application to ignore the alpha channel
 		 * of the texture.
 		 */
-		void set_ignoreAlpha(GLboolean v);
+		void set_ignoreAlpha(bool v);
 
 		/**
 		 * Explicit request to the application to ignore the alpha channel

--- a/regen/textures/texture-state.h
+++ b/regen/textures/texture-state.h
@@ -206,7 +206,7 @@ namespace regen {
 		 * @param factor Specifies how this texture should be mixed with existing
 		 * pixels.
 		 */
-		void set_blendFactor(GLfloat factor);
+		void set_blendFactor(float factor);
 
 		/**
 		 * @param mapping Specifies how a texture should be mapped on geometry.

--- a/regen/textures/texture.cpp
+++ b/regen/textures/texture.cpp
@@ -467,7 +467,7 @@ namespace regen {
 	public:
 		TextureResizer(const ref_ptr<Texture> &tex,
 					   const ref_ptr<Screen> &screen,
-					   GLfloat wScale, GLfloat hScale)
+					   float wScale, float hScale)
 				: EventHandler(),
 				  tex_(tex),
 				  screen_(screen),
@@ -486,7 +486,7 @@ namespace regen {
 	protected:
 		ref_ptr<Texture> tex_;
 		ref_ptr<Screen> screen_;
-		GLfloat wScale_, hScale_;
+		float wScale_, hScale_;
 	};
 }
 

--- a/regen/textures/texture.cpp
+++ b/regen/textures/texture.cpp
@@ -815,7 +815,7 @@ Texture2DDepth::Texture2DDepth(GLenum textureTarget, uint32_t numTextures)
 Texture2DMultisample::Texture2DMultisample(
 		GLsizei numSamples,
 		uint32_t numTextures,
-		GLboolean fixedSampleLocations)
+		bool fixedSampleLocations)
 		: Texture2D(GL_TEXTURE_2D_MULTISAMPLE, numTextures) {
 	fixedSampleLocations_ = fixedSampleLocations;
 	samplerType_ = "sampler2DMS";
@@ -828,7 +828,7 @@ Texture2DMultisample::Texture2DMultisample(
 
 Texture2DMultisampleDepth::Texture2DMultisampleDepth(
 		GLsizei numSamples,
-		GLboolean fixedSampleLocations)
+		bool fixedSampleLocations)
 		: Texture2DDepth(GL_TEXTURE_2D_MULTISAMPLE, 1) {
 	internalFormat_ = GL_DEPTH_COMPONENT24;
 	fixedSampleLocations_ = fixedSampleLocations;
@@ -873,7 +873,7 @@ Texture2DArrayDepth::Texture2DArrayDepth(uint32_t numTextures)
 Texture2DArrayMultisample::Texture2DArrayMultisample(
 		GLsizei numSamples,
 		uint32_t numTextures,
-		GLboolean fixedSampleLocations)
+		bool fixedSampleLocations)
 		: Texture2DArray(GL_TEXTURE_2D_MULTISAMPLE_ARRAY, numTextures) {
 	samplerType_ = "sampler2DMSArray";
 	set_numSamples(numSamples);
@@ -883,7 +883,7 @@ Texture2DArrayMultisample::Texture2DArrayMultisample(
 Texture2DArrayMultisampleDepth::Texture2DArrayMultisampleDepth(
 		GLsizei numSamples,
 		uint32_t numTextures,
-		GLboolean fixedSampleLocations)
+		bool fixedSampleLocations)
 		: Texture2DArray(GL_TEXTURE_2D_MULTISAMPLE_ARRAY, numTextures) {
 	samplerType_ = "sampler2DMSArray";
 	set_numSamples(numSamples);

--- a/regen/textures/texture.cpp
+++ b/regen/textures/texture.cpp
@@ -200,7 +200,7 @@ void Texture::updateImage3D(GLubyte *subData) {
 						subData);
 }
 
-void Texture::updateSubImage1D(GLint layer, GLubyte *subData) {
+void Texture::updateSubImage1D(int layer, GLubyte *subData) {
 	glTextureSubImage1D(id(),
 						0, // mipmap level
 						0, // x offset
@@ -210,7 +210,7 @@ void Texture::updateSubImage1D(GLint layer, GLubyte *subData) {
 						subData);
 }
 
-void Texture::updateSubImage2D(GLint layer, GLubyte *subData) {
+void Texture::updateSubImage2D(int layer, GLubyte *subData) {
 	glTextureSubImage2D(id(),
 						0, // mipmap level
 						0, // x offset
@@ -222,7 +222,7 @@ void Texture::updateSubImage2D(GLint layer, GLubyte *subData) {
 						subData);
 }
 
-void Texture::updateSubImage3D(GLint layer, GLubyte *subData) {
+void Texture::updateSubImage3D(int layer, GLubyte *subData) {
 	glTextureSubImage3D(id(),
 						0, // mipmap level
 						0, // x offset
@@ -339,7 +339,7 @@ void Texture::updateImage(GLubyte *data) {
 	(this->*(this->updateImage_))(data);
 }
 
-void Texture::updateSubImage(GLint layer, GLubyte *subData) {
+void Texture::updateSubImage(int layer, GLubyte *subData) {
 	(this->*(this->updateSubImage_))(layer, subData);
 }
 
@@ -623,7 +623,7 @@ ref_ptr<Texture> Texture::load(LoadingContext &ctx, scene::SceneInputNode &input
 		}
 	} else if (input.hasAttribute("spectrum")) {
 		auto spectrum = input.getValue<Vec2d>("spectrum", Vec2d(0.0, 1.0));
-		auto numTexels = input.getValue<GLint>("num-texels", 256u);
+		auto numTexels = input.getValue<int>("num-texels", 256u);
 		tex = regen::textures::loadSpectrum(spectrum.x, spectrum.y, numTexels);
 	} else if (typeName == "bloom") {
 		auto numMips = input.getValue<uint32_t>("num-mips", 5u);
@@ -751,7 +751,7 @@ void Texture::configure(ref_ptr<Texture> &tex, scene::SceneInputNode &input) {
 		tex->set_compare(TextureCompare(mode, function));
 	}
 	if (!input.getValue("max-level").empty()) {
-		tex->set_maxLevel(input.getValue<GLint>("max-level", 1000));
+		tex->set_maxLevel(input.getValue<int>("max-level", 1000));
 	}
 
 	if (!input.getValue("min-filter").empty() &&

--- a/regen/textures/texture.h
+++ b/regen/textures/texture.h
@@ -488,7 +488,7 @@ namespace regen {
 		int32_t border_ = 0;
 		TextureBind texBind_;
 		int32_t numSamples_ = 1;
-		GLboolean fixedSampleLocations_ = GL_TRUE;
+		bool fixedSampleLocations_ = true;
 		int32_t textureChannel_ = -1;
 		std::string samplerType_;
 		std::optional<TextureFile> textureFile_;
@@ -638,7 +638,7 @@ namespace regen {
 		explicit Texture2DMultisample(
 				GLsizei numSamples,
 				uint32_t numTextures = 1,
-				GLboolean fixedLocations = GL_TRUE);
+				bool fixedLocations = true);
 	};
 
 	/**
@@ -654,7 +654,7 @@ namespace regen {
 		 * @param numSamples number of samples per texel.
 		 * @param fixedLocations use fixed locations.
 		 */
-		explicit Texture2DMultisampleDepth(GLsizei numSamples, GLboolean fixedLocations = GL_TRUE);
+		explicit Texture2DMultisampleDepth(GLsizei numSamples, bool fixedLocations = true);
 	};
 
 	/**
@@ -720,7 +720,7 @@ namespace regen {
 		explicit Texture2DArrayMultisample(
 				int32_t numSamples,
 				uint32_t numTextures = 1,
-				GLboolean fixedLocations = GL_FALSE);
+				bool fixedLocations = false);
 	};
 
 	/**
@@ -736,7 +736,7 @@ namespace regen {
 		explicit Texture2DArrayMultisampleDepth(
 				int32_t numSamples,
 				uint32_t numTextures = 1,
-				GLboolean fixedLocations = GL_FALSE);
+				bool fixedLocations = false);
 	};
 
 	/**

--- a/regen/textures/texture.h
+++ b/regen/textures/texture.h
@@ -508,7 +508,7 @@ namespace regen {
 
 		void (Texture::*allocTexture_)();
 		void (Texture::*updateImage_)(GLubyte *subData);
-		void (Texture::*updateSubImage_)(GLint layer, GLubyte *subData);
+		void (Texture::*updateSubImage_)(int layer, GLubyte *subData);
 		Vec3ui allocatedSize_ = Vec3ui::zero();
 
 		void allocTexture1D();
@@ -529,13 +529,13 @@ namespace regen {
 
 		void updateImage_noop(GLubyte*) {}
 
-		void updateSubImage1D(GLint layer, GLubyte *subData);
+		void updateSubImage1D(int layer, GLubyte *subData);
 
-		void updateSubImage2D(GLint layer, GLubyte *subData);
+		void updateSubImage2D(int layer, GLubyte *subData);
 
-		void updateSubImage3D(GLint layer, GLubyte *subData);
+		void updateSubImage3D(int layer, GLubyte *subData);
 
-		void updateSubImage_noop(GLint, GLubyte*) {}
+		void updateSubImage_noop(int, GLubyte*) {}
 
 		unsigned int texelIndex(const Vec2f &texco) const;
 

--- a/regen/utility/event-object.h
+++ b/regen/utility/event-object.h
@@ -110,7 +110,6 @@ namespace regen {
 			ref_ptr<EventData> data;
 			uint32_t eventID;
 		};
-		ref_ptr<EventData> fallbackEventData_;
 
 		struct StaticData {;
 			std::vector<QueuedEvent> eventQueue_[2];

--- a/regen/utility/state-stacks.h
+++ b/regen/utility/state-stacks.h
@@ -227,7 +227,7 @@ namespace regen {
 				  applyi_(applyi),
 				  lockCounter_(0),
 				  lastStampi_(-1),
-				  isEmpty_(GL_TRUE) {
+				  isEmpty_(true) {
 			head_->stamp = -1;
 			counter_.x = 0;
 			counter_.y = 0;
@@ -235,11 +235,11 @@ namespace regen {
 
 			headi_ = new Node *[numIndices];
 			doApplyi_ = new DoApplyValueIndexed[numIndices];
-			isEmptyi_ = new GLboolean[numIndices];
+			isEmptyi_ = new bool[numIndices];
 			for (uint32_t i = 0; i < numIndices_; ++i) {
 				doApplyi_[i] = &applyInitStampedi;
 				headi_[i] = new Node(zeroValue_);
-				isEmptyi_[i] = GL_TRUE;
+				isEmptyi_[i] = true;
 			}
 		}
 
@@ -297,7 +297,7 @@ namespace regen {
 				// initial push to the stack or first push after everything
 				// was popped out.
 				head_->v = v;
-				isEmpty_ = GL_FALSE;
+				isEmpty_ = false;
 			} else if (head_->next) {
 				// use node created earlier
 				head_ = head_->next;
@@ -338,7 +338,7 @@ namespace regen {
 				// initial push to the stack or first push after everything
 				// was popped out.
 				headi->v = v;
-				isEmptyi_[index] = GL_FALSE;
+				isEmptyi_[index] = false;
 			} else if (headi->next) {
 				// use node created earlier
 				headi = headi->next;
@@ -391,7 +391,7 @@ namespace regen {
 				}
 				head_ = head_->prev;
 			} else {
-				isEmpty_ = GL_TRUE;
+				isEmpty_ = true;
 			}
 
 			// if there are indexed values pushed we may
@@ -417,7 +417,7 @@ namespace regen {
 		 */
 		void pop(uint32_t index) {
 			Node *headi = headi_[index];
-			GLboolean valueChanged;
+			bool valueChanged;
 
 			// apply previously pushed indexed value
 			if (headi->prev) {
@@ -426,8 +426,8 @@ namespace regen {
 				headi_[index] = headi;
 				lastStampi_ = headi->stamp;
 			} else {
-				valueChanged = GL_FALSE;
-				isEmptyi_[index] = GL_TRUE;
+				valueChanged = false;
+				isEmptyi_[index] = true;
 				lastStampi_ = -1;
 			}
 
@@ -465,7 +465,7 @@ namespace regen {
 		/**
 		 * @return true if the stack is locked.
 		 */
-		GLboolean isLocked() const {
+		bool isLocked() const {
 			return lockCounter_ > 0;
 		}
 
@@ -525,8 +525,8 @@ namespace regen {
 
 		int lastStampi_;
 
-		GLboolean isEmpty_;
-		GLboolean *isEmptyi_;
+		bool isEmpty_;
+		bool *isEmptyi_;
 
 		typedef void (*DoApplyValue)(IndexedStateStack *, const ValueType &);
 

--- a/regen/utility/state-stacks.h
+++ b/regen/utility/state-stacks.h
@@ -322,7 +322,7 @@ namespace regen {
 			Node *headi = headi_[index];
 
 			if (counter_.x > counter_.y) {
-				GLint lastStampi = (isEmptyi_[index] ? -1 : headi->stamp);
+				int lastStampi = (isEmptyi_[index] ? -1 : headi->stamp);
 				// an global value was pushed before
 				// if the global value was pushed before the last indexed push. only
 				// apply when the value of last indexed push is not equal
@@ -431,7 +431,7 @@ namespace regen {
 				lastStampi_ = -1;
 			}
 
-			GLint lastStampi = (isEmptyi_[index] ? -1 : headi->stamp);
+			int lastStampi = (isEmptyi_[index] ? -1 : headi->stamp);
 			// reset to equation with latest stamp
 			if (head_->stamp > lastStampi) {
 				if (headi->v != head_->v) applyi_(index, head_->v);
@@ -485,7 +485,7 @@ namespace regen {
 			Node *prev;
 			Node *next;
 			ValueType v;
-			GLint stamp;
+			int stamp;
 		};
 
 		void deleteNodes(Node *n_) {
@@ -521,9 +521,9 @@ namespace regen {
 		ApplyValueIndexed lockedApplyi_;
 
 		// Counts number of locks.
-		GLint lockCounter_;
+		int lockCounter_;
 
-		GLint lastStampi_;
+		int lastStampi_;
 
 		GLboolean isEmpty_;
 		GLboolean *isEmptyi_;


### PR DESCRIPTION
## Pull request overview

This pull request revises the boid simulation CPU path with significant SIMD optimizations and includes widespread refactoring to replace OpenGL-specific types (GLboolean, GLint, GLfloat, GLdouble) with standard C++ types (bool, int, float, double). The PR also introduces a new ThreadSafeQueue implementation, renames animation interface methods for clarity (animate → cpuUpdate/gpuUpdate), and removes the fallback EventData member in favor of a thread_local approach.

**Key Changes:**
- Major rewrite of boid simulation CPU path with improved SIMD utilization and memory layout optimization
- Introduction of ThreadSafeQueue class for lock-free producer-consumer scenarios
- Systematic replacement of OpenGL types with standard C++ equivalents across the entire codebase
- Animation interface standardization (cpuUpdate for CPU updates, gpuUpdate for GPU updates)