### PR TITLE
Optimized dirty list insert

### DIFF
--- a/applications/qt/VectorWidget.cpp
+++ b/applications/qt/VectorWidget.cpp
@@ -75,6 +75,31 @@ VectorWidget::VectorWidget(const RegenWidgetData &data, QWidget *parent)
 	ignoreValueChanges_ = false;
 }
 
+void VectorWidget::initializeValue() {
+	auto mapped = input_->mapClientDataRaw(BUFFER_GPU_READ);
+	const byte *value = mapped.r;
+	const uint32_t count = input_->valsPerElement();
+	QSlider *valueWidgets[4] =
+			{ui_.xValueEdit, ui_.yValueEdit, ui_.zValueEdit, ui_.wValueEdit};
+	QLineEdit *valueTexts[4] =
+			{ui_.xValueText, ui_.yValueText, ui_.zValueText, ui_.wValueText};
+
+	ignoreValueChanges_ = true;
+	for (uint32_t i = 0; i < count; ++i) {
+		float x = readInputValue(input_, value, i);
+		valueWidgets[i]->setValue(static_cast<int>(x * 1000.0f));
+		valueTexts[i]->setText(QString::number(x));
+	}
+	ignoreValueChanges_ = false;
+
+	// set value of external sliders
+	for (uint32_t i = 0; i < count; ++i) {
+		for (auto *slider: externalSlider_[i]) {
+			slider->setValue(valueWidgets[i]->value());
+		}
+	}
+}
+
 QSlider *VectorWidget::createSlider(int componentIndex, bool isExternal) {
 	auto mapped = input_->mapClientDataRaw(BUFFER_GPU_READ);
 	const byte *value = mapped.r;

--- a/applications/qt/VectorWidget.h
+++ b/applications/qt/VectorWidget.h
@@ -17,6 +17,8 @@ namespace regen {
 
 		QSlider *createSlider(int vectorIndex, bool isExternal = true);
 
+		void initializeValue();
+
 	public slots:
 
 		void valueUpdated();

--- a/applications/qt/shader-input-widget.h
+++ b/applications/qt/shader-input-widget.h
@@ -44,6 +44,8 @@ namespace regen {
 		std::map<QTreeWidgetItem *, ref_ptr<StateNode>> nodes_;
 		std::map<QTreeWidgetItem *, const Animation*> animations_;
 
+		std::map<ShaderInput*, QWidget*> inputWidgets_;
+
 		void updateInitialValue(ShaderInput *x);
 
 		bool handleState(

--- a/applications/scene-display/examples/canyon.xml
+++ b/applications/scene-display/examples/canyon.xml
@@ -872,7 +872,7 @@
 
         <!-- Copy G-buffer albedo into the first attachment such that we can run water shader
              only locally where water is visible. -->
-        <!-- TODO: The blit below is a bit expensive, and not needed where water is visible!
+        <!-- NOTE: The blit below is a bit expensive, and not needed where water is visible!
                    However, the depth pass below cannot be moved before the water rendering,
                    as it needs to sample the depth buffer.
                    It could be that doing a stencil only pass first, then doing

--- a/applications/scene-display/examples/character.xml
+++ b/applications/scene-display/examples/character.xml
@@ -560,6 +560,11 @@
             <input type="float" name="uvNoiseScale" value="0.5"/>
             <input type="float" name="softParticleScale" value="30.0"/>
             <input type="float" name="lifetimeSmoothstep" value="1.0"/>
+            <!-- Apply fogging based on distance. -->
+            <input type="float" name="fogDensity" value="1.0"/>
+            <input type="vec2" name="fogDistance" value="50.0,{{far-plane}}" min="0.0" max="{{far-plane}}"/>
+            <input type="vec3" name="fogColor" value="0.2,0.33,0.3" schema="color"/>
+            <input type="vec2" name="farDistance" value="75.0,{{far-plane}}"/>
             <node id="Particle-Density0">
                 <mesh id="test-particles0" shader="regen.particles.sprite.density"/>
             </node>
@@ -752,13 +757,6 @@
         </view>
 
         <!-- render particles into a separate buffer -->
-        <!-- FIXME: Depth-Fog is not applied to particles, and emission! difficulty is that depth is not available.
-                    Earlier a demo had a dedicated T-Buffer next to G-buffer that also stored depth, that could
-                    be the approach to fix it.
-                    However, particles use their own buffer, and emission is part of g-buffer.
-                    Also, emission is more difficult: it is generated with blurring from multiple mips.
-                    Will be difficult to get the depth buffer for that.
-        -->
         <node import="Particle-Update-FBO"/>
         <!-- render transparent objects -->
         <node id="Transparent-Pass">
@@ -857,7 +855,7 @@
                     <bloom fbo="g-buffer" attachment="1" bloom-texture="emission-map-bloom"/>
                 </node>
                 <node id="Shaded Scene">
-                    <!-- TODO: this blit could be avoided by rendering emission into attachment 1 of g-buffer
+                    <!-- NOTE: this blit could be avoided by rendering emission into attachment 1 of g-buffer
                                and then computing fog in attachment 4. Or switch back to GL blending instead of
                                blending in the shader. -->
                     <blit src-fbo="g-buffer" src-attachment="1"

--- a/applications/scene-display/examples/npc-behavior.xml
+++ b/applications/scene-display/examples/npc-behavior.xml
@@ -801,7 +801,7 @@
                 <fbo id="screen-density" draw-buffers="1"/>
                 <texture name="heightTexture" id="ground-height" map-to="HEIGHT"
                          mapping="xz_plane" blend-mode="ADD" blend-factor="{{map-height}}"/>
-                <!-- TODO: output density only -->
+                <define key="OUTPUT_TYPE" value="WHITE"/>
                 <mesh id="ground-path"/>
             </node>
             <node id="Path-Mask-Blur">
@@ -872,9 +872,8 @@
         </shape>
         <shape id="weapon-shape" index="1" cull="1" type="obb"
                mesh-id="dwarf" mesh-index="0" transform-id="dwarf-tf">
-            <!-- FIXME: Shape does not move with bones, and is wrong then.
-                But we need to use separate shape for hiding/drawing weapon.
-            -->
+            <!-- FIXME: Shape of weapon does not move with bones, and is wrong then.
+                   But we need to use separate shape for hiding/drawing weapon.  -->
         </shape>
         <object id="dwarf" type="character" mesh="dwarf" mesh-index="1" radius="5.0">
             <!--

--- a/applications/scene-display/examples/physics.xml
+++ b/applications/scene-display/examples/physics.xml
@@ -556,7 +556,6 @@
                 <node id="Lightning-Bolt0">
                     <input type="float" name="lightningWidth" value="0.6"/>
                     <input type="vec3" name="matDiffuse" value="0.8, 1.5, 20.0"/>
-                    <define key="FAIL_XXX" value="TRUE"/>
                     <mesh id="lightning-mesh"/>
                 </node>
             </node>

--- a/applications/scene-display/examples/physics.xml
+++ b/applications/scene-display/examples/physics.xml
@@ -59,7 +59,7 @@
         <depth pixel-size="24"/>
     </fbo>
     <fbo id="cube-emission-fbo"
-         size-mode="abs" size="256,256,6"
+         size-mode="abs" size="128,128,6"
          target="TEXTURE_CUBE_MAP"
          sampler-type="samplerCube"
          pixel-type="FLOAT" pixel-size="24">
@@ -80,16 +80,6 @@
         <texture id="normal"/>
         <depth pixel-size="24"/>
     </fbo>
-    <!--
-    <fbo id="spot-shadow" size-mode="abs" size="1024,1024,1" >
-      <depth pixel-size="24" pixel-type="FLOAT"
-         wrapping="REPEAT"
-         min-filter="NEAREST" mag-filter="NEAREST"
-         compare-mode="COMPARE_R_TO_TEXTURE"
-         compare-function="LEQUAL"
-         sampler-type="sampler2DShadow" />
-    </fbo>
-    -->
     <!-- Textures -->
     <texture id="reflector-noise" type="noise" preset="perlin" noise-scale="4.0"
             size="2048.0,2048.0,1.0" swizzle-g="RED" swizzle-b="RED"/>
@@ -122,19 +112,6 @@
             tf="sphere1-tf">
         <culling index="main-index" />
     </camera>
-    <!--
-    <camera id="spot-camera" light="spot-light" camera="main-camera" />
-    -->
-    <!-- Lights -->
-    <!--
-    <light id="spot-light"
-           type="SPOT"
-           position="3.0,8.0,4.0"
-           direction="-0.37,-0.95,-0.46"
-           diffuse="0.2,0.45,0.435"
-           radius="10.0,21.0"
-           cone-angles="11.5,25.5" />
-    -->
     <!-- Sky -->
     <sky id="sky" camera="main-camera" update-interval="200.0">
         <star-map texture="res/sky/milkyway.png" scattering="0.8" delta-magnitude="0.05" lod="4"/>
@@ -275,12 +252,6 @@
             <node import="Paraboloid-Background-Pass"/>
             <node import="Cube-Reflector"/>
         </node>
-        <view id="Paraboloid Reflection -- Result">
-            <fbo id="SCREEN"/>
-            <texture name="inputTexture" fbo="paraboloid-reflection-buffer" attachment="1"/>
-            <input type="int" name="arrayTextureSize" value="2"/>
-            <fullscreen-pass shader="regen.filter.sampling.array"/>
-        </view>
     </node>
 
     <!--**************************-->
@@ -317,11 +288,6 @@
             <node import="Cube-Background-Pass"/>
             <node import="Paraboloid-Reflector"/>
         </node>
-        <view id="Cube Reflection -- Result">
-            <fbo id="SCREEN"/>
-            <texture name="inputTexture" fbo="cube-reflection-buffer" attachment="1"/>
-            <fullscreen-pass shader="regen.filter.sampling.cube"/>
-        </view>
     </node>
 
     <!--**************************-->
@@ -460,27 +426,6 @@
         </node>
     </node>
 
-    <node id="Cube-Emission-Update">
-        <node id="Cube-Emission-Depth">
-            <depth test="1" write="1"/>
-            <fbo id="cube-emission-fbo" clear-depth="1"/>
-            <texture name="inputTexture" fbo="cube-reflection-buffer" attachment="depth"/>
-            <fullscreen-pass shader="regen.filter.sampling.downsample.depth"/>
-        </node>
-        <node id="Cube-Emission-Draw">
-            <fbo id="cube-emission-fbo" clear-buffers="0" draw-buffers="0"/>
-            <node import="Emission-Draw" />
-        </node>
-        <node id="Cube-Emission-Blur">
-            <input type="int" name="numBlurPixels" value="9"/>
-            <input type="float" name="blurSigma" value="5.0"/>
-            <filter-sequence id="cube-emission-color" fbo="cube-emission-fbo" attachment="0">
-                <filter shader="regen.filter.blur.horizontal"/>
-                <filter shader="regen.filter.blur.vertical"/>
-            </filter-sequence>
-        </node>
-    </node>
-
     <node id="Emission-Draw-Lightning-Bolt">
         <depth test="1" write="0"/>
         <input type="float" name="lightningWidth" value="0.15"/>
@@ -498,14 +443,6 @@
         <node import="Emission-Draw-Lightning-Bolt" />
         <node import="Emission-Draw-Glow">
             <texture name="inputTexture" id="emission-color"/>
-        </node>
-    </node>
-
-    <node id="Cube-Emission-Draw">
-        <blend mode="alpha"/>
-        <node import="Emission-Draw-Lightning-Bolt" />
-        <node import="Emission-Draw-Glow">
-            <texture name="inputTexture" id="cube-emission-color"/>
         </node>
     </node>
 
@@ -541,14 +478,6 @@
         <cull mode="FRONT"/>
         <define key="OUTPUT_TYPE" value="DEPTH"/>
 
-        <!--
-          <node id="Spot-Shadow">
-            <fbo id="spot-shadow" clear-depth="1" />
-            <camera id="spot-camera" />
-            <node import="Shadow-Caster" />
-          </node>
-        -->
-
         <node id="Sun-Shadow">
             <fbo id="sun-shadow" clear-depth="1"/>
             <camera id="sun-camera"/>
@@ -574,14 +503,6 @@
                        shadow-attachment="depth"
                        shadow-camera="sun-camera"/>
             </light-pass>
-            <!--
-                    <light-pass type="SPOT" ambient="0" shader="regen.shading.deferred.spot">
-                        <light id="spot-light"
-                            shadow-buffer="spot-shadow"
-                            shadow-attachment="depth"
-                            shadow-camera="spot-camera" />
-                     </light-pass>
-            -->
         </node>
     </node>
 
@@ -596,14 +517,6 @@
         </node>
 
         <node import="G-Buffer-Emission-Update"/>
-        <view id="Emission-Color">
-            <blit src-fbo="emission-fbo" src-attachment="0" dst-fbo="SCREEN"/>
-        </view>
-        <view id="Emission-Blur">
-            <fbo id="SCREEN"/>
-            <texture name="inputTexture" id="emission-color"/>
-            <fullscreen-pass shader="regen.filter.sampling"/>
-        </view>
 
         <node id="Transparent-Pass">
             <blend mode="add"/>
@@ -629,7 +542,34 @@
                   when copies are created.
         -->
         <!--
-        <node import="Cube-Emission-Update"/>
+        <node id="Cube-Emission-Update">
+            <node id="Cube-Emission-Depth">
+                <depth test="1" write="1"/>
+                <fbo id="cube-emission-fbo" clear-depth="1"/>
+                <texture name="inputTexture" fbo="cube-reflection-buffer" attachment="depth"/>
+                <fullscreen-pass shader="regen.filter.sampling.downsample.depth"/>
+            </node>
+            <node id="Cube-Emission-Draw">
+                <fbo id="cube-emission-fbo" clear-buffers="0" draw-buffers="0"/>
+                <depth test="1" write="0"/>
+                <blend mode="lighten"/>
+                <node id="Lightning-Bolt0">
+                    <input type="float" name="lightningWidth" value="0.6"/>
+                    <input type="vec3" name="matDiffuse" value="0.8, 1.5, 20.0"/>
+                    <define key="FAIL_XXX" value="TRUE"/>
+                    <mesh id="lightning-mesh"/>
+                </node>
+            </node>
+            <node id="Cube-Emission-Blur">
+                <input type="int" name="numBlurPixels" value="9"/>
+                <input type="float" name="blurSigma" value="5.0"/>
+                <filter-sequence id="cube-emission-color" fbo="cube-emission-fbo" attachment="0">
+                    <filter shader="regen.filter.blur.horizontal"/>
+                    <filter shader="regen.filter.blur.vertical"/>
+                </filter-sequence>
+            </node>
+        </node>
+
         <view id="Cube-Emission-Color">
             <fbo id="SCREEN"/>
             <texture name="inputTexture" fbo="cube-emission-fbo" attachment="0"/>
@@ -643,7 +583,13 @@
         <node id="Cube-Transparent-Pass">
             <blend mode="add"/>
             <depth test="1" write="0"/>
-            <node import="Cube-Emission-Draw" />
+            <node id="Cube-Emission-Draw">
+                <blend mode="alpha"/>
+                <node import="Emission-Draw-Lightning-Bolt" />
+                <node import="Emission-Draw-Glow">
+                    <texture name="inputTexture" id="cube-emission-color"/>
+                </node>
+            </node>
         </node>
         -->
     </node>
@@ -653,19 +599,6 @@
             <depth test="1" write="0"/>
             <sky id="sky"/>
         </node>
-        <!--
-        <node import="Rain">
-            <texture name="depthTexture" fbo="cube-reflection-buffer" attachment="depth"/>
-        </node>
-        -->
-        <!--
-        <node import="Paraboloid-Emission-Update"/>
-        <node id="Paraboloid-Transparent-Pass">
-            <blend mode="add"/>
-            <depth test="1" write="0"/>
-            <node import="Paraboloid-Emission-Draw" />
-        </node>
-        -->
     </node>
 
     <node id="Post-Pass">
@@ -682,6 +615,36 @@
 
     <!--**************************-->
     <!--**************************-->
+
+    <node id="Debug-Views">
+        <view id="Paraboloid Reflection">
+            <fbo id="SCREEN"/>
+            <texture name="inputTexture" fbo="paraboloid-reflection-buffer" attachment="1"/>
+            <input type="int" name="arrayTextureSize" value="2"/>
+            <fullscreen-pass shader="regen.filter.sampling.array"/>
+        </view>
+        <view id="Cube Reflection">
+            <fbo id="SCREEN"/>
+            <texture name="inputTexture" fbo="cube-reflection-buffer" attachment="1"/>
+            <fullscreen-pass shader="regen.filter.sampling.cube"/>
+        </view>
+        <view id="Emission-Color">
+            <blit src-fbo="emission-fbo" src-attachment="0" dst-fbo="SCREEN"/>
+        </view>
+        <view id="Emission-Blur">
+            <fbo id="SCREEN"/>
+            <texture name="inputTexture" id="emission-color"/>
+            <fullscreen-pass shader="regen.filter.sampling"/>
+        </view>
+        <view id="Bullet-Debug">
+            <node import="bullet-debug">
+                <fbo id="g-buffer" draw-buffers="0"/>
+            </node>
+            <node>
+                <blit src-fbo="g-buffer" src-attachment="0" dst-fbo="SCREEN"/>
+            </node>
+        </view>
+    </node>
 
     <node id="root">
         <resource id="sky"/>
@@ -741,15 +704,8 @@
 
                 <node import="Post-Pass"/>
             </node>
+            <node import="Debug-Views"/>
 
-            <view id="Bullet-Debug">
-                <node import="bullet-debug">
-                    <fbo id="g-buffer" draw-buffers="0"/>
-                </node>
-                <node>
-                    <blit src-fbo="g-buffer" src-attachment="0" dst-fbo="SCREEN"/>
-                </node>
-            </view>
             <node import="GUI-Pass">
                 <fbo id="g-buffer" draw-buffers="0"/>
             </node>

--- a/regen/buffer/client-buffer.cpp
+++ b/regen/buffer/client-buffer.cpp
@@ -124,8 +124,7 @@ uint32_t ClientBuffer::swapData() {
 		// Merge overlapping segments, and sort along offsets.
 		// NOTE: This is done also across padded regions, as dataSize_ is used for dirty tracking,
 		//       and it includes the padded bytes too.
-		dirtyThisFrame.coalesce();
-		// Delete all dirty ranges from the last read slot that have been written to this frame.
+		// First, delete all dirty ranges from the last read slot that have been written to this frame.
 		// It is certain that both dirty lists are coalesced, so calling subtract is safe.
 		dirtyLastFrame.subtract(dirtyThisFrame);
 

--- a/regen/camera/camera.cpp
+++ b/regen/camera/camera.cpp
@@ -676,6 +676,12 @@ ref_ptr<Camera> Camera::createCamera(LoadingContext &ctx, scene::SceneInputNode 
 	} else if (camType == "cube") {
 		auto tf = ctx.scene()->getResource<ModelTransformation>(input.getValue("tf"));
 		ref_ptr<CubeCamera> cam = ref_ptr<CubeCamera>::alloc(getHiddenFacesMask(input));
+		// Set perspective parameters
+		cam->setPerspective(
+			1.0f, // aspect ratio is always 1 for cube map faces
+			90.0f, // fov is always 90 for cube map faces
+			input.getValue<float>("near", 0.1f),
+			input.getValue<float>("far", 100.0f));
 		if (tf.get()) {
 			cam->attachToPosition(tf);
 		}

--- a/regen/camera/cube-camera.cpp
+++ b/regen/camera/cube-camera.cpp
@@ -42,9 +42,6 @@ CubeCamera::CubeCamera(int hiddenFacesMask)
 			shaderDefine(REGEN_STRING("SKIP_LAYER" << i), "1");
 		}
 	}
-
-	// TODO: make this configurable
-	setPerspective(1.0f, 90.0f, 0.1f, 100.0f);
 }
 
 bool CubeCamera::isCubeFaceVisible(int face) const {

--- a/regen/objects/lod/impostor-billboard.cpp
+++ b/regen/objects/lod/impostor-billboard.cpp
@@ -208,7 +208,10 @@ void ImpostorBillboard::createResources() {
 	}
 
 	{ // create the snapshot FBO
-		// TODO: Add support for depth correction.
+		// TODO: Add support for depth correction?
+		//       - Depth texture is already created when snapshot FBO is created.
+		//       - This should be given to draw shader, there it must be sampled, and gl_FragCoord.z
+		//         must be adjusted accordingly, which is very expensive.
 		auto fbo = ref_ptr<FBO>::alloc(snapshotWidth_, snapshotHeight_, numSnapshotViews_);
 		std::vector<GLenum> drawAttachments;
 

--- a/regen/objects/particles.cpp
+++ b/regen/objects/particles.cpp
@@ -319,7 +319,9 @@ void Particles::gpuUpdate(RenderState *rs, double dt) {
 	// Ping-Pong VBO references so that next feedback goes to other buffer.
 	updateIdx_ = nextIdx;
 
-	// TODO: Update bounding box every ~166 ms
+	// TODO: Update bounding box every ~166 ms.
+	//      Problem: No support yet for binding VBO as SSBO.
+	//      The current interface requires StagedBuffer.
 	/**
 	bbox_time_ += dt;
 	if (bbox_time_ > 166.0) {

--- a/regen/objects/sky/lightning-bolt.cpp
+++ b/regen/objects/sky/lightning-bolt.cpp
@@ -387,9 +387,9 @@ void LightningBolt::createResources() {
 		brightness_->setVertexData(numVertices);
 		strikeIdx_->setVertexData(numVertices);
 
-		setInput(strikeIdx_);
-		setInput(brightness_);
 		setInput(pos_);
+		setInput(brightness_);
+		setInput(strikeIdx_);
 		updateVertexData();
 
 		// create single LOD level

--- a/regen/objects/sky/sky.h
+++ b/regen/objects/sky/sky.h
@@ -12,6 +12,7 @@
 #include <regen/external/osghimmel/timef.h>
 #include "regen/utility/time.h"
 #include "astronomy.h"
+#include "regen/states/depth-state.h"
 
 namespace regen {
 	class Sky : public StateNode, public Animation, public Resource {
@@ -97,6 +98,7 @@ namespace regen {
 		ref_ptr<Astronomy> astro_;
 
 		std::list<ref_ptr<SkyLayer> > layer_;
+		ref_ptr<DepthState> depth_;
 
 		ref_ptr<Light> sun_;
 		ref_ptr<Light> moon_;

--- a/regen/objects/terrain/ground.h
+++ b/regen/objects/terrain/ground.h
@@ -279,7 +279,7 @@ namespace regen {
 
 		Vec2ui numPatches_ = Vec2ui::one();
 		uint32_t numPatchesPerRow_ = 1;
-		float patchSize_ = 0.0f;
+		Vec2f patchSize_ = Vec2f::zero();
 
 		ref_ptr<Material> groundMaterial_;
 		std::vector<MaterialConfig> materialConfigs_;

--- a/regen/shader/regen/particles/sprite.glsl
+++ b/regen/shader/regen/particles/sprite.glsl
@@ -152,7 +152,7 @@ void main() {
     opacity *= color.a;
     #endif
     #ifdef HAS_fogDistance
-    opacity *= fogIntensity(distance(P, in_cameraPosition.xyz));
+    opacity *= 1.0 - fogIntensity(distance(P, in_cameraPosition.xyz));
     #endif
     out_density = opacity;
 #else // HAS_DENSITY_OUTPUT
@@ -250,5 +250,6 @@ void main()
 #ifdef HAS_brightness
     color.rgb *= in_brightness;
 #endif
+
     out_color = color;
 }

--- a/regen/utility/dirty-list.cpp
+++ b/regen/utility/dirty-list.cpp
@@ -1,9 +1,11 @@
 #include "dirty-list.h"
 #include <algorithm>
 
+#include "logging.h"
+
 using namespace regen;
 
-DirtyList::DirtyList() = default;
+DirtyList::DirtyList() : ranges_(16) {}
 
 void DirtyList::Range::merge(const Range& other) {
 	uint32_t new_start = std::min(offset, other.offset);
@@ -13,25 +15,77 @@ void DirtyList::Range::merge(const Range& other) {
 }
 
 void DirtyList::insert(uint32_t offset, uint32_t size) {
-	if (size == 0) return;
-	Range newRange{offset, size};
+    const Range newRange{offset, size};
 
-	// first check if we can merge with another range
-	// assuming we do not have too many dirt ranges, it should be fine to do a linear search here.
-	// Note that there still can be some fragmentation, as the new range may overlap with another range.
-    for (uint32_t rangeIdx = 0; rangeIdx < count_; ++rangeIdx) {
-		auto &range = ranges_[rangeIdx];
-		if (range.overlaps(newRange)) {
-			range.merge(newRange);
-			return;  // merged, no need to add
-		}
-	}
+    // Fast path: empty list
+    if (count_ == 0) {
+        ranges_[0] = newRange;
+        count_ = 1;
+        return;
+    }
 
-	// Unable to merge, add as a new range.
-	if (count_ == ranges_.size()) {
-		ranges_.resize(count_ + 16);  // grow by chunk
-	}
-	ranges_[count_++] = newRange;
+    // Reference to last range
+    Range& last = ranges_[count_ - 1];
+
+    // Fast path: strictly after last -> append
+    if (offset >= last.end()) {
+        if (offset == last.end()) {
+            // Direct extension
+            last.size += size;
+        } else {
+            // Append new range
+            if (count_ == ranges_.size())
+                ranges_.resize(ranges_.size() + 16);
+            ranges_[count_++] = newRange;
+        }
+        return;
+    }
+
+    // Fast path: merge with last if overlapping
+    if (last.overlaps(newRange)) {
+        last.merge(newRange);
+        return;
+    }
+
+    // -----------------------------------------
+    // GENERAL CASE: Insert into a sorted list, then merge neighbors
+    // -----------------------------------------
+
+    // Ensure capacity before shifting
+    if (count_ == ranges_.size()) {
+        ranges_.resize(ranges_.size() + 16);
+    }
+
+    // Find insertion position (sorted insert)
+    uint32_t pos = count_;
+    while (pos > 0 && ranges_[pos - 1].offset > offset) {
+    	// Make room for insertion by shifting right:
+        ranges_[pos] = ranges_[pos - 1];
+        --pos;
+    }
+    ranges_[pos] = newRange;
+    ++count_;
+
+    // Merge left neighbor if overlap
+    if (pos > 0 && ranges_[pos - 1].overlaps(ranges_[pos])) {
+        ranges_[pos - 1].merge(ranges_[pos]);
+        // shift everything after pos one left
+        for (uint32_t i = pos + 1; i < count_; ++i) {
+            ranges_[i - 1] = ranges_[i];
+        }
+        --count_;
+        pos -= 1;  // merged into left neighbor
+    }
+
+    // Merge right neighbor(s) (can be multiple)
+    while (pos + 1 < count_ && ranges_[pos].overlaps(ranges_[pos + 1])) {
+        ranges_[pos].merge(ranges_[pos + 1]);
+        // shift down
+        for (uint32_t i = pos + 2; i < count_; ++i) {
+            ranges_[i - 1] = ranges_[i];
+        }
+        --count_;
+    }
 }
 
 void DirtyList::append(uint32_t offset, uint32_t size) {
@@ -43,9 +97,8 @@ void DirtyList::append(uint32_t offset, uint32_t size) {
 		return;
 	}
 
-	Range newRange{offset, size};
-	auto &lastRange = ranges_[count_ - 1];
-	if (lastRange.overlaps(newRange)) {
+	const Range newRange{offset, size};
+	if (auto &lastRange = ranges_[count_ - 1]; lastRange.overlaps(newRange)) {
 		lastRange.merge(newRange);
 	} else {
 		if (count_ == ranges_.size()) {
@@ -53,43 +106,6 @@ void DirtyList::append(uint32_t offset, uint32_t size) {
 		}
 		ranges_[count_++] = newRange;
 	}
-}
-
-void DirtyList::coalesce() {
-	if (count_ <= 1) return;
-
-	if (count_ <= 16) {
-		// Use insertion sort for small count_
-		for (uint32_t i = 1u; i < count_; ++i) {
-			Range key = ranges_[i];
-			uint32_t j = i;
-			while (j > 0 && ranges_[j - 1].offset > key.offset) {
-				ranges_[j] = ranges_[j - 1];
-				--j;
-			}
-			ranges_[j] = key;
-		}
-	} else {
-		std::sort(ranges_.begin(), ranges_.begin() + count_,
-			[](const Range& a, const Range& b) {
-				return a.offset < b.offset;
-			});
-	}
-
-	uint32_t write = 0u;
-	for (uint32_t i = 1u; i < count_; ++i) {
-		auto &leftRange = ranges_[write];
-		auto &rightRange = ranges_[i];
-		if (leftRange.end() >= rightRange.offset) {
-			// overlap
-			leftRange.size = rightRange.end() - leftRange.offset;
-		} else {
-			// no overlap, move to next write idx
-			ranges_[++write] = rightRange;
-		}
-	}
-
-	count_ = write + 1;
 }
 
 void DirtyList::subtract(const DirtyList& other) {

--- a/regen/utility/dirty-list.cpp
+++ b/regen/utility/dirty-list.cpp
@@ -1,8 +1,6 @@
 #include "dirty-list.h"
 #include <algorithm>
 
-#include "logging.h"
-
 using namespace regen;
 
 DirtyList::DirtyList() : ranges_(16) {}

--- a/regen/utility/dirty-list.h
+++ b/regen/utility/dirty-list.h
@@ -108,13 +108,6 @@ namespace regen {
 		 */
 		void subtract(const DirtyList &other);
 
-		/**
-		 * Coalesce the dirty ranges in the list.
-		 * This will merge overlapping ranges and sort them by offset.
-		 * After calling this method, the dirty ranges will be non-overlapping.
-		 */
-		void coalesce();
-
 	protected:
 		std::vector<Range> ranges_;
 		uint32_t count_ = 0;


### PR DESCRIPTION
This PR optimizes the dirty list insertion algorithm by removing the separate `coalesce()` method and maintaining a sorted, merged list during insertion. The new implementation adds fast paths for common cases (empty list, appending to end, merging with last element) and handles the general case with sorted insertion and neighbor merging.

Key changes:
- Optimized `DirtyList::insert()` with fast paths and inline merge operations
- Changed terrain patch size from scalar to Vec2f for non-uniform patches
- Fixed fog intensity calculation in particle sprite shader
- Refactored sky depth state management for better control