### PR TITLE
Improved use of atomics

### DIFF
--- a/applications/qt/scene-widget.cpp
+++ b/applications/qt/scene-widget.cpp
@@ -148,9 +148,7 @@ void SceneWidget::run(QOpenGLContext *glContext) {
 		return;
 	}
 	isRunning_ = true;
-#ifdef WAIT_ON_VSYNC
 	int dt;
-#endif
 #ifdef REGEN_SCENE_DEBUG_TIME
 	ElapsedTimeDebugger elapsedTime("Scene Drawing", 300);
 #endif
@@ -204,7 +202,8 @@ void SceneWidget::run(QOpenGLContext *glContext) {
 			// adjust interval to hit the desired frame rate if we can
 			boost::posix_time::ptime t(
 					boost::posix_time::microsec_clock::local_time());
-			dt = std::max(0, updateInterval_ - static_cast<int>((t - app_->lastTime()).total_microseconds()));
+			dt = std::max(0, updateInterval_ - static_cast<int>((t -
+				app_->systemTime().p_time).total_microseconds()));
 			// sleep desired interval
 			usleepRegen(dt);
 		}

--- a/applications/scene-display/scene-display-widget.cpp
+++ b/applications/scene-display/scene-display-widget.cpp
@@ -904,6 +904,9 @@ void SceneDisplayWidget::loadSceneGraphicsThread(const string &sceneFile) {
 	REGEN_INFO("Loading XML scene at " << sceneFile << ".");
 
 	AnimationManager::get().pause(true);
+	// Ensure all GL operations are finished before deleting GL resources.
+	glFinish();
+
 	AnimationManager::get().clear();
 	AnimationManager::get().setRootState(app_->renderTree()->state());
 	TextureBinder::reset();

--- a/regen/camera/camera-controller.cpp
+++ b/regen/camera/camera-controller.cpp
@@ -107,12 +107,11 @@ void CameraController::initCameraController() {
 
 void CameraController::cpuUpdate(double dt) {
 	updateStep(dt);
-	if (!isRotating_ && !isMoving_) return;
-
-	pos_ += step_;
-
-	updateCameraPose();
-	computeMatrices(camPos_, camDir_);
+	if (isRotating_ || isMoving_) {
+		pos_ += step_;
+		updateCameraPose();
+		computeMatrices(camPos_, camDir_);
+	}
 	updateCamera(camPos_, camDir_, dt);
 }
 

--- a/regen/camera/camera-controller.cpp
+++ b/regen/camera/camera-controller.cpp
@@ -12,8 +12,7 @@ CameraController::CameraController(const ref_ptr<Camera> &cam)
 		: Animation(false, true),
 		  CameraControllerBase(cam),
 		  cameraMode_(FIRST_PERSON),
-		  meshDistance_(10.0f),
-		  lastOrientation_(0.0) {
+		  meshDistance_(10.0f) {
 	setAnimationName("controller");
 	horizontalOrientation_ = 0.0;
 	verticalOrientation_ = 0.0;

--- a/regen/camera/camera-controller.h
+++ b/regen/camera/camera-controller.h
@@ -255,7 +255,7 @@ namespace regen {
 		bool moveDown_ = false;
 		bool isMoving_ = false;
 		bool isRotating_ = false;
-		double lastOrientation_;
+		double lastOrientation_ = -1.0;
 
 		Vec3f meshEyeOffset_;
 		double meshHorizontalOrientation_;

--- a/regen/camera/camera.h
+++ b/regen/camera/camera.h
@@ -512,7 +512,7 @@ namespace regen {
 		 * Recompute the camera parameters.
 		 * @return true if the camera was updated.
 		 */
-		virtual bool updateCamera();
+		bool updateCamera();
 
 		virtual void updateViewProjection1();
 

--- a/regen/camera/cascade-camera.cpp
+++ b/regen/camera/cascade-camera.cpp
@@ -142,9 +142,9 @@ bool LightCamera_CSM::updateFrustumSplit() {
 }
 
 bool LightCamera_CSM::updateLightView() {
-	if (lightDirStamp_ == light_->direction()->stampOfReadData() &&
-		lightPosStamp_ == userPositionStamp_) { return false; }
-	lightDirStamp_ = light_->direction()->stampOfReadData();
+	const uint32_t dirStamp = light_->direction()->stampOfReadData();
+	if (lightDirStamp_ == dirStamp && lightPosStamp_ == userPositionStamp_) { return false; }
+	lightDirStamp_ = dirStamp;
 	lightPosStamp_ = userPositionStamp_;
 
 	auto f = -light_->directionStaged(0).r;

--- a/regen/camera/cube-camera.cpp
+++ b/regen/camera/cube-camera.cpp
@@ -114,8 +114,9 @@ bool LightCamera_Cube::updateCubeLight() {
 }
 
 bool LightCamera_Cube::updateLightProjection() {
-	if (lightRadiusStamp_ == light_->radius()->stampOfReadData()) { return false; }
-	lightRadiusStamp_ = light_->radius()->stampOfReadData();
+	const uint32_t radiusStamp = light_->radius()->stampOfReadData();
+	if (lightRadiusStamp_ == radiusStamp) { return false; }
+	lightRadiusStamp_ = radiusStamp;
 
 	auto radius = light_->radiusStaged(0);
 	setPerspective(1.0f, 90.0f, lightNear_, radius.r.y);
@@ -123,8 +124,9 @@ bool LightCamera_Cube::updateLightProjection() {
 }
 
 bool LightCamera_Cube::updateLightView() {
-	if (lightPosStamp_ == light_->position()->stampOfReadData()) { return false; }
-	lightPosStamp_ = light_->position()->stampOfReadData();
+	const uint32_t posStamp = light_->position()->stampOfReadData();
+	if (lightPosStamp_ == posStamp) { return false; }
+	lightPosStamp_ = posStamp;
 	setPosition(0, light_->positionStaged(0).r.xyz());
 	return updateView();
 }

--- a/regen/camera/parabolic-camera.cpp
+++ b/regen/camera/parabolic-camera.cpp
@@ -96,19 +96,21 @@ bool LightCamera_Parabolic::updateParabolicLight() {
 }
 
 bool LightCamera_Parabolic::updateLightProjection() {
-	if (lightRadiusStamp_ == light_->radius()->stampOfReadData()) { return false; }
+	const uint32_t radiusStamp = light_->radius()->stampOfReadData();
+	if (lightRadiusStamp_ == radiusStamp) { return false; }
 	auto radius = light_->radiusStaged(0);
-	lightRadiusStamp_ = light_->radius()->stampOfReadData();
+	lightRadiusStamp_ = radiusStamp;
 	setPerspective(1.0f, 180.0f, lightNear_, radius.r.y);
 	return true;
 }
 
 bool LightCamera_Parabolic::updateLightView() {
-	if (lightPosStamp_ == light_->position()->stampOfReadData() &&
-		lightDirStamp_ == light_->direction()->stampOfReadData()) { return false; }
+	const uint32_t posStamp = light_->position()->stampOfReadData();
+	const uint32_t dirStamp = light_->direction()->stampOfReadData();
+	if (lightPosStamp_ == posStamp && lightDirStamp_ == dirStamp) { return false; }
 	auto dir = light_->directionStaged(0);
-	lightPosStamp_ = light_->position()->stampOfReadData();
-	lightDirStamp_ = light_->direction()->stampOfReadData();
+	lightPosStamp_ = posStamp;
+	lightDirStamp_ = dirStamp;
 	// Set the position of the light camera
 	setPosition(0, light_->positionStaged(0).r.xyz());
 	setDirection(0, -dir.r);

--- a/regen/camera/reflection-camera.cpp
+++ b/regen/camera/reflection-camera.cpp
@@ -101,18 +101,25 @@ bool ReflectionCamera::updateReflection() {
 
 	bool reflectorChanged = false;
 	if (hasMesh_) {
-		if (transform_.get() != nullptr && transform_->stampOfReadData() != transformStamp_) {
-			reflectorChanged = true;
-			transformStamp_ = transform_->stampOfReadData();
+		if (transform_.get() != nullptr) {
+			const uint32_t tfStamp = transform_->stampOfReadData();
+			if (tfStamp != transformStamp_) {
+				reflectorChanged = true;
+				transformStamp_ = tfStamp;
+			}
 		}
-		if (nor_->stampOfReadData() != norStamp_) {
+
+		const uint32_t norStamp = nor_->stampOfReadData();
+		const uint32_t posStamp = pos_->stampOfReadData();
+		if (norStamp != norStamp_) {
 			reflectorChanged = true;
-			norStamp_ = nor_->stampOfReadData();
+			norStamp_ = norStamp;
 		}
-		if (pos_->stampOfReadData() != posStamp_) {
+		if (posStamp != posStamp_) {
 			reflectorChanged = true;
-			posStamp_ = pos_->stampOfReadData();
+			posStamp_ = posStamp;
 		}
+
 		// Compute plane parameters...
 		if (reflectorChanged) {
 			if (!pos_->hasClientData()) pos_->readServerData();

--- a/regen/camera/spot-light-camera.cpp
+++ b/regen/camera/spot-light-camera.cpp
@@ -30,8 +30,9 @@ bool LightCamera_Spot::updateSpotLight() {
 }
 
 bool LightCamera_Spot::updateLightProjection() {
-	if (lightRadiusStamp_ == light_->radius()->stampOfReadData() &&
-		lightConeStamp_ == light_->coneAngle()->stampOfReadData()) { return false; }
+	const uint32_t radiusStamp = light_->radius()->stampOfReadData();
+	const uint32_t coneStamp = light_->coneAngle()->stampOfReadData();
+	if (lightRadiusStamp_ == radiusStamp && lightConeStamp_ == coneStamp) { return false; }
 	const auto radius = light_->radiusStaged(0);
 	const auto coneAngle = light_->coneAngleStaged(0);
 	setPerspective(
@@ -39,16 +40,17 @@ bool LightCamera_Spot::updateLightProjection() {
 			2.0f * acosf(coneAngle.r.y) * math::RAD_TO_DEG,
 			lightNear_,
 			radius.r.y);
-	lightRadiusStamp_ = light_->radius()->stampOfReadData();
-	lightConeStamp_ = light_->coneAngle()->stampOfReadData();
+	lightRadiusStamp_ = radiusStamp;
+	lightConeStamp_ = coneStamp;
 	return true;
 }
 
 bool LightCamera_Spot::updateLightView() {
-	if (lightPosStamp_ == light_->position()->stampOfReadData() &&
-		lightDirStamp_ == light_->direction()->stampOfReadData()) { return false; }
-	lightPosStamp_ = light_->position()->stampOfReadData();
-	lightDirStamp_ = light_->direction()->stampOfReadData();
+	const uint32_t posStamp = light_->position()->stampOfReadData();
+	const uint32_t dirStamp = light_->direction()->stampOfReadData();
+	if (lightPosStamp_ == posStamp && lightDirStamp_ == dirStamp) { return false; }
+	lightPosStamp_ = posStamp;
+	lightDirStamp_ = dirStamp;
 	setPosition(0, light_->positionStaged(0).r.xyz());
 	setDirection(0, light_->directionStaged(0).r);
 	return updateView();

--- a/regen/compute/matrix.h
+++ b/regen/compute/matrix.h
@@ -336,9 +336,9 @@ namespace regen {
 		 */
 		constexpr Vec3f mul_30(const Vec3f &v) const {
 			return Vec3f{
-				v.x * x[0] + v.y * x[1] + v.z * x[2] + x[3],
-				v.x * x[4] + v.y * x[5] + v.z * x[6] + x[7],
-				v.x * x[8] + v.y * x[9] + v.z * x[10] + x[11]};
+				v.x * x[0] + v.y * x[1] + v.z * x[2],
+				v.x * x[4] + v.y * x[5] + v.z * x[6],
+				v.x * x[8] + v.y * x[9] + v.z * x[10]};
 		}
 
 		/**

--- a/regen/compute/matrix.h
+++ b/regen/compute/matrix.h
@@ -330,6 +330,30 @@ namespace regen {
 		}
 
 		/**
+		 * Matrix-Vec3 multiplication (ignoring translation, w=0).
+		 * @param v the vector.
+		 * @return transformed vector.
+		 */
+		constexpr Vec3f mul_30(const Vec3f &v) const {
+			return Vec3f{
+				v.x * x[0] + v.y * x[1] + v.z * x[2] + x[3],
+				v.x * x[4] + v.y * x[5] + v.z * x[6] + x[7],
+				v.x * x[8] + v.y * x[9] + v.z * x[10] + x[11]};
+		}
+
+		/**
+		 * Matrix-Vec3 multiplication (including translation, w=1).
+		 * @param v the vector.
+		 * @return transformed vector.
+		 */
+		constexpr Vec3f mul_31(const Vec3f &v) const {
+			return Vec3f{
+				v.x * x[0] + v.y * x[1] + v.z * x[2] + x[3],
+				v.x * x[4] + v.y * x[5] + v.z * x[6] + x[7],
+				v.x * x[8] + v.y * x[9] + v.z * x[10] + x[11]};
+		}
+
+		/**
 		 * Matrix-Matrix multiplication.
 		 * @param b another matrix.
 		 * @return the matrix product.
@@ -756,7 +780,7 @@ namespace regen {
 		 * @return vector multiplied with matrix, ignoring the translation.
 		 */
 		constexpr Vec3f rotateVector(const Vec3f &v) const {
-			return ((*this) * Vec4f::create(v, 0.0f)).xyz();
+			return mul_30(v);
 		}
 
 		/**
@@ -764,7 +788,7 @@ namespace regen {
 		 * @return vector multiplied with matrix.
 		 */
 		constexpr Vec3f transformVector(const Vec3f &v) const {
-			return ((*this) * Vec4f::create(v, 1.0f)).xyz();
+			return mul_31(v);
 		}
 
 		/**
@@ -919,12 +943,12 @@ namespace regen {
 					euler.z = atan2f(x[9], x[10]);
 					euler.y = atan2f(x[4], x[0]);
 				} else {
-					euler.x = -M_PI / 2;
+					euler.x = -math::halfPi<float>();
 					euler.z = -atan2f(x[6], x[5]);
 					euler.y = 0;
 				}
 			} else {
-				euler.x = M_PI / 2;
+				euler.x = math::halfPi<float>();
 				euler.z = atan2f(x[6], x[5]);
 				euler.y = 0;
 			}

--- a/regen/memory/client-buffer.cpp
+++ b/regen/memory/client-buffer.cpp
@@ -85,6 +85,10 @@ void ClientBuffer::removeSegment(const ref_ptr<ClientBuffer> &segment) {
 	}
 }
 
+static inline uint32_t loadAtomicStamp(const CachePadded<std::atomic<uint32_t>> &stamp) {
+	return stamp.value.load(std::memory_order_relaxed);
+}
+
 uint32_t ClientBuffer::swapData() {
 	// NOTE: This function should be very fast as potentially both animation and rendering threads
 	//       are waiting for it to finish.
@@ -107,7 +111,7 @@ uint32_t ClientBuffer::swapData() {
 		if(!dirtyThisFrame.empty()) {
 			// there was a write this frame -> need to do a swap
 			writeLockAll();
-			lastDataSlot_.store(lastWriteSlot, std::memory_order_relaxed);
+			lastDataSlot_.store(lastWriteSlot, std::memory_order_release);
 			writeUnlockAll(0u, 0u);
 			swapDataSlot_ = lastWriteSlot;
 		}
@@ -118,6 +122,10 @@ uint32_t ClientBuffer::swapData() {
 		// over to have the full data in place for reading in the next frame.
 		const int32_t lastWriteSlot = 1 - lastReadSlot;
 		const auto &dirtyThisFrame = dirtyLists_[lastWriteSlot];
+
+		// pull the slot data pointers
+		const byte* __restrict lastReadData = dataSlots_[lastReadSlot];
+		byte* __restrict lastWriteData = dataSlots_[lastWriteSlot];
 
 		// We need to avoid race conditions of another thread getting a read lock
 		// while we do the switching, then the thread may attempt (while holding read)
@@ -139,26 +147,28 @@ uint32_t ClientBuffer::swapData() {
 			const auto &range = dirtyLastFrame.ranges()[rangeIdx];
 			// Copy the data from the read slot to the write slot.
 			std::memcpy(
-					dataSlots_[lastWriteSlot] + range.offset,
-					dataSlots_[lastReadSlot] + range.offset,
+					lastWriteData + range.offset,
+					lastReadData + range.offset,
 					range.size);
 		}
 
 		// For each write segment with stamp < read segment stamp: set the stamp to read segment stamp,
 		// as we have synced the data above.
-		dataStamps_[lastWriteSlot].value.store(
-			dataStamps_[lastReadSlot].value.load(std::memory_order_relaxed),
-			std::memory_order_relaxed);
+		const uint32_t readStamp  = loadAtomicStamp(dataStamps_[lastReadSlot]);
+		const uint32_t writeStamp = loadAtomicStamp(dataStamps_[lastWriteSlot]);
+		if (writeStamp < readStamp) {
+			dataStamps_[lastWriteSlot].value.store(readStamp, std::memory_order_relaxed);
+		}
 		for (auto &segment: bufferSegments_) {
-			const auto writeStamp = segment->dataStamps_[lastWriteSlot].value.load(std::memory_order_relaxed);
-			const auto readStamp = segment->dataStamps_[lastReadSlot].value.load(std::memory_order_relaxed);
-			if (writeStamp < readStamp) {
-				segment->dataStamps_[lastWriteSlot].value.store(readStamp, std::memory_order_relaxed);
+			const auto s_writeStamp = loadAtomicStamp(segment->dataStamps_[lastWriteSlot]);
+			const auto s_readStamp  = loadAtomicStamp(segment->dataStamps_[lastReadSlot]);
+			if (s_writeStamp < s_readStamp) {
+				segment->dataStamps_[lastWriteSlot].value.store(s_readStamp, std::memory_order_relaxed);
 			}
 		}
 
 		// Finally swap read and write idx, new read idx should have new data for reading next frame.
-		lastDataSlot_.store(lastWriteSlot, std::memory_order_relaxed);
+		lastDataSlot_.store(lastWriteSlot, std::memory_order_release);
 
 		// Unlock the write locks on both slots.
 		writeUnlockAll(0u, 0u);
@@ -174,51 +184,56 @@ uint32_t ClientBuffer::swapData() {
 	}
 }
 
-void ClientBuffer::nextStamp() const {
-	uint32_t stamp = 1u + std::max(
-		dataStamps_[0].value.load(std::memory_order_relaxed),
-		dataStamps_[1].value.load(std::memory_order_relaxed));
-	dataStamps_[0].value.store(stamp, std::memory_order_relaxed);
-	dataStamps_[1].value.store(stamp, std::memory_order_relaxed);
-	auto *parent = parentBuffer_;
-	while (parent != nullptr) {
-		stamp = 1u + std::max(
-			parent->dataStamps_[0].value.load(std::memory_order_relaxed),
-			parent->dataStamps_[1].value.load(std::memory_order_relaxed));
-		parent->dataStamps_[0].value.store(stamp, std::memory_order_relaxed);
-		parent->dataStamps_[1].value.store(stamp, std::memory_order_relaxed);
-		parent = parent->parentBuffer_;
-	}
-}
+void ClientBuffer::nextStamp(int32_t writeSlot) const {
+	// Increase the stamp for the given write slot to one higher than the current read slot.
+	const int32_t readSlot = (dataSlots_[1] ? (1 - writeSlot) : 0);
+	uint32_t stamp = loadAtomicStamp(dataStamps_[readSlot]);
+	dataStamps_[writeSlot].value.store(stamp + 1, std::memory_order_relaxed);
 
-void ClientBuffer::nextStamp(uint32_t dataSlot) const {
-	const auto readSlot = (dataSlots_[1] ? (1 - dataSlot) : 0);
-	auto stamp = dataStamps_[readSlot].value.load(std::memory_order_relaxed);
-	dataStamps_[dataSlot].value.store(stamp + 1, std::memory_order_relaxed);
-	// Increase the stamp for all parent buffer ranges as well.
+	// Propagate to parent buffers.
 	auto *parent = parentBuffer_;
 	while (parent) {
-		stamp = parent->dataStamps_[readSlot].value.load(std::memory_order_relaxed);
-		parent->dataStamps_[dataSlot].value.store(stamp + 1, std::memory_order_relaxed);
+		stamp = loadAtomicStamp(parent->dataStamps_[readSlot]);
+		parent->dataStamps_[writeSlot].value.store(stamp + 1, std::memory_order_relaxed);
 		parent = parent->parentBuffer_;
 	}
 }
 
-void ClientBuffer::nextSegmentStamp(uint32_t dataSlot, uint32_t writeBegin, uint32_t writeSize) const {
+void ClientBuffer::nextSegmentStamp(int32_t dataSlot, uint32_t writeBegin, uint32_t writeSize) const {
 	const uint32_t writeEnd = writeBegin + writeSize;
 
 	// Update the stamp for all segments that overlap with the updated range.
 	for (auto &segment: bufferSegments_) {
 		if (writeBegin < segment->dataOffset_ + segment->dataSize_ && writeEnd > segment->dataOffset_) {
 			// check if the segment overlaps with the updated range.
-			const auto readSlot = (segment->dataSlots_[1] ? (1 - dataSlot) : 0);
-			segment->dataStamps_[dataSlot].value.store(
-				segment->dataStamps_[readSlot].value.load(std::memory_order_relaxed) + 1,
-				std::memory_order_relaxed);
+			const int32_t readSlot = (segment->dataSlots_[1] ? (1 - dataSlot) : 0);
+			const uint32_t readStamp = loadAtomicStamp(segment->dataStamps_[readSlot]);
+			segment->dataStamps_[dataSlot].value.store(readStamp + 1, std::memory_order_relaxed);
 		} else if (segment->dataOffset_ >= writeEnd) {
 			// drop out if segment is located after the updated range
 			break;
 		}
+	}
+}
+
+void ClientBuffer::nextStamp() const {
+	// Increase the stamp for both slots.
+	// This is only rarely used, e.g. when segments are changed or buffer resized.
+	uint32_t stamp = 1u + std::max(
+		loadAtomicStamp(dataStamps_[0]),
+		loadAtomicStamp(dataStamps_[1]));
+	dataStamps_[0].value.store(stamp, std::memory_order_relaxed);
+	dataStamps_[1].value.store(stamp, std::memory_order_relaxed);
+
+	// Propagate to parent buffers.
+	auto *parent = parentBuffer_;
+	while (parent != nullptr) {
+		stamp = 1u + std::max(
+			loadAtomicStamp(parent->dataStamps_[0]),
+			loadAtomicStamp(parent->dataStamps_[1]));
+		parent->dataStamps_[0].value.store(stamp, std::memory_order_relaxed);
+		parent->dataStamps_[1].value.store(stamp, std::memory_order_relaxed);
+		parent = parent->parentBuffer_;
 	}
 }
 
@@ -959,7 +974,7 @@ void ClientBuffer::createSecondSlot() {
 	std::memcpy(dataSlots_[1], dataSlots_[0], dataSize_);
 
 	// Initialize second slot stamp to the same value as the first slot.
-	dataStamps_[1].value.store(dataStamps_[0].value.load(std::memory_order_relaxed), std::memory_order_relaxed);
+	dataStamps_[1].value.store(loadAtomicStamp(dataStamps_[0]), std::memory_order_relaxed);
 	REGEN_INFO("Switch to double-buffered mode"
 					   << " with " << dataSize_ / 1024.0f << " KiB "
 					   << " in " << bufferSegments_.size() << " segments.");
@@ -968,7 +983,7 @@ void ClientBuffer::createSecondSlot() {
 	for (auto &segment: bufferSegments_) {
 		segment->setDataPointer(this, dataSlots_[1] + segment->dataOffset_, 1);
 		segment->dataStamps_[1].value.store(
-			segment->dataStamps_[0].value.load(std::memory_order_relaxed), std::memory_order_relaxed);
+			loadAtomicStamp(segment->dataStamps_[0]), std::memory_order_relaxed);
 	}
 
 	markWrittenTo(currentWriteSlot(), 0, dataSize_);

--- a/regen/memory/client-buffer.cpp
+++ b/regen/memory/client-buffer.cpp
@@ -133,12 +133,11 @@ uint32_t ClientBuffer::swapData() {
 		// Also we need to avoid any writer adding stuff to the dirty list while we read it.
 		writeLockAll();
 
-		// Merge overlapping segments, and sort along offsets.
-		// NOTE: This is done also across padded regions, as dataSize_ is used for dirty tracking,
-		//       and it includes the padded bytes too.
-		// First, delete all dirty ranges from the last read slot that have been written to this frame.
+		// Delete all dirty ranges from the last read slot that have been written to this frame.
 		// It is certain that both dirty lists are coalesced, so calling subtract is safe.
 		dirtyLastFrame.subtract(dirtyThisFrame);
+		// Coalesce the remaining dirty ranges reducing the number of copy operations needed.
+		dirtyLastFrame.coalesce();
 
 		// Remaining are the ranges where data in the write slot is not up-to-date with the read slot,
 		// hence we copy it over.

--- a/regen/memory/client-buffer.cpp
+++ b/regen/memory/client-buffer.cpp
@@ -21,6 +21,40 @@ ClientBuffer::~ClientBuffer() {
 	bufferSegments_.clear();
 }
 
+ClientBufferPool *ClientBuffer::getMemoryPool(bool reset) {
+	static ClientBufferPool *memoryPool = nullptr;
+	if (reset && memoryPool != nullptr) {
+		delete memoryPool;
+		memoryPool = nullptr;
+	}
+	if (memoryPool == nullptr) {
+		memoryPool = new ClientBufferPool();
+		memoryPool->set_index(0);
+		memoryPool->set_alignment(32);
+		memoryPool->set_minSize(4u * 1024u * 1024u); // 4 MB blocks
+	}
+	return memoryPool;
+}
+
+ClientBufferPool *ClientBuffer::getMemoryPool() {
+	return getMemoryPool(false);
+}
+
+ClientBufferPool *ClientBuffer::resetMemoryPool() {
+	return getMemoryPool(true);
+}
+
+ClientBufferPool::Node* ClientBuffer::getMemoryAllocator(uint32_t dataSize) {
+	ClientBufferPool::Node *n = getMemoryPool()->chooseAllocator(dataSize);
+	if (n == nullptr) {
+		n = getMemoryPool()->createAllocator(dataSize);
+	}
+	if (n == nullptr) {
+		REGEN_ERROR("no allocator found for " << dataSize/1024.0 << " KB for client buffer.");
+	}
+	return n;
+}
+
 void ClientBuffer::setFrameLocked(bool frameLocked) {
 	isFrameLocked_ = frameLocked;
 	for (auto &segment: bufferSegments_) {
@@ -478,37 +512,6 @@ void ClientBuffer::updateBufferSize() {
 	}
 }
 
-ClientBufferPool *ClientBuffer::getMemoryPool(bool reset) {
-	static ClientBufferPool *memoryPool = nullptr;
-	if (reset && memoryPool != nullptr) {
-		delete memoryPool;
-		memoryPool = nullptr;
-	}
-	if (memoryPool == nullptr) {
-		memoryPool = new ClientBufferPool();
-		memoryPool->set_index(0);
-		memoryPool->set_alignment(1);
-		memoryPool->set_minSize(4u * 1024u * 1024u); // 4 MB blocks
-	}
-	return memoryPool;
-}
-
-ClientBufferPool::Node* ClientBuffer::getMemoryAllocator(uint32_t dataSize) {
-	ClientBufferPool::Node *n = getMemoryPool()->chooseAllocator(dataSize);
-	if (n == nullptr) {
-		n = getMemoryPool()->createAllocator(dataSize);
-	}
-	return n;
-}
-
-ClientBufferPool *ClientBuffer::getMemoryPool() {
-	return getMemoryPool(false);
-}
-
-ClientBufferPool *ClientBuffer::resetMemoryPool() {
-	return getMemoryPool(true);
-}
-
 void ClientBuffer::ownerResize() {
 	// keep a reference to the old data slots, for copying data over.
 	byte *oldData0 = dataSlots_[0];
@@ -522,17 +525,20 @@ void ClientBuffer::ownerResize() {
 	if constexpr(USE_CLIENT_BUFFER_POOL) {
 		auto oldDataRefs0 = dataRefs_[0];
 		auto oldDataRefs1 = dataRefs_[1];
-		auto memoryPool = ClientBuffer::getMemoryPool();
-		auto *allocator = ClientBuffer::getMemoryAllocator(dataSize_);
+		auto memoryPool = getMemoryPool();
+		auto *allocator = getMemoryAllocator(dataSize_);
 		dataRefs_[0] = memoryPool->alloc(allocator, dataSize_);
 		dataSlots_[0] = dataRefs_[0].allocatorNode->allocatorRef;
+
 		if (clientBufferMode_ == SingleBuffer) {
 			dataSlots_[1] = nullptr;
 		} else if (clientBufferMode_ == DoubleBuffer) {
+			allocator = getMemoryAllocator(dataSize_);
 			dataRefs_[1] = memoryPool->alloc(allocator, dataSize_);
 			dataSlots_[1] = dataRefs_[1].allocatorNode->allocatorRef;
 		} else if (clientBufferMode_ == AdaptiveBuffer) {
 			if (dataSlots_[1]) {
+				allocator = getMemoryAllocator(dataSize_);
 				dataRefs_[1] = memoryPool->alloc(allocator, dataSize_);
 				dataSlots_[1] = dataRefs_[1].allocatorNode->allocatorRef;
 			}
@@ -553,8 +559,8 @@ void ClientBuffer::ownerResize() {
 		}
 
 		// delete the old data slots.
-		if (oldData0) getMemoryPool()->free(oldDataRefs0);
-		if (oldData1) getMemoryPool()->free(oldDataRefs1);
+		if (oldData0) memoryPool->free(oldDataRefs0);
+		if (oldData1) memoryPool->free(oldDataRefs1);
 	} else { // not using memory pool
 		dataSlots_[0] = new byte[dataSize_];
 		if (clientBufferMode_ == SingleBuffer) {

--- a/regen/memory/client-buffer.cpp
+++ b/regen/memory/client-buffer.cpp
@@ -91,12 +91,9 @@ uint32_t ClientBuffer::swapData() {
 	// flushing is only needed if the buffer is frame-locked.
 	if (!isFrameLocked_ || dataSize_ == 0u) return 0u;
 
-	// TODO: We could exploit here knowledge of the last swap. If we swapped last frame
-	//  we might be able to avoid some of the atomic fetch operations.
-	//  e.g. lastReadSlot = 1 - swappedReadSlot where swappedReadSlot is cached from last swap.
-
-	const int32_t lastReadSlot = lastDataSlot_.load(std::memory_order_relaxed);
+	const int32_t lastReadSlot = swapDataSlot_;
 	auto &dirtyLastFrame = dirtyLists_[lastReadSlot];
+	//assert(lastReadSlot == lastDataSlot_.load(std::memory_order_relaxed));
 
 	if (!dataSlots_[1]) {
 		// Single-buffered mode, no need to copy data.
@@ -112,6 +109,7 @@ uint32_t ClientBuffer::swapData() {
 			writeLockAll();
 			lastDataSlot_.store(lastWriteSlot, std::memory_order_relaxed);
 			writeUnlockAll(0u, 0u);
+			swapDataSlot_ = lastWriteSlot;
 		}
 
 		return 0u;
@@ -164,6 +162,9 @@ uint32_t ClientBuffer::swapData() {
 
 		// Unlock the write locks on both slots.
 		writeUnlockAll(0u, 0u);
+
+		// Keep a cached copy of the last read slot for the next swap.
+		swapDataSlot_ = lastWriteSlot;
 
 		// clear dirty lists for the last read slot, such that it can be reused
 		// next frame for writing.
@@ -222,27 +223,18 @@ void ClientBuffer::nextSegmentStamp(uint32_t dataSlot, uint32_t writeBegin, uint
 }
 
 MappedClientData ClientBuffer::mapRange(int mapMode, uint32_t offset, uint32_t size) const {
+	const bool singleBufferMode = (clientBufferMode_ == SingleBuffer ||
+		(clientBufferMode_ == AdaptiveBuffer && !hasTwoSlots()));
+
 	if ((mapMode & BUFFER_GPU_WRITE) != 0) {
-		if (clientBufferMode_ == AdaptiveBuffer) {
-			if (!hasTwoSlots()) {
-				return writeRange_SingleBuffer(offset, size);
-			} else {
-				return writeRange_DoubleBuffer(offset, size);
-			}
-		} else if (clientBufferMode_ == SingleBuffer) {
+		if (singleBufferMode) {
 			// Single-buffered mode, we can only write to the first slot.
 			return writeRange_SingleBuffer(offset, size);
-		} else { // clientBufferMode_ == DoubleBuffer
+		} else { // DoubleBuffer || (AdaptiveBuffer && isDoubleBuffered)
 			// Double-buffered mode, we can write to either slot.
 			return writeRange_DoubleBuffer(offset, size);
 		}
-	} else if (clientBufferMode_ == AdaptiveBuffer) {
-		if (!hasTwoSlots()) {
-			return readRange_SingleBuffer(offset, size);
-		} else {
-			return readRange_DoubleBuffer(offset, size);
-		}
-	} else if (clientBufferMode_ == SingleBuffer) {
+	} else if (singleBufferMode) {
 		// Single-buffered mode, we can only read from the first slot.
 		return readRange_SingleBuffer(offset, size);
 	} else { // clientBufferMode_ == DoubleBuffer

--- a/regen/memory/client-buffer.h
+++ b/regen/memory/client-buffer.h
@@ -144,7 +144,7 @@ namespace regen {
 		 * Returns the current read slot index.
 		 * @return the current read slot index (0 or 1).
 		 */
-		inline uint32_t currentReadSlot() const {
+		inline int32_t currentReadSlot() const {
 			return dataOwner_->lastDataSlot_.load(std::memory_order_acquire);
 		}
 
@@ -153,14 +153,14 @@ namespace regen {
 		 * This is the slot that will be written to next.
 		 * @return the current write slot index (0 or 1).
 		 */
-		inline uint32_t currentWriteSlot() const {
-			return hasTwoSlots() ? 1u - currentReadSlot() : 0u;
+		inline int32_t currentWriteSlot() const {
+			return (1 - currentReadSlot()) - static_cast<int32_t>(dataSlots_[1] == nullptr);
 		}
 
 		/**
 		 * Increment the stamp.
 		 */
-		void nextStamp(uint32_t slotIdx) const;
+		void nextStamp(int32_t writeSlot) const;
 
 		/**
 		 * Assigns a list of segments to this client buffer, replacing any existing segments.
@@ -335,7 +335,7 @@ namespace regen {
 
 		bool readLock_SingleBuffer() const;
 
-		void readUnlock(int slotIndex) const;
+		void readUnlock(int32_t slotIndex) const;
 
 		int writeLock_DoubleBuffer() const;
 
@@ -353,11 +353,11 @@ namespace regen {
 
 		void nextStamp() const;
 
-		bool isOwnerOfWriteLock(int dataSlot) const;
+		bool isOwnerOfWriteLock(int32_t dataSlot) const;
 
-		void setOwnerOfWriteLock(int dataSlot) const;
+		void setOwnerOfWriteLock(int32_t dataSlot) const;
 
-		void nextSegmentStamp(uint32_t dataSlot, uint32_t updatedOffset, uint32_t updateSize) const;
+		void nextSegmentStamp(int32_t dataSlot, uint32_t updatedOffset, uint32_t updateSize) const;
 
 		void createSecondSlot();
 

--- a/regen/memory/client-buffer.h
+++ b/regen/memory/client-buffer.h
@@ -305,6 +305,8 @@ namespace regen {
 		// Active slot for readers.
 		// Threads might read this concurrently, so we need atomic operations.
 		mutable std::atomic<int> lastDataSlot_{0};
+		// cached copy of lastDataSlot_ for writers to avoid repeated atomic loads in swap function.
+		int swapDataSlot_ = 0;
 		// Per-slot reader/writer count.
 		// Multiple readers are allowed, so we need atomic operations here.
 		// note: only the data owner manages the reader counts.

--- a/regen/memory/dirty-list.cpp
+++ b/regen/memory/dirty-list.cpp
@@ -12,6 +12,23 @@ void DirtyList::Range::merge(const Range& other) {
 	size = new_end - new_start;
 }
 
+void DirtyList::coalesce() {
+	// assume correct ordering, but elements may overlap
+	if (count_ < 2) return;
+	uint32_t write = 0;
+	for (uint32_t read = 1; read < count_; ++read) {
+		if (ranges_[write].end() == ranges_[read].offset) {
+			ranges_[write].size += ranges_[read].size;
+		} else {
+			++write;
+			if (write != read) {
+				ranges_[write] = ranges_[read];
+			}
+		}
+	}
+	count_ = write + 1;
+}
+
 void DirtyList::insert(uint32_t offset, uint32_t size) {
     const Range newRange{offset, size};
 

--- a/regen/memory/dirty-list.h
+++ b/regen/memory/dirty-list.h
@@ -93,6 +93,13 @@ namespace regen {
 		inline void clear() { count_ = 0; }
 
 		/**
+		 * Coalesce adjacent dirty ranges in the list.
+		 * This method merges ranges are directly adjacent
+		 * to reduce the number of dirty ranges.
+		 */
+		void coalesce();
+
+		/**
 		 * Insert a new dirty range into the list.
 		 * If the range overlaps with an existing range, it will be merged.
 		 * @param offset The offset in bytes from the start of the buffer.

--- a/regen/memory/dirty-list.h
+++ b/regen/memory/dirty-list.h
@@ -94,7 +94,7 @@ namespace regen {
 
 		/**
 		 * Coalesce adjacent dirty ranges in the list.
-		 * This method merges ranges are directly adjacent
+		 * This method merges ranges that are directly adjacent
 		 * to reduce the number of dirty ranges.
 		 */
 		void coalesce();

--- a/regen/objects/composite-mesh.cpp
+++ b/regen/objects/composite-mesh.cpp
@@ -362,6 +362,15 @@ ref_ptr<CompositeMesh> CompositeMesh::load(LoadingContext &ctx, scene::SceneInpu
 		}
 	}
 
+	// Set number of instances if requested
+	const uint32_t numInstances = input.getValue<uint32_t>("num-instances", 1u);
+	if (numInstances > 1u) {
+		for (auto &mesh: out->meshes()) {
+			mesh->set_numInstances(numInstances);
+			mesh->set_numVisibleInstances(numInstances);
+		}
+	}
+
 	// generate LOD levels if requested
 	if (input.hasAttribute("lod-simplification")) {
 		auto thresholds = input.getValue<Vec4f>(

--- a/regen/objects/composite-mesh.cpp
+++ b/regen/objects/composite-mesh.cpp
@@ -119,7 +119,7 @@ ref_ptr<CompositeMesh> CompositeMesh::load(LoadingContext &ctx, scene::SceneInpu
 		meshCfg.mapMode = mapMode;
 		meshCfg.accessMode = accessMode;
 		uint32_t numInstances = input.getValue<uint32_t>("num-instances", 1u);
-		auto blanket = ref_ptr<Blanket>::alloc(meshCfg, numInstances);
+		auto blanket = ref_ptr<Blanket>::alloc(meshCfg, numInstances, parser->systemTime());
 		blanket->updateAttributes();
 		(*out) = CompositeMesh();
 		out->addMesh(blanket);

--- a/regen/objects/mesh-processor.cpp
+++ b/regen/objects/mesh-processor.cpp
@@ -126,8 +126,16 @@ void MeshNodeProvider::processInput(
 					meshCopy->setSortMode(cullShape->instanceSortMode());
 				}
 			}
-		} else if (input.hasAttribute("update-visibility")) {
-			REGEN_WARN("Mesh '" << input.getDescription() << "' has no cull shape, but update-visibility is set.");
+		} else {
+			if (input.hasAttribute("update-visibility")) {
+				REGEN_WARN("Mesh '" << input.getDescription() << "' has no cull shape, but update-visibility is set.");
+			}
+			// If multi-layer rendering is used, we need to create an indirect draw buffer
+			// to replicate each LOD level for each layer.
+			auto cam = ref_ptr<Camera>::dynamicCast(parent->getParentCamera());
+			if (cam.get() && cam->numLayer() > 1) {
+				meshCopy->createIndirectDrawBuffer(cam->numLayer());
+			}
 		}
 
 		LoadingContext ctx(scene, parent);

--- a/regen/objects/mesh.cpp
+++ b/regen/objects/mesh.cpp
@@ -994,6 +994,10 @@ void Mesh::loadShaderConfig(LoadingContext &ctx, scene::SceneInputNode &input) {
 	} else if (input.hasAttribute("key")) {
 		setShaderKey(input.getValue<std::string>("key", shaderKey_));
 	}
+	if (input.hasAttribute("num-instances")) {
+		set_numInstances(input.getValue<int32_t>("num-instances", numInstances()));
+		set_numVisibleInstances(numInstances());
+	}
 	for (int i = 0; i < glenum::glslStageCount(); ++i) {
 		auto stage = glenum::glslStages()[i];
 		auto keyName = glenum::glslStagePrefix(stage);

--- a/regen/objects/primitives/blanket.cpp
+++ b/regen/objects/primitives/blanket.cpp
@@ -53,10 +53,20 @@ Blanket::Blanket(const BlanketConfig &cfg, uint32_t numInstances, const SystemTi
 		}
 	}
 	blanketLifetime_.resize(numInstances, cfg.isInitiallyDead ? 0.0f : 1.0f);
+
+	// create GL buffer for blanket data that is written per-frame but only for the few
+	// blankets that were inserted.
+	timeOfBirth_ = ref_ptr<ShaderInput1f>::alloc("timeOfBirth");
+	timeOfBirth_->setInstanceData(numBlankets_, 1, (byte*)blanketLifetime_.data());
+
+	blanketBuffer_ = ref_ptr<SSBO>::alloc("Blanket", BufferUpdateFlags::PARTIAL_PER_FRAME);
+	blanketBuffer_->addStagedInput(timeOfBirth_);
+	setInput(blanketBuffer_);
+
 	// expose max lifetime as shader input
-	auto sh_maxLife = ref_ptr<ShaderInput1f>::alloc("maxLifetime");
-	sh_maxLife->setUniformData(blanketLifetimeMax_);
-	setInput(sh_maxLife);
+	auto maxLife = ref_ptr<ShaderInput1f>::alloc("maxLifetime");
+	maxLife->setUniformData(blanketLifetimeMax_);
+	setInput(maxLife);
 }
 
 void Blanket::updateAttributes() {
@@ -70,9 +80,6 @@ void Blanket::updateAttributes() {
 		}
 	}
 
-	timeOfBirth_ = ref_ptr<ShaderInput1f>::alloc("timeOfBirth");
-	timeOfBirth_->setInstanceData(numBlankets_, 1, (byte*)blanketLifetime_.data());
-	setInput(timeOfBirth_);
 	if (blanketLifetimeMax_ > 0.0f) {
 		lifetimeAnimation_ = ref_ptr<BlanketLifetimeAnimation>::alloc(this);
 		lifetimeAnimation_->startAnimation();

--- a/regen/objects/primitives/blanket.cpp
+++ b/regen/objects/primitives/blanket.cpp
@@ -39,12 +39,13 @@ namespace regen {
 	};
 }
 
-Blanket::Blanket(const BlanketConfig &cfg, uint32_t numInstances)
+Blanket::Blanket(const BlanketConfig &cfg, uint32_t numInstances, const SystemTime &systemTime)
 		: Rectangle(getRectangleConfig(cfg)),
           numBlankets_(numInstances),
 		  blanketLifetimeMax_(cfg.blanketLifetime) {
 	numDeadBlankets_ = cfg.isInitiallyDead ? numInstances : 0;
 	deadBlankets_.resize(numInstances);
+	systemTime_ = &systemTime;
 	for (uint32_t i = 0; i < numInstances; ++i) {
 		deadBlankets_[i] = i;
 		if (cfg.isInitiallyDead && hasIndexedShapes()) {
@@ -52,6 +53,10 @@ Blanket::Blanket(const BlanketConfig &cfg, uint32_t numInstances)
 		}
 	}
 	blanketLifetime_.resize(numInstances, cfg.isInitiallyDead ? 0.0f : 1.0f);
+	// expose max lifetime as shader input
+	auto sh_maxLife = ref_ptr<ShaderInput1f>::alloc("maxLifetime");
+	sh_maxLife->setUniformData(blanketLifetimeMax_);
+	setInput(sh_maxLife);
 }
 
 void Blanket::updateAttributes() {
@@ -65,9 +70,9 @@ void Blanket::updateAttributes() {
 		}
 	}
 
-	sh_blanketLifetime_ = ref_ptr<ShaderInput1f>::alloc("blanketLifetime");
-	sh_blanketLifetime_->setInstanceData(numBlankets_, 1, (byte*)blanketLifetime_.data());
-	setInput(sh_blanketLifetime_);
+	timeOfBirth_ = ref_ptr<ShaderInput1f>::alloc("timeOfBirth");
+	timeOfBirth_->setInstanceData(numBlankets_, 1, (byte*)blanketLifetime_.data());
+	setInput(timeOfBirth_);
 	if (blanketLifetimeMax_ > 0.0f) {
 		lifetimeAnimation_ = ref_ptr<BlanketLifetimeAnimation>::alloc(this);
 		lifetimeAnimation_->startAnimation();
@@ -92,8 +97,6 @@ void Blanket::updateLifetime(float deltaSeconds) {
 			}
 		}
 	}
-	auto lifetimeData = sh_blanketLifetime_->mapClientDataRaw(BUFFER_GPU_WRITE);
-	std::memcpy(lifetimeData.w, blanketLifetime_.data(), sizeof(float) * numBlankets_);
 }
 
 uint32_t Blanket::reviveBlanket() {
@@ -104,6 +107,11 @@ uint32_t Blanket::reviveBlanket() {
 		--numDeadBlankets_;
 		auto idx = deadBlankets_[numDeadBlankets_];
 		blanketLifetime_[idx] = 1.0f;
+
+		const boost::posix_time::ptime &currentTime = systemTime_->p_time;
+		static constexpr float timeScale = 1.0f / 1e+6f;
+		timeOfBirth_->setVertex(idx, currentTime.time_of_day().total_microseconds() * timeScale);
+
 		// reset traversal mask
 		if (!indexedShapes_->empty()) {
 			indexedShape(idx)->setTraversalMask(blanketTraversalMask_);

--- a/regen/objects/primitives/blanket.h
+++ b/regen/objects/primitives/blanket.h
@@ -68,12 +68,14 @@ namespace regen {
 		uint32_t numBlankets_;
 		uint32_t numDeadBlankets_ = 0;
 		float blanketLifetimeMax_;
-		ref_ptr<ShaderInput1f> timeOfBirth_;
 		std::vector<uint32_t> deadBlankets_;
 		std::vector<float> blanketLifetime_;
 		uint32_t blanketTraversalMask_;
 		ref_ptr<Animation> lifetimeAnimation_;
 		const SystemTime *systemTime_ = nullptr;
+
+		ref_ptr<BufferBlock> blanketBuffer_;
+		ref_ptr<ShaderInput1f> timeOfBirth_;
 	};
 } // namespace
 

--- a/regen/objects/primitives/blanket.h
+++ b/regen/objects/primitives/blanket.h
@@ -44,7 +44,9 @@ namespace regen {
 		 * @param cfg the blanket configuration.
 		 * @param numInstances the number of blanket instances.
 		 */
-		explicit Blanket(const BlanketConfig &cfg, uint32_t numInstances);
+		Blanket(const BlanketConfig &cfg,
+			uint32_t numInstances,
+			const SystemTime &systemTime);
 
 		/**
 		 * Revive a dead blanket instance, returning its index
@@ -66,11 +68,12 @@ namespace regen {
 		uint32_t numBlankets_;
 		uint32_t numDeadBlankets_ = 0;
 		float blanketLifetimeMax_;
-		ref_ptr<ShaderInput1f> sh_blanketLifetime_;
+		ref_ptr<ShaderInput1f> timeOfBirth_;
 		std::vector<uint32_t> deadBlankets_;
 		std::vector<float> blanketLifetime_;
 		uint32_t blanketTraversalMask_;
 		ref_ptr<Animation> lifetimeAnimation_;
+		const SystemTime *systemTime_ = nullptr;
 	};
 } // namespace
 

--- a/regen/objects/terrain/blanket-trail.cpp
+++ b/regen/objects/terrain/blanket-trail.cpp
@@ -41,7 +41,7 @@ void BlanketTrail::setBlanketMask(const ref_ptr<Texture> &tex) {
 		maskIndex_.resize(numBlankets_, 0);
 		u_maskIndex_ = ref_ptr<ShaderInput1ui>::alloc("maskIndex");
 		u_maskIndex_->setInstanceData(numBlankets_, 1, (byte*)maskIndex_.data());
-		setInput(u_maskIndex_);
+		blanketBuffer_->addStagedInput(u_maskIndex_);
 	} else {
 		maskIndex_.clear();
 		u_maskIndex_ = {};

--- a/regen/objects/terrain/blanket-trail.cpp
+++ b/regen/objects/terrain/blanket-trail.cpp
@@ -16,11 +16,14 @@ static uint32_t computeMaxInstances(const BlanketTrail::TrailConfig &cfg) {
 }
 
 BlanketTrail::BlanketTrail(
-	const ref_ptr<Ground> &groundMesh,
-	const TrailConfig &cfg) : Blanket(cfg, computeMaxInstances(cfg)) {
+		const ref_ptr<Ground> &groundMesh,
+		const TrailConfig &cfg,
+		const SystemTime &systemTime)
+		: Blanket(cfg, computeMaxInstances(cfg), systemTime),
+		  tmpMat_(Mat4f::identity()) {
 	groundMesh_ = groundMesh;
 	insertHeight_ = groundMesh_->mapCenter()->getVertex(0).r.y -
-			0.5f*groundMesh_->mapSize()->getVertex(0).r.y;
+	                0.5f * groundMesh_->mapSize()->getVertex(0).r.y;
 }
 
 void BlanketTrail::setBlanketMask(const ref_ptr<Texture> &tex) {
@@ -129,7 +132,7 @@ ref_ptr<BlanketTrail> BlanketTrail::load(LoadingContext &ctx,
 	meshCfg.accessMode = input.getValue<ClientAccessMode>("access-mode", BUFFER_CPU_WRITE);
 	meshCfg.numTrails = input.getValue<uint32_t>("blanket-trails", 1u);
 	meshCfg.blanketFrequency = input.getValue<float>("blanket-frequency", 0.5f);
-	auto blanket = ref_ptr<BlanketTrail>::alloc(groundMesh, meshCfg);
+	auto blanket = ref_ptr<BlanketTrail>::alloc(groundMesh, meshCfg, scene->systemTime());
 
 	// early add mesh vector to scene for children handling below
 	auto out_ = ref_ptr<CompositeMesh>::alloc();

--- a/regen/objects/terrain/blanket-trail.h
+++ b/regen/objects/terrain/blanket-trail.h
@@ -36,7 +36,8 @@ namespace regen {
 		 */
 		BlanketTrail(
 			const ref_ptr<Ground> &groundMesh,
-			const TrailConfig &cfg);
+			const TrailConfig &cfg,
+			const SystemTime &systemTime);
 
 		/**
 		 * Assigns a blanket mask texture.

--- a/regen/scene/scene-loader.h
+++ b/regen/scene/scene-loader.h
@@ -77,6 +77,16 @@ namespace regen::scene {
 		const ref_ptr<ShaderInput2f> &getMouseTexco() const;
 
 		/**
+		 * @return The world time.
+		 */
+		const WorldTime& worldTime() const { return application()->worldTime(); }
+
+		/**
+		 * @return The system time.
+		 */
+		const SystemTime& systemTime() const { return application()->systemTime(); }
+
+		/**
 		 * @return The world model.
 		 */
 		ref_ptr<WorldModel> worldModel() const { return worldModel_; }

--- a/regen/scene/scene.h
+++ b/regen/scene/scene.h
@@ -310,14 +310,14 @@ namespace regen {
 		void updateTime();
 
 		/**
-		 * @return the world time uniform. time in seconds.
+		 * @return the world time.
 		 */
-		auto &worldTime() const { return worldTime_; }
+		const WorldTime &worldTime() const { return worldTime_; }
 
 		/**
-		 * @return the time of last frame.
+		 * @return the system time.
 		 */
-		auto &lastTime() const { return lastTime_; }
+		const SystemTime &systemTime() const { return systemTime_; }
 
 		/**
 		 * Sets the world time scale.
@@ -387,15 +387,14 @@ namespace regen {
 		ref_ptr<ShaderInput2f> mousePosition_;
 		ref_ptr<ShaderInput2f> mouseTexco_;
 		ref_ptr<ShaderInput1f> mouseDepth_;
-		ref_ptr<ShaderInput1f> timeSeconds_;
 		ref_ptr<ShaderInput1f> timeDelta_;
 		ref_ptr<UBO> globalUniforms_;
 
 		ref_ptr<WorldModel> worldModel_;
 
 		boost::posix_time::ptime lastMotionTime_;
-		boost::posix_time::ptime lastTime_;
 		WorldTime worldTime_;
+		SystemTime systemTime_;
 
 		bool isGLInitialized_;
 		bool isTimeInitialized_;

--- a/regen/shader/regen/terrain/ground.glsl
+++ b/regen/shader/regen/terrain/ground.glsl
@@ -331,8 +331,9 @@ void main() {
     vec2 maskUV = in_texco0;
     #endif
     float blanketMaskVal = texture(in_blanketMask, maskUV).r;
-    #ifdef HAS_blanketLifetime
-    blanketMaskVal *= in_blanketLifetime;
+    #ifdef HAS_timeOfBirth
+    const float lifetime = in_time - in_timeOfBirth;
+    blanketMaskVal *= max(1.0 - lifetime / in_maxLifetime, 0.0);
     #endif
     out_collision = blanketMaskVal;
 }

--- a/regen/shader/shader.cpp
+++ b/regen/shader/shader.cpp
@@ -663,10 +663,10 @@ void Shader::enable(RenderState *) {
 		if (uniform.input->isBufferBlock()) {
 			// enable buffer block
 			uniform.input->enableUniform(uniform.location);
-		} else if (uniform.input->stampOfReadData() != uniform.uploadStamp) {
+		} else if (const uint32_t inputStamp = uniform.input->stampOfReadData(); inputStamp != uniform.uploadStamp) {
 			// enable uniform
 			uniform.input->enableUniform(uniform.location);
-			uniform.uploadStamp = uniform.input->stampOfReadData();
+			uniform.uploadStamp = inputStamp;
 		}
 	}
 }

--- a/regen/shading/light-pass.cpp
+++ b/regen/shading/light-pass.cpp
@@ -214,9 +214,10 @@ void LightPass::enable(RenderState *rs) {
 		}
 		// enable light pass uniforms
 		for (auto &inputLocation: l.inputLocations) {
-			if (lights_.size() > 1 || inputLocation.uploadStamp != inputLocation.input->stampOfReadData()) {
+			const uint32_t inputStamp = inputLocation.input->stampOfReadData();
+			if (lights_.size() > 1 || inputLocation.uploadStamp != inputStamp) {
 				inputLocation.input->enableUniform(inputLocation.location);
-				inputLocation.uploadStamp = inputLocation.input->stampOfReadData();
+				inputLocation.uploadStamp = inputStamp;
 			}
 		}
 

--- a/regen/shading/light-state.cpp
+++ b/regen/shading/light-state.cpp
@@ -75,9 +75,7 @@ void Light::setConeAngles(float inner, float outer) {
 }
 
 bool Light::updateConeMatrix() {
-	uint32_t stamp = std::max(lightRadius_->stampOfReadData(),
-			std::max(lightDirection_->stampOfReadData(),
-			std::max(lightConeAngles_->stampOfReadData(), lightPosition_->stampOfReadData())));
+	const uint32_t stamp = lightBuffer_->stampOfReadData();
 	if (lightConeStamp_ == stamp) return false; // no update needed
 
 	// Note: cone opens in positive z direction.

--- a/regen/shapes/bounding-shape.cpp
+++ b/regen/shapes/bounding-shape.cpp
@@ -13,7 +13,7 @@ BoundingShape::BoundingShape(BoundingShapeType shapeType)
 		: shapeType_(shapeType),
 		  useLocalStamp_(false),
 		  lastGeometryStamp_(0u) {
-	localStamp_.store(0u);
+	localStamp_.store(0u, std::memory_order_relaxed);
 	updateStampFunction();
 }
 

--- a/regen/shapes/bounding-shape.h
+++ b/regen/shapes/bounding-shape.h
@@ -87,7 +87,7 @@ namespace regen {
 		 * Advance the local stamp by one.
 		 * This is used when no ModelTransformation is set and the local transform is used
 		 */
-		void nextLocalStamp() { localStamp_ += 1u; }
+		void nextLocalStamp() { localStamp_.fetch_add(1u, std::memory_order_relaxed); }
 
 		/**
 		 * Set the bitmask used to skip the shape during traversal.

--- a/regen/shapes/orthogonal-projection.cpp
+++ b/regen/shapes/orthogonal-projection.cpp
@@ -106,21 +106,25 @@ void OrthogonalProjection::createRectangle_AABB(const BoundingShape &box) {
 	auto &aabb = static_cast<const AABB&>(box);
 	auto &batchData = aabb.globalBatchData_t();
 	const uint32_t batchIdx = aabb.globalIndex();
+	float* __restrict minX = batchData.minX().data();
+	float* __restrict minZ = batchData.minZ().data();
+	float* __restrict maxX = batchData.maxX().data();
+	float* __restrict maxZ = batchData.maxZ().data();
 	type = RECTANGLE;
 	// generate the 4 corners of the box in the xz-plane.
 	points.resize(4);
 	// bottom-left
-	points[0].x = batchData.minX()[batchIdx];
-	points[0].y = batchData.minZ()[batchIdx];
+	points[0].x = minX[batchIdx];
+	points[0].y = minZ[batchIdx];
 	// bottom-right
-	points[1].x = batchData.maxX()[batchIdx];
-	points[1].y = batchData.minZ()[batchIdx];
+	points[1].x = maxX[batchIdx];
+	points[1].y = minZ[batchIdx];
 	// top-right
-	points[2].x = batchData.maxX()[batchIdx];
-	points[2].y = batchData.maxZ()[batchIdx];
+	points[2].x = maxX[batchIdx];
+	points[2].y = maxZ[batchIdx];
 	// top-left
-	points[3].x = batchData.minX()[batchIdx];
-	points[3].y = batchData.maxZ()[batchIdx];
+	points[3].x = minX[batchIdx];
+	points[3].y = maxZ[batchIdx];
 	// axes of the rectangle (and quad)
 	axes[2].dir = perpendicular(points[1] - points[0]);
 	axes[3].dir = perpendicular(points[3] - points[0]);

--- a/regen/simulation/boids-cpu.cpp
+++ b/regen/simulation/boids-cpu.cpp
@@ -470,8 +470,9 @@ void BoidsCPU::clearGrid() {
 	// update the grid based on gridBounds_, creating a cell every `2.0*(visual range)` in all directions.
 	BoidSimulation::updateGridSize();
 
-	if (priv_->gridStamp_ != gridSize_->stampOfReadData()) {
-		priv_->gridStamp_ = gridSize_->stampOfReadData();
+	const uint32_t gridStamp = gridSize_->stampOfReadData();
+	if (priv_->gridStamp_ != gridStamp) {
+		priv_->gridStamp_ = gridStamp;
 		auto gridSize = gridSize_->getVertex(0).r;
 		priv_->gridSize_.x = static_cast<int>(gridSize.x);
 		priv_->gridSize_.y = static_cast<int>(gridSize.y);

--- a/regen/simulation/boids-gpu.cpp
+++ b/regen/simulation/boids-gpu.cpp
@@ -305,12 +305,13 @@ void BoidsGPU::gpuUpdate(RenderState *rs, double dt) {
 		bboxPass_->enable(rs);
 		bboxPass_->disable(rs);
 		// update the grid in case the bounding box around the boids changed.
-		if(bboxBuffer_->updateBoundingBox() || vrStamp_ != visualRange_->stampOfReadData()) {
+		const uint32_t vrStamp = visualRange_->stampOfReadData();
+		if(bboxBuffer_->updateBoundingBox() || vrStamp_ != vrStamp) {
 			auto &newBounds = bboxBuffer_->bbox();
 			if (newBounds.max != newBounds.min) {
 				boidBounds_ = newBounds;
 				updateGrid();
-				vrStamp_ = visualRange_->stampOfReadData();
+				vrStamp_ = vrStamp;
 			}
 		}
 #ifdef BOID_DEBUG_BBOX_TIME

--- a/regen/simulation/model-matrix-motion.cpp
+++ b/regen/simulation/model-matrix-motion.cpp
@@ -36,8 +36,9 @@ ModelMatrixUpdater::~ModelMatrixUpdater() {
 }
 
 void ModelMatrixUpdater::cpuUpdate(double dt) {
-	if (stamp_ == tf_->modelMat()->stampOfReadData()) return;
-	stamp_ = tf_->modelMat()->stampOfReadData();
+	const uint32_t stamp = tf_->modelMat()->stampOfReadData();
+	if (stamp_ == stamp) return;
+	stamp_ = stamp;
 	auto regenData = tf_->modelMat()->mapClientDataRaw(BUFFER_GPU_WRITE);
 	std::memcpy(regenData.w, backBuffer_, tf_->modelMat()->inputSize());
 }

--- a/regen/utility/time.h
+++ b/regen/utility/time.h
@@ -5,10 +5,29 @@
 #include "regen/shader/shader-input.h"
 
 namespace regen {
+	/**
+	 * \brief World time structure.
+	 *
+	 * This structure holds the world time information,
+	 * including the current time and a shader input
+	 * that can be used in shaders.
+	 */
 	struct WorldTime {
 		boost::posix_time::ptime p_time;
 		ref_ptr<ShaderInput1f> in;
 		double scale = 1.0;
+	};
+
+	/**
+	 * \brief System time structure.
+	 *
+	 * This structure holds the system time information,
+	 * including the current time and a shader input
+	 * that can be used in shaders.
+	 */
+	struct SystemTime {
+		boost::posix_time::ptime p_time;
+		ref_ptr<ShaderInput1f> in;
 	};
 }
 


### PR DESCRIPTION
This PR improves the use of atomic operations throughout the codebase, focusing on performance optimizations through better memory ordering, reduced redundant atomic loads, and improved cache efficiency. The changes also refactor time management by introducing separate SystemTime and WorldTime structures.

- Optimized atomic operations by caching stamp values to avoid redundant atomic loads in hot paths
- Improved memory ordering semantics with explicit `memory_order_relaxed` and `memory_order_release` usage
- Refactored time management with distinct SystemTime and WorldTime structures for clearer separation of concerns