### PR TITLE
Introduced example case for ML data generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,8 @@ jobs:
             libavcodec-dev libavformat-dev libavutil-dev libswscale-dev \
             libpng-dev libalut-dev \
             qtbase5-dev libgtest-dev \
-            doxygen graphviz
+            doxygen graphviz \
+            nlohmann-json3-dev
         mkdir build
         cd build
         cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DBUILD_VIDEO_PLAYER=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,9 @@ find_package(Boost ${Boost_MIN_VERSION}
 find_package(Threads REQUIRED)
 # Font library: text rendering support
 find_package(Freetype REQUIRED)
+# JSON library: for serialization
+find_package(nlohmann_json REQUIRED)
+set(JSON_LIBRARIES nlohmann_json::nlohmann_json)
 
 # Image loading libraries: required for loading textures from files
 find_package(PNG REQUIRED)
@@ -158,6 +161,7 @@ message(STATUS "regen will link against following libraries:")
 message(STATUS "  OpenGL: ${OPENGL_LIBRARIES};")
 message(STATUS "  glew: ${GLEW_LIBRARIES};")
 message(STATUS "  Boost: ${Boost_LIBRARIES};")
+message(STATUS "  JSON: ${JSON_LIBRARIES};")
 message(STATUS "  Fonts: ${FREETYPE_LIBRARIES};")
 message(STATUS "  Images: ${IMG_LIBRARIES};")
 message(STATUS "  Audio+Video: ${AV_LIBRARIES};")
@@ -193,6 +197,7 @@ set(REGEN_LIBRARIES
     ${OPENGL_LIBRARIES}
     ${GLEW_LIBRARIES}
     ${Boost_LIBRARIES}
+    ${JSON_LIBRARIES}
     ${ASSIMP_LIBRARIES}
     ${FREETYPE_LIBRARIES} -lbrotlidec
     ${IMG_LIBRARIES}

--- a/applications/qt/ColorWidget.cpp
+++ b/applications/qt/ColorWidget.cpp
@@ -54,7 +54,7 @@ QColor ColorWidget::initializeColor() {
 void ColorWidget::updateColor(const QColor &color) {
 	// Update the shader input
 	uint32_t count = input_->valsPerElement();
-	byte *changedData = new byte[input_->elementSize()];
+	byte *changedData = new byte[input_->vertexSize()];
 	if (input_->baseType() == GL_FLOAT) {
 		((float *) changedData)[0] = color.redF();
 		((float *) changedData)[1] = color.greenF();

--- a/applications/qt/shader-input-widget.cpp
+++ b/applications/qt/shader-input-widget.cpp
@@ -43,8 +43,8 @@ void ShaderInputWidget::updateInitialValue(ShaderInput *x) {
 		// last time value was not changed from widget
 		// update initial data
 		auto clientData = x->mapClientDataRaw(BUFFER_GPU_READ);
-		byte *initialValue = new byte[x->elementSize()];
-		memcpy(initialValue, clientData.r, x->elementSize());
+		byte *initialValue = new byte[x->vertexSize()];
+		memcpy(initialValue, clientData.r, x->vertexSize());
 
 		byte *oldInitial = initialValue_[x];
 		delete[]oldInitial;
@@ -383,8 +383,8 @@ bool ShaderInputWidget::addParameter(
 		delete[]lastValue;
 	}
 	auto clientData = in->mapClientDataRaw(BUFFER_GPU_READ);
-	byte *initialValue = new byte[in->elementSize()];
-	memcpy(initialValue, clientData.r, in->elementSize());
+	byte *initialValue = new byte[in->vertexSize()];
+	memcpy(initialValue, clientData.r, in->vertexSize());
 	clientData.unmap();
 	initialValue_[in.get()] = initialValue;
 	initialValueStamp_[in.get()] = in->stampOfReadData();

--- a/applications/scene-display/examples/compute/bonsai-input-data.py
+++ b/applications/scene-display/examples/compute/bonsai-input-data.py
@@ -1,0 +1,35 @@
+# Generate a sequence of input data samples for Bonsai volume rendering.
+# Each input is (1) ray origin, a point on sphere of radius 1 centered at (0,0,0),
+# and (2) ray direction, a unit vector pointing into the sphere.
+import numpy as np
+
+# Assuming we only need a small network for modeling the function
+# we might get away with 500k - 1M training samples.
+NUM_SAMPLES = 500000
+RADIUS = 1.0
+ray_origins = []
+ray_directions = []
+
+def compute_sphere_point(radius):
+	theta = np.arccos(1 - 2 * np.random.rand())  # polar angle
+	phi = 2 * np.pi * np.random.rand()           # azimuthal angle
+	x = radius * np.sin(theta) * np.cos(phi)
+	y = radius * np.sin(theta) * np.sin(phi)
+	z = radius * np.cos(theta)
+	return np.array([x, y, z])
+
+for _ in range(NUM_SAMPLES):
+	# Generate a random point on the sphere surface for ray origin
+	ray_origin = compute_sphere_point(RADIUS)
+	ray_origins.append(ray_origin)
+
+	# Generate a second random point on the sphere surface for ray direction
+	ray_direction = compute_sphere_point(RADIUS) - ray_origin
+	ray_direction /= np.linalg.norm(ray_direction)  # Normalize to unit vector
+	ray_directions.append(ray_direction)
+
+ray_origins = np.array(ray_origins, dtype=np.float32)
+ray_directions = np.array(ray_directions, dtype=np.float32)
+
+ray_origins.tofile("rayOrigin.bin")
+ray_directions.tofile("rayDirection.bin")

--- a/applications/scene-display/examples/compute/bonsai-training-data.xml
+++ b/applications/scene-display/examples/compute/bonsai-training-data.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <node>
+    <constant name="numSamples" value="500000"/>
+
     <gui-config ego-camera="0"
                 look-at-camera="1"
                 look-at="0.0,0.0,0.0"
@@ -129,18 +131,14 @@
 
     <block type="ssbo" id="ComputeInput">
         <!-- generate random ray origins and destinations within a unit cube -->
-        <input name="rayOrigin" type="vec4" num-elements="256" value="0.0,0.0,0.0,0.0">
-            <set mode="random" min="-1.0,-1.0,-1.0,0.0" max="1.0,1.0,1.0,0.0" />
-        </input>
-        <input name="rayDestination" type="vec4" num-elements="256" value="0.0,0.0,0.0,0.0">
-            <set mode="random" min="-1.0,-1.0,-1.0,0.0" max="1.0,1.0,1.0,0.0" />
-        </input>
+        <input name="rayOrigin" type="vec3" num-elements="{{numSamples}}" layout="std430" data-file="data/hdr/rayOrigin.bin" />
+        <input name="rayDirection" type="vec3" num-elements="{{numSamples}}" layout="std430" data-file="data/hdr/rayDirection.bin" />
     </block>
 
     <block type="ssbo" id="ComputeOutput">
-        <input name="position" type="vec4"  num-elements="256" value="0.0,0.0,0.0,0.0" />
-        <input name="normal"   type="vec4"  num-elements="256" value="0.0,1.0,0.0,0.0" />
-        <input name="density"  type="float" num-elements="256" value="0.0" />
+        <input name="position" type="vec3"  num-elements="{{numSamples}}" layout="std430" value="0.0,0.0,0.0" />
+        <input name="normal"   type="vec3"  num-elements="{{numSamples}}" layout="std430" value="0.0,1.0,0.0" />
+        <input name="density"  type="float" num-elements="{{numSamples}}" layout="std430" value="0.0" />
     </block>
 
     <node id="initialize">
@@ -157,7 +155,7 @@
 
             <compute
                 shader="regen.objects.volume.neural.training-data"
-                work-units="256,1,1" group-size="256,1,1" />
+                work-units="{{numSamples}},1,1" group-size="256,1,1" />
         </node>
         <node>
             <barrier bit="CLIENT_MAPPED_BUFFER" />

--- a/applications/scene-display/examples/compute/training-data-bonsai.xml
+++ b/applications/scene-display/examples/compute/training-data-bonsai.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<node>
+    <gui-config ego-camera="0"
+                look-at-camera="1"
+                look-at="0.0,0.0,0.0"
+                look-at-height="0.0"
+                look-at-radius="2.0"
+                look-at-degree="0.0"
+                look-at-step="0.001"
+                look-at-scroll-step="0.05"
+                look-at-step-x="0.02"
+                look-at-step-y="0.001"
+                look-at-interval="10"
+    />
+    <node id="configuration">
+        <controller camera="main-camera" type="key-frames" interpolation="quadratic" dt="3.0" ease-in-out="0.0">
+            <key-frame pos=" 0.0, 0.0,  4.0" dir=" 0.0,  0.0, -2.0" dt="0.0"/>
+            <key-frame pos=" 4.0, 0.5, 0.0" dir="-2.0,-0.5, 0.0"/>
+            <key-frame pos=" 0.0, 0.5,-4.0" dir=" 0.0,-0.5, 2.0"/>
+            <key-frame pos="-4.0, 0.0,  0.0" dir=" 2.0, 0.0, 0.0"/>
+
+            <key-frame pos=" 0.0,  0.0,  4.0" dir=" 0.0,  0.0,-2.0"/>
+            <key-frame pos=" 4.0, -0.5, 0.0" dir="-2.0, 0.5, 0.0"/>
+            <key-frame pos=" 0.0, -0.5,-4.0" dir=" 0.0, 0.5, 2.0"/>
+            <key-frame pos="-4.0,  0.0,  0.0" dir=" 2.0,  0.0, 0.0"/>
+            <key-frame pos=" 0.0,  0.0,  4.0" dir=" 0.0,  0.0,-2.0"/>
+        </controller>
+    </node>
+
+    <include xml-file="scene-display/examples/templates/default.xml"/>
+
+    <!-- Framebuffer -->
+    <fbo id="buffer-float" size-mode="rel" size="1,1"
+         pixel-type="FLOAT" pixel-size="16">
+        <texture id="color0" pixel-components="3"/>
+        <texture id="color1" pixel-components="3"/>
+    </fbo>
+    <fbo id="g-buffer"
+         size-mode="rel" size="1.0,1.0"
+         pixel-type="UNSIGNED_BYTE"
+         pixel-size="16"
+         pixel-components="4">
+        <texture id="diffuse"/>
+        <texture id="tmp"/>
+        <texture id="specular"/>
+        <texture id="normal"/>
+        <depth id="depth" pixel-size="24"/>
+    </fbo>
+    <!-- Textures -->
+    <texture id="sky-texture"
+             is-cube="1" cube-flip-back="1"
+             file="res/textures/cube-maps/grace.hdr"
+             mipmap="1"
+             wrapping="CLAMP_TO_EDGE"
+             internal-format="R11F_G11F_B10F"
+             aniso="2.0"/>
+    <!-- Cameras -->
+    <camera id="main-camera"
+            fov="45.0" near="0.1" far="200.0"
+            position="0.0,0.0,-2.0"
+            direction="0.0,0.0,1.0"/>
+    <!-- Meshes -->
+    <mesh id="sky-box"
+          type="box"
+          use-normal="0"
+          use-tangent="0"
+          texco-mode="CUBE_MAP"
+          update-frequency="NEVER"/>
+
+    <!--**************************-->
+    <!--**************************-->
+
+    <texture id="bonsai-transfer"
+             file="res/textures/volumes/bonsai-transfer.png"/>
+
+    <texture id="bonsai-volume"
+             file="res/textures/volumes/bonsai.raw"
+             is-raw="1"
+             raw-size="256,256,256"
+             raw-components="1"
+             raw-bytes="8"
+             wrapping="CLAMP_TO_EDGE"/>
+
+    <mesh id="bonsai-mesh"
+          type="box"
+          scaling="0.8, 0.8, 0.8"
+          use-normal="0"
+          use-tangent="0"
+          texco-mode="NONE"
+          update-frequency="NEVER">
+        <material emission="0.05,0.1,0.05" update-frequency="NEVER"/>
+    </mesh>
+
+    <node id="Scene-Objects">
+        <transform update-frequency="NEVER"/>
+        <node id="Bonsai">
+            <!-- <define key="DEPTH_CORRECT" value="TRUE"/> -->
+            <!-- <define key="RAY_CAST_JITTER" value="TRUE"/> -->
+            <!-- <define key="DENSITY_ALPHA" value="TRUE"/> -->
+            <alpha discard-threshold="0.25"/>
+            <define key="RAY_CASTING_MODE" value="FIRST_MAXIMUM"/>
+            <define key="SWITCH_VOLUME_Y" value="FALSE"/>
+            <cull mode="front"/>
+            <input type="float" name="rayStep" value="0.01"/>
+            <input type="float" name="densityThreshold" value="0.175"/>
+            <input type="float" name="densityScale" value="1.0"/>
+            <input type="vec3" name="halfVolumeSize" value="0.8, 0.8, 0.8"/>
+            <texture name="transferTexture" id="bonsai-transfer"/>
+            <texture name="volumeTexture" id="bonsai-volume"/>
+            <mesh id="bonsai-mesh" shader="regen.objects.volume"/>
+        </node>
+    </node>
+
+    <!--**************************-->
+    <!--**************************-->
+
+    <node id="Background">
+        <define key="IGNORE_VIEW_TRANSLATION" value="TRUE"/>
+
+        <cull mode="front"/>
+        <depth function="LEQUAL"/>
+        <texture id="sky-texture" map-to="COLOR"/>
+        <mesh id="sky-box" shader="regen.objects.sky-box"/>
+    </node>
+
+    <!--**************************-->
+    <!--**************************-->
+
+    <block type="ssbo" id="ComputeInput">
+        <!-- generate random ray origins and destinations within a unit cube -->
+        <input name="rayOrigin" type="vec4" num-elements="256" value="0.0,0.0,0.0,0.0">
+            <set mode="random" min="-1.0,-1.0,-1.0,0.0" max="1.0,1.0,1.0,0.0" />
+        </input>
+        <input name="rayDestination" type="vec4" num-elements="256" value="0.0,0.0,0.0,0.0">
+            <set mode="random" min="-1.0,-1.0,-1.0,0.0" max="1.0,1.0,1.0,0.0" />
+        </input>
+    </block>
+
+    <block type="ssbo" id="ComputeOutput">
+        <input name="position" type="vec4"  num-elements="256" value="0.0,0.0,0.0,0.0" />
+        <input name="normal"   type="vec4"  num-elements="256" value="0.0,1.0,0.0,0.0" />
+        <input name="density"  type="float" num-elements="256" value="0.0" />
+    </block>
+
+    <node id="initialize">
+        <node>
+            <barrier bit="SHADER_STORAGE"/>
+            <input name="InputData" ssbo="ComputeInput"/>
+            <input name="OutputData" ssbo="ComputeOutput"/>
+
+            <input type="float" name="rayStep" value="0.01"/>
+            <input type="float" name="densityThreshold" value="0.175"/>
+            <input type="float" name="densityScale" value="1.0"/>
+            <input type="vec3" name="halfVolumeSize" value="0.8, 0.8, 0.8"/>
+            <texture name="volumeTexture" id="bonsai-volume"/>
+
+            <compute
+                shader="regen.objects.volume.neural.training-data"
+                work-units="256,1,1" group-size="256,1,1" />
+        </node>
+        <node>
+            <barrier bit="CLIENT_MAPPED_BUFFER" />
+            <data-export buffer-id="ComputeInput" gpu-export="0"
+                export-path="export/hdr/compute/in" />
+            <data-export buffer-id="ComputeOutput" gpu-export="1"
+                export-path="export/hdr/compute/out" />
+        </node>
+    </node>
+
+    <node id="root">
+        <fbo id="buffer-float" clear-buffers="0" draw-buffers="0"/>
+        <camera id="main-camera"/>
+
+        <node import="Background"/>
+        <node import="Scene-Objects"/>
+
+        <node import="GUI-Pass">
+            <fbo id="buffer-float" draw-buffers="0"/>
+        </node>
+
+        <view id="Result">
+            <blit src-fbo="buffer-float" src-attachment="0" dst-fbo="SCREEN"/>
+        </view>
+    </node>
+</node>

--- a/applications/scene-display/examples/hdr.xml
+++ b/applications/scene-display/examples/hdr.xml
@@ -15,7 +15,7 @@
     />
     <node id="configuration">
         <controller camera="main-camera" type="key-frames" interpolation="quadratic" dt="3.0" ease-in-out="0.0">
-            <key-frame pos=" 0.0, 0.0,  2.0" dir=" 0.0,  0.0,-2.0" dt="0.0"/>
+            <key-frame pos=" 0.0, 0.0,  2.0" dir=" 0.0,  0.0, -2.0" dt="0.0"/>
             <key-frame pos=" 2.0, 0.5, 0.0" dir="-2.0,-0.5, 0.0"/>
             <key-frame pos=" 0.0, 0.5,-2.0" dir=" 0.0,-0.5, 2.0"/>
             <key-frame pos="-2.0, 0.0,  0.0" dir=" 2.0, 0.0, 0.0"/>

--- a/regen/compute/compute-pass.h
+++ b/regen/compute/compute-pass.h
@@ -17,9 +17,16 @@ namespace regen {
 	public:
 		/**
 		 * @param shaderKey the key will be imported when createShader is called.
+		 * @param computeState the compute state.
 		 */
-		explicit ComputePass(const std::string &shaderKey) : State(), HasShader(shaderKey) {
-			computeState_ = ref_ptr<ComputeState>::alloc();
+		explicit ComputePass(const std::string &shaderKey,
+					const ref_ptr<ComputeState> &computeState = {})
+					: State(), HasShader(shaderKey) {
+			if (!computeState) {
+				computeState_ = ref_ptr<ComputeState>::alloc();
+			} else {
+				computeState_ = computeState;
+			}
 			joinStates(shaderState_);
 			joinStates(computeState_);
 		}
@@ -46,7 +53,9 @@ namespace regen {
 				REGEN_WARN("Missing shader attribute for " << input.getDescription() << ".");
 				return {};
 			}
-			ref_ptr<ComputePass> cs = ref_ptr<ComputePass>::alloc(input.getValue("shader"));
+			ref_ptr<ComputePass> cs = ref_ptr<ComputePass>::alloc(
+				input.getValue("shader"),
+				ComputeState::load(ctx, input));
 			StateConfigurer shaderConfigurer;
 			shaderConfigurer.addNode(ctx.parent().get());
 			shaderConfigurer.addState(cs.get());
@@ -58,4 +67,4 @@ namespace regen {
 		ref_ptr<ComputeState> computeState_;
 	};
 } // namespace
-#endif /* FULLSCREEN_PASS_H_ */
+#endif /* REGEN_COMPUTE_PASS_H_ */

--- a/regen/compute/compute-state.h
+++ b/regen/compute/compute-state.h
@@ -19,7 +19,7 @@ namespace regen {
 
 		ComputeState();
 
-		ref_ptr<ComputeState> load(LoadingContext &ctx, scene::SceneInputNode &input);
+		static ref_ptr<ComputeState> load(LoadingContext &ctx, scene::SceneInputNode &input);
 
 		void setNumWorkUnits(uint32_t x, uint32_t y, uint32_t z);
 

--- a/regen/gl/gl-enum.cpp
+++ b/regen/gl/gl-enum.cpp
@@ -351,12 +351,16 @@ GLenum glenum::barrierBit(const std::string &v) {
 		return GL_VERTEX_ATTRIB_ARRAY_BARRIER_BIT;
 	else if (val == "ELEMENT_ARRAY")
 		return GL_ELEMENT_ARRAY_BARRIER_BIT;
+	else if (val == "CLIENT_MAPPED_BUFFER")
+		return GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT;
 	else if (val == "UNIFORM")
 		return GL_UNIFORM_BARRIER_BIT;
 	else if (val == "TEXTURE_FETCH")
 		return GL_TEXTURE_FETCH_BARRIER_BIT;
 	else if (val == "SHADER_IMAGE_ACCESS")
 		return GL_SHADER_IMAGE_ACCESS_BARRIER_BIT;
+	else if (val == "SHADER_STORAGE")
+		return GL_SHADER_STORAGE_BARRIER_BIT;
 	else if (val == "COMMAND")
 		return GL_COMMAND_BARRIER_BIT;
 	else if (val == "PIXEL_BUFFER")

--- a/regen/gl/states/feedback-state.cpp
+++ b/regen/gl/states/feedback-state.cpp
@@ -19,7 +19,7 @@ ref_ptr<ShaderInput> FeedbackSpecification::addFeedback(const ref_ptr<ShaderInpu
 
 	// create feedback attribute
 	ref_ptr<ShaderInput> feedback = ShaderInput::create(in);
-	feedback->set_inputSize(feedbackCount * feedback->elementSize());
+	feedback->set_inputSize(feedbackCount * feedback->vertexSize());
 	feedback->set_numVertices(feedbackCount);
 	feedback->set_isVertexAttribute(true);
 	feedbackAttributes_.push_back(feedback);
@@ -81,13 +81,13 @@ void FeedbackState::initializeResources() {
 		if (feedbackMode_ == GL_INTERLEAVED_ATTRIBS) {
 			GLsizei vertexSize = 0;
 			for (auto & att : feedbackAttributes_) {
-				vertexSize += static_cast<GLsizei>(att->elementSize());
+				vertexSize += static_cast<GLsizei>(att->vertexSize());
 			}
 			uint32_t byteOffset = feedbackRef_->address();
 			for (auto & att : feedbackAttributes_) {
 				att->setMainBuffer(feedbackRef_, byteOffset);
 				att->setVertexStride(vertexSize);
-				byteOffset += att->elementSize();
+				byteOffset += att->vertexSize();
 			}
 		} else {
 			// set up separate attributes

--- a/regen/memory/buffer-object.cpp
+++ b/regen/memory/buffer-object.cpp
@@ -359,7 +359,7 @@ void BufferObject::setBufferSubData(uint32_t localOffset, uint32_t dataSize, con
 
 void BufferObject::readBufferSubData(uint32_t localOffset, uint32_t dataSize, byte *data) {
 	auto &ref = allocations_[0];
-	if (!flags_.isWritable()) {
+	if (!flags_.isReadable()) {
 		// CPU is not allowed to read from this buffer, so we cannot read data directly.
 		// But we can copy data to a temporary buffer and then copy it to the target buffer.
 		auto tempRef = adoptBufferRange(dataSize,

--- a/regen/memory/staged-buffer.cpp
+++ b/regen/memory/staged-buffer.cpp
@@ -3,6 +3,7 @@
 #include "ssbo.h"
 #include "regen/scene/state.h"
 #include "../shader/input-processor.h"
+#include <nlohmann/json.hpp>
 
 using namespace regen;
 
@@ -816,4 +817,106 @@ void StagedBuffer::Shared::setUpdatedFrame(bool isUpdated) {
 void StagedBuffer::resetUpdateHistory() {
 	shared_->updateIdx_ = 0;
 	shared_->hasUpdateRotated_ = false;
+}
+
+template<typename T, bool ExportFromGPU>
+void exportToBinary(ShaderInput &input, const std::filesystem::path &exportPath) {
+	const uint32_t numElements   = input.numElements();
+	const uint32_t numComponents = input.valsPerElement();
+
+	std::vector<T> values(numElements * numComponents, T(0));
+	T* dstPtr = values.data();
+
+	byte *gpuData;
+	if constexpr (ExportFromGPU) {
+		gpuData = new byte[input.alignedInputSize()];
+		input.readServerData(gpuData);
+
+		for (uint32_t i = 0; i < numElements; ++i) {
+			const size_t offset = i * input.alignedElementSize();
+			std::memcpy(dstPtr, gpuData + offset, numComponents * sizeof(T));
+			dstPtr += numComponents;
+		}
+
+		delete[] gpuData;
+	} else {
+		auto mapped = input.mapClientDataRaw(BUFFER_GPU_READ);
+		auto* gpuData = mapped.r;
+
+		for (uint32_t i = 0; i < numElements; ++i) {
+			const size_t offset = i * input.alignedElementSize();
+			std::memcpy(dstPtr, gpuData + offset, numComponents * sizeof(T));
+			dstPtr += numComponents;
+		}
+	}
+
+	std::string binFile = (exportPath / input.name()).string() + ".bin";
+	std::ofstream bin(binFile, std::ios::binary);
+	bin.write(reinterpret_cast<const char*>(values.data()),
+			  values.size() * sizeof(T));
+	bin.close();
+}
+
+void StagedBuffer::exportGPUToJSON(const std::filesystem::path &exportPath) const {
+	static constexpr bool ExportFromGPU = true;
+
+	// Create JSON meta data dictionary.
+	nlohmann::json j;
+	j["name"] = name();
+	j["inputs"] = nlohmann::json::array();
+
+	// we create a subdirectory under the given export path for storing binary data files.
+	std::filesystem::path subPath = exportPath; // / name();
+	if (!std::filesystem::exists(subPath) && !std::filesystem::create_directories(subPath)) {
+		REGEN_ERROR("Failed to create export directory '"
+			<< subPath.string() << "' for staged buffer JSON export.");
+		return;
+	}
+
+	for (const auto &inputPair : inputs_) {
+		nlohmann::json &jInput = j["inputs"].emplace_back();
+		jInput["name"] = inputPair.name_;
+		jInput["binary"] = REGEN_STRING(inputPair.name_ << ".bin");
+		jInput["components"] = inputPair.in_->valsPerElement();
+		jInput["count"] = inputPair.in_->numElements();
+		jInput["layout"] = "packed";
+		jInput["originalStrideBytes"] = inputPair.in_->alignedElementSize();
+
+		// Read data from the main buffer to CPU memory for exporting.
+		ShaderInput &input = *inputPair.in_.get();
+		// Write base type arrays as JSON arrays.
+		switch (input.baseType()) {
+			case GL_FLOAT:
+				exportToBinary<float,ExportFromGPU>(input, subPath);
+				jInput["dtype"] = "float32";
+				break;
+			case GL_DOUBLE:
+				exportToBinary<double,ExportFromGPU>(input, subPath);
+				jInput["dtype"] = "float64";
+				break;
+			case GL_INT:
+				exportToBinary<int32_t,ExportFromGPU>(input, subPath);
+				jInput["dtype"] = "int32";
+				break;
+			case GL_UNSIGNED_INT:
+				exportToBinary<uint32_t,ExportFromGPU>(input, subPath);
+				jInput["dtype"] = "uint32";
+				break;
+			default:
+				REGEN_WARN("Unsupported base type " << input.baseType()
+								   << " for exporting staged buffer input '" << input.name() << "' to JSON.");
+				break;
+		}
+	}
+
+	// write JSON meta data file
+	std::filesystem::path jsonPath = subPath / "meta.json";
+	std::ofstream file(jsonPath);
+	if (!file.is_open()) {
+		REGEN_ERROR("Failed to open file '" << jsonPath.string() <<
+			"' for writing staged buffer JSON export.");
+		return;
+	}
+	file << j.dump(4);
+	file.close();
 }

--- a/regen/memory/staged-buffer.cpp
+++ b/regen/memory/staged-buffer.cpp
@@ -201,7 +201,7 @@ void StagedBuffer::addStagedInput(const ref_ptr<ShaderInput> &input, std::string
 	auto &bufferInput = stagedInputs_.emplace_back();
 	bufferInput.input = input.get();
 	inputs_.emplace_back(input, std::string(name));
-	estimatedSize_ += input->elementSize();
+	estimatedSize_ += input->vertexSize() * input->numVertices();
 	hasClientData_ = input->hasClientData() && hasClientData_;
 	input->setMemoryLayout(memoryLayout_);
 	if (clientBuffer_->hasSegments()) {
@@ -827,9 +827,8 @@ void exportToBinary(ShaderInput &input, const std::filesystem::path &exportPath)
 	std::vector<T> values(numElements * numComponents, T(0));
 	T* dstPtr = values.data();
 
-	byte *gpuData;
 	if constexpr (ExportFromGPU) {
-		gpuData = new byte[input.alignedInputSize()];
+		byte *gpuData = new byte[input.alignedInputSize()];
 		input.readServerData(gpuData);
 
 		for (uint32_t i = 0; i < numElements; ++i) {

--- a/regen/memory/staged-buffer.cpp
+++ b/regen/memory/staged-buffer.cpp
@@ -857,54 +857,55 @@ void exportToBinary(ShaderInput &input, const std::filesystem::path &exportPath)
 	bin.close();
 }
 
-void StagedBuffer::exportGPUToJSON(const std::filesystem::path &exportPath) const {
-	static constexpr bool ExportFromGPU = true;
+template<bool ExportFromGPU>
+void exportToJSON(const std::filesystem::path &exportPath,
+	std::string_view bufferName,
+	std::vector<ShaderInput*> &inputs) {
 
 	// Create JSON meta data dictionary.
 	nlohmann::json j;
-	j["name"] = name();
+	j["name"] = bufferName;
 	j["inputs"] = nlohmann::json::array();
 
 	// we create a subdirectory under the given export path for storing binary data files.
-	std::filesystem::path subPath = exportPath; // / name();
+	std::filesystem::path subPath = exportPath;
 	if (!std::filesystem::exists(subPath) && !std::filesystem::create_directories(subPath)) {
 		REGEN_ERROR("Failed to create export directory '"
 			<< subPath.string() << "' for staged buffer JSON export.");
 		return;
 	}
 
-	for (const auto &inputPair : inputs_) {
+	for (auto &input : inputs) {
 		nlohmann::json &jInput = j["inputs"].emplace_back();
-		jInput["name"] = inputPair.name_;
-		jInput["binary"] = REGEN_STRING(inputPair.name_ << ".bin");
-		jInput["components"] = inputPair.in_->valsPerElement();
-		jInput["count"] = inputPair.in_->numElements();
+		jInput["name"] = input->name();
+		jInput["binary"] = REGEN_STRING(input->name() << ".bin");
+		jInput["components"] = input->valsPerElement();
+		jInput["count"] = input->numElements();
 		jInput["layout"] = "packed";
-		jInput["originalStrideBytes"] = inputPair.in_->alignedElementSize();
+		jInput["originalStrideBytes"] = input->alignedElementSize();
 
 		// Read data from the main buffer to CPU memory for exporting.
-		ShaderInput &input = *inputPair.in_.get();
 		// Write base type arrays as JSON arrays.
-		switch (input.baseType()) {
+		switch (input->baseType()) {
 			case GL_FLOAT:
-				exportToBinary<float,ExportFromGPU>(input, subPath);
+				exportToBinary<float,ExportFromGPU>(*input, subPath);
 				jInput["dtype"] = "float32";
 				break;
 			case GL_DOUBLE:
-				exportToBinary<double,ExportFromGPU>(input, subPath);
+				exportToBinary<double,ExportFromGPU>(*input, subPath);
 				jInput["dtype"] = "float64";
 				break;
 			case GL_INT:
-				exportToBinary<int32_t,ExportFromGPU>(input, subPath);
+				exportToBinary<int32_t,ExportFromGPU>(*input, subPath);
 				jInput["dtype"] = "int32";
 				break;
 			case GL_UNSIGNED_INT:
-				exportToBinary<uint32_t,ExportFromGPU>(input, subPath);
+				exportToBinary<uint32_t,ExportFromGPU>(*input, subPath);
 				jInput["dtype"] = "uint32";
 				break;
 			default:
-				REGEN_WARN("Unsupported base type " << input.baseType()
-								   << " for exporting staged buffer input '" << input.name() << "' to JSON.");
+				REGEN_WARN("Unsupported base type " << input->baseType()
+								   << " for exporting staged buffer input '" << input->name() << "' to JSON.");
 				break;
 		}
 	}
@@ -919,4 +920,22 @@ void StagedBuffer::exportGPUToJSON(const std::filesystem::path &exportPath) cons
 	}
 	file << j.dump(4);
 	file.close();
+}
+
+void StagedBuffer::exportGPUToJSON(const std::filesystem::path &exportPath) const {
+	static constexpr bool ExportFromGPU = true;
+	std::vector<ShaderInput*> inputs(stagedInputs_.size());
+	for (size_t i = 0; i < stagedInputs_.size(); ++i) {
+		inputs[i] = stagedInputs_[i].input;
+	}
+	exportToJSON<ExportFromGPU>(exportPath, name(), inputs);
+}
+
+void StagedBuffer::exportCPUToJSON(const std::filesystem::path &exportPath) const {
+	static constexpr bool ExportFromGPU = false;
+	std::vector<ShaderInput*> inputs(stagedInputs_.size());
+	for (size_t i = 0; i < stagedInputs_.size(); ++i) {
+		inputs[i] = stagedInputs_[i].input;
+	}
+	exportToJSON<ExportFromGPU>(exportPath, name(), inputs);
 }

--- a/regen/memory/staged-buffer.h
+++ b/regen/memory/staged-buffer.h
@@ -205,6 +205,14 @@ namespace regen {
 		 */
 		void exportGPUToJSON(const std::filesystem::path &exportPath) const;
 
+		/**
+		 * Export the buffer block data to a JSON file.
+		 * The data is loaded from the client buffer.
+		 * This will write the whole buffer content to a JSON file.
+		 * @param exportPath the path to the JSON file to write.
+		 */
+		void exportCPUToJSON(const std::filesystem::path &exportPath) const;
+
 	protected:
 		bool hasClientData_ = true;
 		bool isBufferValid_ = true;

--- a/regen/memory/staged-buffer.h
+++ b/regen/memory/staged-buffer.h
@@ -5,6 +5,7 @@
 #include "regen/scene/scene-input.h"
 #include "regen/compute/threading.h"
 #include "staging-buffer.h"
+#include <filesystem>
 
 namespace regen {
 	/**
@@ -195,6 +196,14 @@ namespace regen {
 		 * Reset the update history, clearing the array of updated frames.
 		 */
 		void resetUpdateHistory();
+
+		/**
+		 * Export the buffer block data to a JSON file.
+		 * The data is loaded from the main GL buffer (client buffer is not used).
+		 * This will load the whole buffer content from the GPU and write it to a JSON file.
+		 * @param exportPath the path to the JSON file to write.
+		 */
+		void exportGPUToJSON(const std::filesystem::path &exportPath) const;
 
 	protected:
 		bool hasClientData_ = true;

--- a/regen/objects/lod/mesh-simplifier.cpp
+++ b/regen/objects/lod/mesh-simplifier.cpp
@@ -855,7 +855,7 @@ void MeshSimplifier::simplifyMesh() {
 				std::memcpy(
 						(byte *) levelData.pos.data(),
 						(byte *) lastLevelData.pos.data(),
-						levelData.pos.size() * inputPos_->elementSize());
+						levelData.pos.size() * inputPos_->vertexSize());
 				for (unsigned int attributeIndex = 0u; attributeIndex < inputAttributes_.size(); ++attributeIndex) {
 					auto lodAttr = lastLevelData.attributes[attributeIndex];
 					initializeLevelData(
@@ -954,14 +954,14 @@ uint32_t MeshSimplifier::createOutputAttributes() {
 	// then copy the LOD data into the new attributes
 	for (auto &lod: lodData_) {
 		std::memcpy(
-				outputPos_->clientData() + lod.offset * outputPos_->elementSize(),
+				outputPos_->clientData() + lod.offset * outputPos_->vertexSize(),
 				(byte *) lod.pos.data(),
-				lod.pos.size() * outputPos_->elementSize());
+				lod.pos.size() * outputPos_->vertexSize());
 		for (unsigned int attributeIndex = 0; attributeIndex < lod.attributes.size(); ++attributeIndex) {
 			auto &in = lod.attributes[attributeIndex];
 			auto &out = outputAttributes_[attributeIndex].second;
 			std::memcpy(
-					out->clientData() + lod.offset * out->elementSize(),
+					out->clientData() + lod.offset * out->vertexSize(),
 					in->clientData(),
 					in->inputSize());
 		}

--- a/regen/objects/sky/lightning-bolt.cpp
+++ b/regen/objects/sky/lightning-bolt.cpp
@@ -481,19 +481,19 @@ void LightningBolt::gpuUpdate(RenderState *rs, double dt) {
 		std::memcpy(
 			posData + numVertices,
 			segment.pos_.data(),
-			strikeVertices * pos_->elementSize());
+			strikeVertices * pos_->vertexSize());
 
 		// Copy brightness data
 		std::memcpy(
 			brightnessData + numVertices,
 			segment.brightness_.data(),
-			strikeVertices * brightness_->elementSize());
+			strikeVertices * brightness_->vertexSize());
 
 		// Copy strikeIdx data
 		std::memcpy(
 			strikeIdxData + numVertices,
 			segment.strikeIdx_.data(),
-			strikeVertices * strikeIdx_->elementSize());
+			strikeVertices * strikeIdx_->vertexSize());
 
 		numVertices += strikeVertices;
 	}

--- a/regen/objects/volume.glsl
+++ b/regen/objects/volume.glsl
@@ -238,11 +238,11 @@ void main() {
 -- neural.training-data.cs
 #include regen.compute.compute.defines
 
-buffer vec4 in_rayOrigin[];
-buffer vec4 in_rayDestination[];
+buffer vec3 in_rayOrigin[];
+buffer vec3 in_rayDirection[];
 
-buffer vec4 in_position[];
-buffer vec4 in_normal[];
+buffer vec3 in_position[];
+buffer vec3 in_normal[];
 buffer float in_density[];
 
 uniform sampler3D in_volumeTexture;
@@ -261,14 +261,14 @@ void main() {
     if (id >= numElements) return;
 
     const vec3 origin = in_rayOrigin[id].xyz;
-    vec3 dir = in_rayDestination[id].xyz - origin;
+    vec3 dir = in_rayDirection[id].xyz;
     float len = length(dir);
     if (len > 0.0) {
         dir /= len;
     } else {
         // invalid ray
-        in_position[id] = vec4(9999.0, 9999.0, 9999.0, 0.0);
-        in_normal[id] = vec4(0.0, 0.0, 0.0, 0.0);
+        in_position[id] = vec3(9999.0, 9999.0, 9999.0);
+        in_normal[id] = vec3(0.0, 0.0, 0.0);
         in_density[id] = 0.0;
         return;
     }
@@ -310,13 +310,13 @@ void main() {
     if(hit) {
         // Store position in object space
         vec3 po = 2.0 * pos - vec3(1.0);
-        in_position[id] = vec4(po, 0.0);
-        in_normal[id] = vec4(normalize(computeNormal(pos)), 0.0);
+        in_position[id] = po;
+        in_normal[id] = normalize(computeNormal(pos));
         in_density[id] = density;
     } else {
         // No hit: write invalid values
-        in_position[id] = vec4(9999.0, 9999.0, 9999.0, 0.0);
-        in_normal[id] = vec4(0.0, 0.0, 0.0, 0.0);
+        in_position[id] = vec3(9999.0, 9999.0, 9999.0);
+        in_normal[id] = vec3(0.0, 0.0, 0.0);
         in_density[id] = 0.0;
     }
 }

--- a/regen/objects/volume.glsl
+++ b/regen/objects/volume.glsl
@@ -1,9 +1,30 @@
 
---------------------------------
---------------------------------
------ Raycasting Shader
---------------------------------
---------------------------------
+-- intersectBox
+bool intersectBox(vec3 origin, vec3 dir, out float t0, out float t1) {
+    vec3 invR = 1.0 / dir;
+    vec3 tbot = invR * (-in_halfVolumeSize-origin);
+    vec3 ttop = invR * (+in_halfVolumeSize-origin);
+    vec3 tmin = min(ttop, tbot);
+    vec3 tmax = max(ttop, tbot);
+    t0 = max(max(tmin.x, tmin.y), tmin.z);
+    t1 = min(min(tmax.x, tmax.y), tmax.z);
+    return t0 < t1;
+}
+
+-- computeNormal
+vec3 computeNormal(vec3 pos) {
+    float dx =
+        texture(in_volumeTexture, pos + vec3(in_rayStep, 0.0, 0.0)).x -
+        texture(in_volumeTexture, pos - vec3(in_rayStep, 0.0, 0.0)).x;
+    float dy =
+        texture(in_volumeTexture, pos + vec3(0.0, in_rayStep, 0.0)).x -
+        texture(in_volumeTexture, pos - vec3(0.0, in_rayStep, 0.0)).x;
+    float dz =
+        texture(in_volumeTexture, pos + vec3(0.0, 0.0, in_rayStep)).x -
+        texture(in_volumeTexture, pos - vec3(0.0, 0.0, in_rayStep)).x;
+    return vec3(-dx, -dy, -dz);
+}
+
 -- vs
 #include regen.objects.mesh.defines
 
@@ -100,27 +121,16 @@ const vec3 in_halfVolumeSize = vec3(1.0);
     #include regen.objects.mesh.writeOutput
 #endif
 #include regen.camera.camera.transformWorldToScreen
+#include regen.objects.volume.intersectBox
+#include regen.objects.volume.computeNormal
 
-vec4 volumeTransfer(float val)
-{
+vec4 volumeTransfer(float val) {
     vec3 col = texture(in_transferTexture, vec2(val)).rgb;
 #ifdef DENSITY_ALPHA
     return vec4(col, min(1.0,in_densityScale*val));
 #else
     return vec4(col*1.6, 1.0);
 #endif
-}
-
-bool intersectBox(vec3 origin, vec3 dir, out float t0, out float t1)
-{
-    vec3 invR = 1.0 / dir;
-    vec3 tbot = invR * (-in_halfVolumeSize-origin);
-    vec3 ttop = invR * (+in_halfVolumeSize-origin);
-    vec3 tmin = min(ttop, tbot);
-    vec3 tmax = max(ttop, tbot);
-    t0 = max(max(tmin.x, tmin.y), tmin.z);
-    t1 = min(min(tmax.x, tmax.y), tmax.z);
-    return t0 < t1;
 }
 
 void main() {
@@ -140,14 +150,21 @@ void main() {
     rayStop = 0.5 * (rayStop + vec3(1.0));
     // do the ray casting from start to stop
     vec3 ray = rayStop - rayStart;
-    vec3 stepVector = normalize(ray) * max(in_rayStep, 0.001);
+
+    float rayLength = length(ray);
+    int numSteps = int(rayLength / in_rayStep);
+    vec3 stepVector = ray / float(numSteps);
+    //vec3 stepVector = normalize(ray) * max(in_rayStep, 0.001);
+
     vec3 pos = rayStart;
     vec4 dst = vec4(0);
 #if RAY_CASTING_MODE==AVERAGE_INTENSITY
     float counter = 0.0;
 #endif
-    for(float rayLength=length(ray); rayLength>=0.0; rayLength-=in_rayStep)
-    {
+#if RAY_CASTING_MODE==MAX_INTENSITY
+    float maxIntensity = 0.0;
+#endif
+    for(int i=0; i<numSteps; i++) {
 #ifdef RAY_CAST_JITTER
         vec3 jitter = vec3(
             fract(sin(dot(pos.xy, vec2(12.9898, 78.233))) * 43758.5453),
@@ -160,8 +177,9 @@ void main() {
 #endif
 
 #if RAY_CASTING_MODE==MAX_INTENSITY
-        if(value > max(in_densityThreshold,dst.a)) {
+        if(value > max(in_densityThreshold,maxIntensity)) {
             dst = volumeTransfer(value);
+            maxIntensity = value;
         }
 #elif RAY_CASTING_MODE==AVERAGE_INTENSITY
         if(value > in_densityThreshold) {
@@ -202,18 +220,7 @@ void main() {
     vec4 ps = transformWorldToScreen(vec4(pw,1.0),0);
     gl_FragDepth = (ps.z/ps.w)*0.5 + 0.5;
 #endif
-    // calculate normal by approximating the gradient using central differences
-    float dx =
-        texture(in_volumeTexture, pos + vec3(in_rayStep, 0.0, 0.0)).x -
-        texture(in_volumeTexture, pos - vec3(in_rayStep, 0.0, 0.0)).x;
-    float dy =
-        texture(in_volumeTexture, pos + vec3(0.0, in_rayStep, 0.0)).x -
-        texture(in_volumeTexture, pos - vec3(0.0, in_rayStep, 0.0)).x;
-    float dz =
-        texture(in_volumeTexture, pos + vec3(0.0, 0.0, in_rayStep)).x -
-        texture(in_volumeTexture, pos - vec3(0.0, 0.0, in_rayStep)).x;
-    // compute normal in world space
-    vec3 normal = normalize(mat3(in_modelMatrix) * vec3(-dx, -dy, -dz));
+    vec3 normal = normalize(mat3(in_modelMatrix) * computeNormal(pos));
 
 #ifndef FS_NO_OUTPUT
     #if DRAW_RAY_LENGTH==1
@@ -228,3 +235,88 @@ void main() {
 #endif
 }
 
+-- neural.training-data.cs
+#include regen.compute.compute.defines
+
+buffer vec4 in_rayOrigin[];
+buffer vec4 in_rayDestination[];
+
+buffer vec4 in_position[];
+buffer vec4 in_normal[];
+buffer float in_density[];
+
+uniform sampler3D in_volumeTexture;
+
+const float in_rayStep=0.02;
+const float in_densityThreshold=0.125;
+const float in_densityScale=2.0;
+const vec3 in_halfVolumeSize = vec3(1.0);
+
+#include regen.objects.volume.intersectBox
+#include regen.objects.volume.computeNormal
+
+void main() {
+    const uint id = gl_GlobalInvocationID.x;
+    const uint numElements = CS_WORK_UNITS_X;
+    if (id >= numElements) return;
+
+    const vec3 origin = in_rayOrigin[id].xyz;
+    vec3 dir = in_rayDestination[id].xyz - origin;
+    float len = length(dir);
+    if (len > 0.0) {
+        dir /= len;
+    } else {
+        // invalid ray
+        in_position[id] = vec4(9999.0, 9999.0, 9999.0, 0.0);
+        in_normal[id] = vec4(0.0, 0.0, 0.0, 0.0);
+        in_density[id] = 0.0;
+        return;
+    }
+
+    // We use mode=FIRST_MAXIMUM for generating training data
+    float tnear, tfar;
+    intersectBox( origin, dir, tnear, tfar);
+    tnear = max(tnear,0.0);
+    vec3 rayStart = origin + dir * tnear;
+    vec3 rayStop = origin + dir * tfar;
+#ifdef SWITCH_VOLUME_Y
+    // switch y-axis
+    rayStart.y *= -1; rayStop.y *= -1;
+#endif
+
+    // Transform from object space to texture coordinate space:
+    rayStart = 0.5 * (rayStart + vec3(1.0));
+    rayStop = 0.5 * (rayStop + vec3(1.0));
+
+    // do the ray casting from start to stop
+    vec3 ray = rayStop - rayStart;
+    float rayLength = length(ray);
+    int numSteps = int(rayLength / in_rayStep);
+    vec3 stepVector = ray / float(numSteps);
+    vec3 pos = rayStart;
+    float density = 0.0;
+    bool hit = false;
+
+    for(int i=0; i<numSteps; i++) {
+        float value = texture(in_volumeTexture, pos).x;
+        if(value > in_densityThreshold) {
+            density = value;
+            hit = true;
+            break;
+        }
+        pos += stepVector;
+    }
+
+    if(hit) {
+        // Store position in object space
+        vec3 po = 2.0 * pos - vec3(1.0);
+        in_position[id] = vec4(po, 0.0);
+        in_normal[id] = vec4(normalize(computeNormal(pos)), 0.0);
+        in_density[id] = density;
+    } else {
+        // No hit: write invalid values
+        in_position[id] = vec4(9999.0, 9999.0, 9999.0, 0.0);
+        in_normal[id] = vec4(0.0, 0.0, 0.0, 0.0);
+        in_density[id] = 0.0;
+    }
+}

--- a/regen/scene/scene-loader.cpp
+++ b/regen/scene/scene-loader.cpp
@@ -66,6 +66,7 @@ void SceneLoader::init() {
 	setStateProcessor(ref_ptr<ResourceStateProvider>::alloc());
 	setStateProcessor(ref_ptr<ShapeProcessor>::alloc());
 	setStateProcessor(ref_ptr<AnimationProcessor>::alloc());
+	setStateProcessor(ref_ptr<LoadableState<ComputePass> >::alloc("compute"));
 	setStateProcessor(ref_ptr<LoadableState<BlendState> >::alloc("blend"));
 	setStateProcessor(ref_ptr<LoadableState<AlphaState> >::alloc("alpha"));
 	setStateProcessor(ref_ptr<LoadableState<BarrierState> >::alloc("barrier"));

--- a/regen/scene/scene-loader.cpp
+++ b/regen/scene/scene-loader.cpp
@@ -61,6 +61,7 @@ void SceneLoader::init() {
 	setNodeProcessor(ref_ptr<LoadableNode<HorizonDividerNode>>::alloc("horizon"));
 	// add some default state processors
 	setStateProcessor(ref_ptr<ShaderInputProcessor>::alloc());
+	setStateProcessor(ref_ptr<DataExportProcessor>::alloc());
 	setStateProcessor(ref_ptr<ShaderDefineProcessor>::alloc());
 	setStateProcessor(ref_ptr<ResourceStateProvider>::alloc());
 	setStateProcessor(ref_ptr<ShapeProcessor>::alloc());

--- a/regen/scene/value-generator.h
+++ b/regen/scene/value-generator.h
@@ -110,7 +110,14 @@ namespace regen {
 			T nextRandom() {
 				const T min = n_->getValue<T>("min", Vec::create<T>(0));
 				const T max = n_->getValue<T>("max", Vec::create<T>(1));
-				value_ = min + (max - min) * math::random<float>();
+				static constexpr uint32_t NumComponents = sizeof(T) / sizeof(typename VecTraits<T>::BaseType);
+				if constexpr (NumComponents == 1) {
+					value_ = min + (max - min) * math::random<float>();
+				} else {
+					for (uint32_t i = 0; i < NumComponents; ++i) {
+						value_[i] = min[i] + (max[i] - min[i]) * math::random<float>();
+					}
+				}
 				counter_.x += 1;
 				return value_;
 			}

--- a/regen/shader/input-processor.h
+++ b/regen/shader/input-processor.h
@@ -374,6 +374,10 @@ namespace regen {
 					}
 					delete[] tempBuffer;
 				}
+				// verify that we read enough data
+				if (file.gcount() < static_cast<std::streamsize>(count * sizeof(T))) {
+					REGEN_WARN("Data file '" << dataPath << "' contains insufficient data for input.");
+				}
 				file.close();
 			}
 

--- a/regen/shader/input-processor.h
+++ b/regen/shader/input-processor.h
@@ -230,7 +230,7 @@ namespace regen {
 					in = ref_ptr<UBO>::dynamicCast(block);
 				}
 				else if (input.hasAttribute("ssbo")) {
-					auto block = scene->getResource<BufferBlock>(input.getValue("ubo"));
+					auto block = scene->getResource<BufferBlock>(input.getValue("ssbo"));
 					if (block.get() == nullptr || !block->isSSBO()) {
 						REGEN_WARN("No SSBO found for '" << input.getDescription() << "'.");
 						return {};
@@ -364,8 +364,10 @@ namespace regen {
 
 				auto numInstances = input.getValue<uint32_t>("num-instances", 1u);
 				auto numVertices = input.getValue<uint32_t>("num-vertices", 1u);
+				auto numElements = input.getValue<uint32_t>("num-elements", 1u);
 				bool isInstanced = input.getValue<bool>("is-instanced", false);
 				bool isAttribute = input.getValue<bool>("is-attribute", false);
+				bool isArray = (numElements > 1u);
 				uint32_t count = 1;
 				// read the gpu-usage flag
 				if (input.getValue<std::string>("gpu-usage", "READ") == "WRITE") {
@@ -376,16 +378,20 @@ namespace regen {
 
 				if (isInstanced) {
 					v->setInstanceData(numInstances, 1, nullptr);
-					count = numInstances;
+					count = numInstances * numElements;
 				} else if (isAttribute) {
 					v->setVertexData(numVertices, nullptr);
-					count = numVertices;
+					count = numVertices * numElements;
+				} else if (isArray) {
+					v->set_numArrayElements(numElements);
+					v->setInstanceData(1, 1, nullptr);
+					count = numElements;
 				} else {
 					v->setUniformData(input.getValue<T>("value", defaultValue));
 				}
 
 				// Handle Attribute values.
-				if (isInstanced || isAttribute) {
+				if (isInstanced || isAttribute || isArray) {
 					auto values = v->template mapClientData<T>(BUFFER_GPU_WRITE);
 					auto typedValues = values.w;
 					for (uint32_t i = 0; i < count; i += 1) typedValues[i] = defaultValue;
@@ -427,13 +433,22 @@ namespace regen {
 					  exportBuffer_(exportBuffer),
 					  exportPath_(exportPath) {}
 
+			void setUseGPUData(bool useGPUData) {
+				useGPUData_ = useGPUData;
+			}
+
 			// override
 			void enable(RenderState* /*rs*/) override {
-				exportBuffer_->exportGPUToJSON(exportPath_);
+				if (useGPUData_) {
+					exportBuffer_->exportGPUToJSON(exportPath_);
+				} else {
+					exportBuffer_->exportCPUToJSON(exportPath_);
+				}
 			}
 		protected:
 			ref_ptr<StagedBuffer> exportBuffer_;
 			std::filesystem::path exportPath_;
+			bool useGPUData_ = true;
 		};
 
 		/**
@@ -475,6 +490,17 @@ namespace regen {
 						return;
 					}
 					in = in_opt.value().in;
+				} else if (input.hasAttribute("buffer-id")) {
+					auto bufferID = input.getValue("buffer-id");
+					in = scene->getResource<BufferBlock>(bufferID);
+					if (!in) {
+						scene->loadResources(bufferID);
+						in = scene->getResource<BufferBlock>(bufferID);
+					}
+					if (!in) {
+						REGEN_WARN("No BufferBlock found for for '" << input.getDescription() << ".");
+						return;
+					}
 				}
 
 				if (!in) {
@@ -491,6 +517,7 @@ namespace regen {
 
 				auto exportState =
 					ref_ptr<DataExportState>::alloc(stagedBuffer, exportPath);
+				exportState->setUseGPUData(input.getValue<bool>("gpu-export", true));
 				state->joinStates(exportState);
 			}
 		};

--- a/regen/shader/input-processor.h
+++ b/regen/shader/input-processor.h
@@ -21,9 +21,9 @@ namespace regen {
 		 * @param name optional timer name.
 		 */
 		explicit TimerInput(float timeScale, const std::string &name = "time")
-				: ShaderInput1f(name),
-				  Animation(false, true),
-				  timeScale_(timeScale) {
+			: ShaderInput1f(name),
+			  Animation(false, true),
+			  timeScale_(timeScale) {
 			setUniformData(0.0f);
 		}
 
@@ -51,7 +51,7 @@ namespace regen {
 		public:
 			template<typename T, typename BaseType>
 			static void setInput(SceneInputNode &input, ShaderInput *shaderInput, unsigned int count) {
-				auto v_values =  shaderInput->mapClientData<T>(BUFFER_GPU_WRITE);
+				auto v_values = shaderInput->mapClientData<T>(BUFFER_GPU_WRITE);
 				auto default_value = input.getValue<T>("value", Vec::create<T>(0));
 				for (unsigned int i = 0; i < count; ++i) {
 					v_values.w[i] = default_value;
@@ -62,12 +62,12 @@ namespace regen {
 						auto blendMode = child->getValue<BlendMode>("blend-mode", BLEND_MODE_SRC);
 
 						uint32_t numInstances = 0;
-						for (auto &range : indices) {
+						for (auto &range: indices) {
 							numInstances += (range.to - range.from) / range.step + 1;
 						}
 						ValueGenerator<T> generator(child.get(), numInstances,
-													child->getValue<T>("value", Vec::create<T>(1)));
-						for (auto &range : indices) {
+						                            child->getValue<T>("value", Vec::create<T>(1)));
+						for (auto &range: indices) {
 							for (unsigned int j = range.from; j <= range.to; j = j + range.step) {
 								switch (blendMode) {
 									case BLEND_MODE_ADD:
@@ -96,48 +96,48 @@ namespace regen {
 					case GL_FLOAT:
 						switch (in->valsPerElement()) {
 							case 1:
-								setInput<float,float>(input, in, count);
+								setInput<float, float>(input, in, count);
 								break;
 							case 2:
-								setInput<Vec2f,float>(input, in, count);
+								setInput<Vec2f, float>(input, in, count);
 								break;
 							case 3:
-								setInput<Vec3f,float>(input, in, count);
+								setInput<Vec3f, float>(input, in, count);
 								break;
 							case 4:
-								setInput<Vec4f,float>(input, in, count);
+								setInput<Vec4f, float>(input, in, count);
 								break;
 						}
 						break;
 					case GL_INT:
 						switch (in->valsPerElement()) {
 							case 1:
-								setInput<int,int>(input, in, count);
+								setInput<int, int>(input, in, count);
 								break;
 							case 2:
-								setInput<Vec2i,int>(input, in, count);
+								setInput<Vec2i, int>(input, in, count);
 								break;
 							case 3:
-								setInput<Vec3i,int>(input, in, count);
+								setInput<Vec3i, int>(input, in, count);
 								break;
 							case 4:
-								setInput<Vec4i,int>(input, in, count);
+								setInput<Vec4i, int>(input, in, count);
 								break;
 						}
 						break;
 					case GL_UNSIGNED_INT:
 						switch (in->valsPerElement()) {
 							case 1:
-								setInput<uint32_t,uint32_t>(input, in, count);
+								setInput<uint32_t, uint32_t>(input, in, count);
 								break;
 							case 2:
-								setInput<Vec2ui,uint32_t>(input, in, count);
+								setInput<Vec2ui, uint32_t>(input, in, count);
 								break;
 							case 3:
-								setInput<Vec3ui,uint32_t>(input, in, count);
+								setInput<Vec3ui, uint32_t>(input, in, count);
 								break;
 							case 4:
-								setInput<Vec4ui,uint32_t>(input, in, count);
+								setInput<Vec4ui, uint32_t>(input, in, count);
 								break;
 						}
 						break;
@@ -148,7 +148,7 @@ namespace regen {
 
 			static int getNumInstances(const ref_ptr<Mesh> &mesh) {
 				int num = mesh->numInstances();
-				std::stack<ref_ptr<State>> stack;
+				std::stack<ref_ptr<State> > stack;
 				stack.emplace(mesh);
 				while (!stack.empty()) {
 					auto state = stack.top();
@@ -166,9 +166,9 @@ namespace regen {
 			 * @return The ShaderInput created or a null reference on failure.
 			 */
 			static ref_ptr<ShaderInput> createShaderInput(
-					scene::SceneLoader *scene,
-					SceneInputNode &input,
-					const ref_ptr<State> &state) {
+				scene::SceneLoader *scene,
+				SceneInputNode &input,
+				const ref_ptr<State> &state) {
 				ref_ptr<ShaderInput> in;
 
 				if (input.hasAttribute("state")) {
@@ -220,24 +220,21 @@ namespace regen {
 					auto numInstances = getNumInstances(mesh);
 					in->setInstanceData(numInstances, 1, nullptr);
 					setInput(input, in.get(), numInstances);
-				}
-				else if (input.hasAttribute("ubo")) {
+				} else if (input.hasAttribute("ubo")) {
 					auto block = scene->getResource<BufferBlock>(input.getValue("ubo"));
 					if (block.get() == nullptr || !block->isUBO()) {
 						REGEN_WARN("No UBO found for '" << input.getDescription() << "'.");
 						return {};
 					}
 					in = ref_ptr<UBO>::dynamicCast(block);
-				}
-				else if (input.hasAttribute("ssbo")) {
+				} else if (input.hasAttribute("ssbo")) {
 					auto block = scene->getResource<BufferBlock>(input.getValue("ssbo"));
 					if (block.get() == nullptr || !block->isSSBO()) {
 						REGEN_WARN("No SSBO found for '" << input.getDescription() << "'.");
 						return {};
 					}
 					in = ref_ptr<SSBO>::dynamicCast(block);
-				}
-				else {
+				} else {
 					auto type = input.getValue<std::string>("type", "");
 					if (type == "time") {
 						auto scale = input.getValue<float>("scale", 1.0f);
@@ -281,14 +278,15 @@ namespace regen {
 			}
 
 			ShaderInputProcessor()
-					: StateProcessor(REGEN_INPUT_STATE_CATEGORY) {}
+				: StateProcessor(REGEN_INPUT_STATE_CATEGORY) {
+			}
 
 			// Override
 			void processInput(
-					scene::SceneLoader *scene,
-					SceneInputNode &input,
-					const ref_ptr<StateNode> &parent,
-					const ref_ptr<State> &state) override {
+				scene::SceneLoader *scene,
+				SceneInputNode &input,
+				const ref_ptr<StateNode> &parent,
+				const ref_ptr<State> &state) override {
 				ref_ptr<ShaderInput> in = createShaderInput(scene, input, state);
 				if (in.get() == nullptr) {
 					REGEN_WARN("Failed to create input for " << input.getDescription() << ".");
@@ -298,22 +296,22 @@ namespace regen {
 				const uint32_t dataType = in->baseType();
 				const uint32_t numComponents = in->valsPerElement();
 				if (dataType == GL_INT) {
-					if (numComponents == 1) processTyped<ShaderInput1i,int,int>(input, state, in);
-					else if (numComponents == 2) processTyped<ShaderInput2i,Vec2i,int>(input, state, in);
-					else if (numComponents == 3) processTyped<ShaderInput3i,Vec3i,int>(input, state, in);
-					else if (numComponents == 4) processTyped<ShaderInput4i,Vec4i,int>(input, state, in);
+					if (numComponents == 1) processTyped<ShaderInput1i, int, int>(input, state, in);
+					else if (numComponents == 2) processTyped<ShaderInput2i, Vec2i, int>(input, state, in);
+					else if (numComponents == 3) processTyped<ShaderInput3i, Vec3i, int>(input, state, in);
+					else if (numComponents == 4) processTyped<ShaderInput4i, Vec4i, int>(input, state, in);
 				} else if (dataType == GL_UNSIGNED_INT) {
-					if (numComponents == 1) processTyped<ShaderInput1ui,uint32_t,uint32_t>(input, state, in);
-					else if (numComponents == 2) processTyped<ShaderInput2ui,Vec2ui,unsigned int>(input, state, in);
-					else if (numComponents == 3) processTyped<ShaderInput3ui,Vec3ui,unsigned int>(input, state, in);
-					else if (numComponents == 4) processTyped<ShaderInput4ui,Vec4ui,unsigned int>(input, state, in);
+					if (numComponents == 1) processTyped<ShaderInput1ui, uint32_t, uint32_t>(input, state, in);
+					else if (numComponents == 2) processTyped<ShaderInput2ui, Vec2ui, unsigned int>(input, state, in);
+					else if (numComponents == 3) processTyped<ShaderInput3ui, Vec3ui, unsigned int>(input, state, in);
+					else if (numComponents == 4) processTyped<ShaderInput4ui, Vec4ui, unsigned int>(input, state, in);
 				} else if (dataType == GL_FLOAT) {
-					if (numComponents == 1) processTyped<ShaderInput1f,float,float>(input, state, in);
-					else if (numComponents == 2) processTyped<ShaderInput2f,Vec2f,float>(input, state, in);
-					else if (numComponents == 3) processTyped<ShaderInput3f,Vec3f,float>(input, state, in);
-					else if (numComponents == 4) processTyped<ShaderInput4f,Vec4f,float>(input, state, in);
-					else if (numComponents == 9) processTyped<ShaderInputMat3,Mat3f,float>(input, state, in);
-					else if (numComponents == 16) processTyped<ShaderInputMat4,Mat4f,float>(input, state, in);
+					if (numComponents == 1) processTyped<ShaderInput1f, float, float>(input, state, in);
+					else if (numComponents == 2) processTyped<ShaderInput2f, Vec2f, float>(input, state, in);
+					else if (numComponents == 3) processTyped<ShaderInput3f, Vec3f, float>(input, state, in);
+					else if (numComponents == 4) processTyped<ShaderInput4f, Vec4f, float>(input, state, in);
+					else if (numComponents == 9) processTyped<ShaderInputMat3, Mat3f, float>(input, state, in);
+					else if (numComponents == 16) processTyped<ShaderInputMat4, Mat4f, float>(input, state, in);
 				}
 
 				if (in->name() != input.getValue("name")) {
@@ -322,24 +320,24 @@ namespace regen {
 
 				if (input.getValue<bool>("join", true)) {
 					state->setInput(in,
-						input.getValue("name"),
-						input.getValue<std::string>("member-suffix", ""));
+					                input.getValue("name"),
+					                input.getValue<std::string>("member-suffix", ""));
 				}
 			}
 
 			template<class U, class T, typename ValueType>
 			static void processTyped(
-					SceneInputNode &input,
-					const ref_ptr<State> &state,
-					const ref_ptr<ShaderInput> &untyped) {
+				SceneInputNode &input,
+				const ref_ptr<State> &state,
+				const ref_ptr<ShaderInput> &untyped) {
 				ref_ptr<U> v = ref_ptr<U>::dynamicCast(untyped);
 				// Load animations.
 				for (const auto &n: input.getChildren("animation")) {
 					ref_ptr<InputAnimation<U, T> > inputAnimation = ref_ptr<InputAnimation<U, T> >::alloc(v);
 					for (const auto &m: n->getChildren("key-frame")) {
 						inputAnimation->push_back(
-								m->getValue<T>("value", T()),
-								m->getValue<double>("dt", 1.0)
+							m->getValue<T>("value", T()),
+							m->getValue<double>("dt", 1.0)
 						);
 					}
 					state->attach(inputAnimation);
@@ -347,11 +345,43 @@ namespace regen {
 				}
 			}
 
+			template<class T>
+			static void loadDataFile(const std::string &dataFile,
+			                         uint32_t count, WriteAccessor<T> &typedValues, const ref_ptr<ShaderInput> &v) {
+				std::filesystem::path dataPath = dataFile;
+				if (!exists(dataPath)) {
+					REGEN_WARN("Data file '" << dataPath << "' does not exist for input.");
+					return;
+				}
+				std::ifstream file(dataPath, std::ios::binary);
+				if (!file.is_open()) {
+					REGEN_WARN("Failed to open data file '" << dataPath << "' for input.");
+					return;
+				}
+				// Note that we might need to add padding, e.g. for std140 layout and vec3 arrays.
+				// So we cannot just read directly into the mapped buffer, but we need to read
+				// into a temporary buffer and then copy element by element, at least for the
+				// padded attributes.
+				if (v->elementSize() == v->alignedElementSize()) {
+					// no padding
+					file.read(reinterpret_cast<char *>(typedValues.data()), count * sizeof(T));
+				} else {
+					// with padding
+					T *tempBuffer = new T[count];
+					file.read(reinterpret_cast<char *>(tempBuffer), count * sizeof(T));
+					for (uint32_t i = 0; i < count; i += 1) {
+						typedValues[i] = tempBuffer[i];
+					}
+					delete[] tempBuffer;
+				}
+				file.close();
+			}
+
 			template<class U, class T, typename ValueType>
 			static ref_ptr<U> createShaderInputTyped(
-					SceneInputNode &input,
-					const ref_ptr<State> &state,
-					const T &defaultValue) {
+				SceneInputNode &input,
+				const ref_ptr<State> &state,
+				const T &defaultValue) {
 				if (!input.hasAttribute("name")) {
 					REGEN_WARN("No name specified for " << input.getDescription() << ".");
 					return ref_ptr<U>();
@@ -359,7 +389,8 @@ namespace regen {
 				ref_ptr<U> v = ref_ptr<U>::alloc(input.getValue("name"));
 				v->set_isConstant(input.getValue<bool>("is-constant", false));
 				if (input.hasAttribute("layout")) {
-					v->setMemoryLayout(input.getValue<BufferMemoryLayout>("layout", BUFFER_MEMORY_STD430));
+					v->setMemoryLayout(input.getValue<BufferMemoryLayout>(
+						"layout", BUFFER_MEMORY_STD430));
 				}
 
 				auto numInstances = input.getValue<uint32_t>("num-instances", 1u);
@@ -393,24 +424,34 @@ namespace regen {
 				// Handle Attribute values.
 				if (isInstanced || isAttribute || isArray) {
 					auto values = v->template mapClientData<T>(BUFFER_GPU_WRITE);
-					auto typedValues = values.w;
+					auto &typedValues = values.w;
 					for (uint32_t i = 0; i < count; i += 1) typedValues[i] = defaultValue;
+
+					// Check for "data-file" attribute, this would be a file with binary data
+					// in packed layout which must cover all elements.
+					if (input.hasAttribute("data-file")) {
+						std::string dataFile = input.getValue("data-file");
+						ShaderInputProcessor::loadDataFile<T>(resourcePath(dataFile),
+						                                      count, typedValues, v);
+					}
+
 					values.unmap();
+
 					setInput(input, v.get(), count);
 				}
 
 				// Set the schema.
 				bool hasMinMax = input.hasAttribute("min") || input.hasAttribute("max");
 				auto semantics = input.getValue<InputSchema::Semantics>(
-						"schema", InputSchema::Semantics::UNKNOWN);
+					"schema", InputSchema::Semantics::UNKNOWN);
 				if (hasMinMax) {
 					auto min = input.getValue<T>("min", Vec::create<T>(0));
 					auto max = input.getValue<T>("max", Vec::create<T>(1));
 					auto schema = InputSchema::alloc(semantics);
 					for (int i = 0; i < v->valsPerElement(); i += 1) {
 						schema->setLimits(i,
-							static_cast<float>(((ValueType*)&min)[i]),
-							static_cast<float>(((ValueType*)&max)[i]));
+						                  static_cast<float>(((ValueType *) &min)[i]),
+						                  static_cast<float>(((ValueType *) &max)[i]));
 					}
 					v->setSchema(schema);
 				} else if (input.hasAttribute("schema")) {
@@ -427,24 +468,26 @@ namespace regen {
 		class DataExportState : public State {
 		public:
 			DataExportState(
-					const ref_ptr<StagedBuffer> &exportBuffer,
-					const std::filesystem::path &exportPath)
-					: State(),
-					  exportBuffer_(exportBuffer),
-					  exportPath_(exportPath) {}
+				const ref_ptr<StagedBuffer> &exportBuffer,
+				const std::filesystem::path &exportPath)
+				: State(),
+				  exportBuffer_(exportBuffer),
+				  exportPath_(exportPath) {
+			}
 
 			void setUseGPUData(bool useGPUData) {
 				useGPUData_ = useGPUData;
 			}
 
 			// override
-			void enable(RenderState* /*rs*/) override {
+			void enable(RenderState * /*rs*/) override {
 				if (useGPUData_) {
 					exportBuffer_->exportGPUToJSON(exportPath_);
 				} else {
 					exportBuffer_->exportCPUToJSON(exportPath_);
 				}
 			}
+
 		protected:
 			ref_ptr<StagedBuffer> exportBuffer_;
 			std::filesystem::path exportPath_;
@@ -457,14 +500,15 @@ namespace regen {
 		class DataExportProcessor : public StateProcessor {
 		public:
 			DataExportProcessor()
-					: StateProcessor("data-export") {}
+				: StateProcessor("data-export") {
+			}
 
 			// Override
 			void processInput(
-					scene::SceneLoader *scene,
-					SceneInputNode &input,
-					const ref_ptr<StateNode> &parent,
-					const ref_ptr<State> &state) override {
+				scene::SceneLoader *scene,
+				SceneInputNode &input,
+				const ref_ptr<StateNode> &parent,
+				const ref_ptr<State> &state) override {
 				if (!input.hasAttribute("export-path")) {
 					REGEN_WARN("No export-path specified for " << input.getDescription() << ".");
 					return;
@@ -516,7 +560,7 @@ namespace regen {
 				}
 
 				auto exportState =
-					ref_ptr<DataExportState>::alloc(stagedBuffer, exportPath);
+						ref_ptr<DataExportState>::alloc(stagedBuffer, exportPath);
 				exportState->setUseGPUData(input.getValue<bool>("gpu-export", true));
 				state->joinStates(exportState);
 			}

--- a/regen/shader/input-processor.h
+++ b/regen/shader/input-processor.h
@@ -517,7 +517,7 @@ namespace regen {
 					REGEN_WARN("No export-path specified for " << input.getDescription() << ".");
 					return;
 				}
-				std::string exportPath = input.getValue("export-path");;
+				std::string exportPath = input.getValue("export-path");
 				ref_ptr<ShaderInput> in;
 
 				if (input.hasAttribute("state")) {

--- a/regen/shader/input-processor.h
+++ b/regen/shader/input-processor.h
@@ -414,6 +414,86 @@ namespace regen {
 				return v;
 			}
 		};
+
+		/**
+		 * State that exports data from a staged buffer to a file.
+		 */
+		class DataExportState : public State {
+		public:
+			DataExportState(
+					const ref_ptr<StagedBuffer> &exportBuffer,
+					const std::filesystem::path &exportPath)
+					: State(),
+					  exportBuffer_(exportBuffer),
+					  exportPath_(exportPath) {}
+
+			// override
+			void enable(RenderState* /*rs*/) override {
+				exportBuffer_->exportGPUToJSON(exportPath_);
+			}
+		protected:
+			ref_ptr<StagedBuffer> exportBuffer_;
+			std::filesystem::path exportPath_;
+		};
+
+		/**
+		 * Processes SceneInput nodes of category "data-export".
+		 */
+		class DataExportProcessor : public StateProcessor {
+		public:
+			DataExportProcessor()
+					: StateProcessor("data-export") {}
+
+			// Override
+			void processInput(
+					scene::SceneLoader *scene,
+					SceneInputNode &input,
+					const ref_ptr<StateNode> &parent,
+					const ref_ptr<State> &state) override {
+				if (!input.hasAttribute("export-path")) {
+					REGEN_WARN("No export-path specified for " << input.getDescription() << ".");
+					return;
+				}
+				std::string exportPath = input.getValue("export-path");;
+				ref_ptr<ShaderInput> in;
+
+				if (input.hasAttribute("state")) {
+					// take uniform from state
+					ref_ptr<State> s = scene->getState(input.getValue("state"));
+					if (!s) {
+						scene->loadResources(input.getValue("state"));
+						s = scene->getState(input.getValue("state"));
+					}
+					if (!s) {
+						REGEN_WARN("No State found for for '" << input.getDescription() << "'.");
+						return;
+					}
+
+					auto in_opt = s->findShaderInput(input.getValue("component"));
+					if (!in_opt.has_value() || !in_opt.value().in.get()) {
+						REGEN_WARN("No ShaderInput found for for '" << input.getDescription() << ".");
+						return;
+					}
+					in = in_opt.value().in;
+				}
+
+				if (!in) {
+					REGEN_WARN("No state specified for data export in " << input.getDescription() << ".");
+					return;
+				}
+
+				// we only support export of staged buffers here
+				auto stagedBuffer = ref_ptr<StagedBuffer>::dynamicCast(in);
+				if (!stagedBuffer) {
+					REGEN_WARN("Data export only supported for staged buffers in " << input.getDescription() << ".");
+					return;
+				}
+
+				auto exportState =
+					ref_ptr<DataExportState>::alloc(stagedBuffer, exportPath);
+				state->joinStates(exportState);
+			}
+		};
 	}
 }
 

--- a/regen/shader/shader-input.cpp
+++ b/regen/shader/shader-input.cpp
@@ -316,27 +316,17 @@ void ShaderInput::writeServerData() const {
 
 void ShaderInput::readServerData() {
 	if (!hasServerData()) return;
-	auto mappedClientData = clientBuffer_->mapRange(BUFFER_GPU_WRITE, 0, inputSize_);
+	auto mappedClientData = clientBuffer_->mapRange(BUFFER_GPU_WRITE, 0, alignedInputSize_);
 	auto clientData = mappedClientData.w;
+	auto bufferObj = (BufferObject*) bufferRef_->bufferObject();
+	bufferObj->readBufferSubData(offset_, alignedInputSize_, clientData);
+	clientBuffer_->unmapRange(BUFFER_GPU_WRITE, 0, alignedInputSize_, mappedClientData.w_index);
+}
 
-	byte *serverData = (byte *) glMapNamedBufferRange(
-			mainBufferName(),
-			offset_,
-			numVertices_ * vertexStride_ + elementSize_,
-			GL_MAP_READ_BIT);
-
-	if (static_cast<uint32_t>(vertexStride_) == elementSize_) {
-		std::memcpy(clientData, serverData, inputSize_);
-	} else {
-		for (uint32_t i = 0; i < numVertices_; ++i) {
-			std::memcpy(clientData, serverData, elementSize_);
-			serverData += vertexStride_;
-			clientData += elementSize_;
-		}
-	}
-
-	glUnmapNamedBuffer(mainBufferName());
-	clientBuffer_->unmapRange(BUFFER_GPU_WRITE, 0, inputSize_, mappedClientData.w_index);
+void ShaderInput::readServerData(byte *dstData) {
+	if (!hasServerData()) return;
+	auto bufferObj = static_cast<BufferObject *>(bufferRef_->bufferObject());
+	bufferObj->readBufferSubData(offset_, alignedInputSize_, dstData);
 }
 
 /////////////

--- a/regen/shader/shader-input.cpp
+++ b/regen/shader/shader-input.cpp
@@ -34,7 +34,7 @@ ShaderInput::ShaderInput(
 		  baseType_(baseType),
 		  dataType_(glenum::dataType(baseType, valsPerElement)),
 		  dataTypeBytes_(dataTypeBytes),
-		  baseSize_(dataTypeBytes * valsPerElement),
+		  elementSize_(dataTypeBytes * valsPerElement),
 		  valsPerElement_(valsPerElement),
 		  numArrayElements_(numArrayElements),
 		  numElements_i_(static_cast<int32_t>(numArrayElements)),
@@ -42,7 +42,7 @@ ShaderInput::ShaderInput(
 		  bufferStamp_(0),
 		  clientBuffer_(ref_ptr<ClientBuffer>::alloc()),
 		  normalize_(normalize) {
-	elementSize_ = baseSize_ * numArrayElements_;
+	vertexSize_ = elementSize_ * numArrayElements_;
 	enableAttribute_ = &ShaderInput::enableAttribute_f;
 	updateAlignment();
 }
@@ -52,16 +52,16 @@ ShaderInput::ShaderInput(const ShaderInput &o)
 		  baseType_(o.baseType_),
 		  dataType_(o.dataType_),
 		  dataTypeBytes_(o.dataTypeBytes_),
-		  baseSize_(o.baseSize_),
+		  elementSize_(o.elementSize_),
 		  valsPerElement_(o.valsPerElement_),
 		  baseAlignment_(o.baseAlignment_),
 		  alignmentCount_(o.alignmentCount_),
 		  alignedElementSize_(o.alignedElementSize_),
 		  unalignedSize_(o.unalignedSize_),
 		  vertexStride_(o.vertexStride_),
+		  vertexSize_(o.vertexSize_),
 		  offset_(o.offset_),
 		  inputSize_(o.inputSize_),
-		  elementSize_(o.elementSize_),
 		  numArrayElements_(o.numArrayElements_),
 		  numVertices_(o.numVertices_),
 		  numInstances_(o.numInstances_),
@@ -108,19 +108,19 @@ ShaderInput::~ShaderInput() {
 void ShaderInput::updateAlignment() {
 	if (memoryLayout_ == BUFFER_MEMORY_PACKED) {
 		baseAlignment_ = PACKED_BASE_ALIGNMENT;
-		alignedElementSize_ = baseSize_;
+		alignedElementSize_ = elementSize_;
 		alignmentCount_ = 1u;
 		alignedInputSize_ = alignedElementSize_ * numElements_ui_;
 	} else {
-		baseAlignment_ = baseSize_;
-		alignedElementSize_ = baseSize_;
+		baseAlignment_ = elementSize_;
+		alignedElementSize_ = elementSize_;
 		alignmentCount_ = 1u;
-		if (baseSize_ == 12u) { // vec3
+		if (elementSize_ == 12u) { // vec3
 			baseAlignment_ = 16u;
-		} else if (baseSize_ == 48u) { // mat3
+		} else if (elementSize_ == 48u) { // mat3
 			baseAlignment_ = 16u;
 			alignmentCount_ = 3u;
-		} else if (baseSize_ == 64u) { // mat4
+		} else if (elementSize_ == 64u) { // mat4
 			baseAlignment_ = 16u;
 			alignmentCount_ = 4u;
 		} else if (numElements() > 1u && memoryLayout_ == BUFFER_MEMORY_STD140) {
@@ -147,7 +147,7 @@ void ShaderInput::set_numArrayElements(uint32_t v) {
 		return;
 	}
 	numArrayElements_ = v;
-	elementSize_ = dataTypeBytes_ * valsPerElement_ * numArrayElements_;
+	vertexSize_ = elementSize_ * numArrayElements_;
 	if (isVertexAttribute_) {
 		numElements_ui_ = numArrayElements_ * numVertices_;
 	} else {
@@ -194,12 +194,11 @@ void ShaderInput::writeVertex(uint32_t index, const byte *data) {
 	//       For vertex data, it is assumed that data is one vertex including all array elements.
 	//       For uniform array data, it is assumed that data is one array element.
 	if (isVertexAttribute_) {
+		auto mapped = mapClientDataRaw(BUFFER_GPU_WRITE, index * vertexSize_, vertexSize_);
+		std::memcpy(mapped.w, data, vertexSize_);
+	} else {
 		auto mapped = mapClientDataRaw(BUFFER_GPU_WRITE, index * elementSize_, elementSize_);
 		std::memcpy(mapped.w, data, elementSize_);
-	} else {
-		auto arrayElementSize = dataTypeBytes_ * valsPerElement_;
-		auto mapped = mapClientDataRaw(BUFFER_GPU_WRITE, index * arrayElementSize, arrayElementSize);
-		std::memcpy(mapped.w, data, arrayElementSize);
 	}
 }
 
@@ -241,7 +240,7 @@ void ShaderInput::setInstanceData(uint32_t numInstances, uint32_t divisor, const
 		numInstances_ = 1u;
 	}
 
-	auto dataSize_bytes = elementSize_ * numInstances / divisor;
+	auto dataSize_bytes = vertexSize_ * numInstances / divisor;
 	if (dataSize_bytes != unalignedSize_ || isVertexAttribute_ || !hasClientData()) {
 		// size of the data has changed, need to reallocate the data buffer.
 		clientBuffer_->writeLockAll();
@@ -266,7 +265,7 @@ void ShaderInput::setInstanceData(uint32_t numInstances, uint32_t divisor, const
 }
 
 void ShaderInput::setVertexData(uint32_t numVertices, const byte *data) {
-	auto dataSize_bytes = elementSize_ * numVertices;
+	auto dataSize_bytes = vertexSize_ * numVertices;
 
 	if (dataSize_bytes != unalignedSize_ || !isVertexAttribute_ || !hasClientData()) {
 		// size of the data has changed, need to reallocate the data buffer.
@@ -299,14 +298,14 @@ void ShaderInput::writeServerData() const {
 	auto clientData = mappedClientData.r;
 	auto count = std::max(numVertices_, numInstances_);
 
-	if (static_cast<uint32_t>(vertexStride_) == elementSize_) {
+	if (static_cast<uint32_t>(vertexStride_) == vertexSize_) {
 		glNamedBufferSubData(buffer_, offset_, inputSize_, clientData);
 	} else {
 		uint32_t offset = offset_;
 		for (uint32_t i = 0; i < count; ++i) {
-			glNamedBufferSubData(buffer_, offset, elementSize_, clientData);
+			glNamedBufferSubData(buffer_, offset, vertexSize_, clientData);
 			offset += vertexStride_;
-			clientData += elementSize_;
+			clientData += vertexSize_;
 		}
 	}
 
@@ -420,7 +419,7 @@ ref_ptr<ShaderInput> ShaderInput::copy(const ref_ptr<ShaderInput> &in, bool copy
 	cp->vertexStride_ = in->vertexStride_;
 	cp->offset_ = in->offset_;
 	cp->inputSize_ = in->inputSize_;
-	cp->elementSize_ = in->elementSize_;
+	cp->vertexSize_ = in->vertexSize_;
 	cp->numArrayElements_ = in->numArrayElements_;
 	cp->numVertices_ = in->numVertices_;
 	cp->numInstances_ = in->numInstances_;

--- a/regen/shader/shader-input.h
+++ b/regen/shader/shader-input.h
@@ -153,7 +153,7 @@ namespace regen {
 		 * The base size of the input.
 		 * @return the base size of the input in bytes.
 		 */
-		inline uint32_t baseSize() const { return baseSize_; }
+		inline uint32_t elementSize() const { return elementSize_; }
 
 		/**
 		 * Specifies the byte offset between consecutive elements of the shader data.
@@ -221,7 +221,7 @@ namespace regen {
 		/**
 		 * Attribute size for a single vertex.
 		 */
-		inline uint32_t elementSize() const { return elementSize_; }
+		inline uint32_t vertexSize() const { return vertexSize_; }
 
 		/**
 		 * numArrayElements() * numInstances()
@@ -644,7 +644,7 @@ namespace regen {
 		const GLenum baseType_;
 		const GLenum dataType_;
 		const uint32_t dataTypeBytes_;
-		const uint32_t baseSize_;
+		const uint32_t elementSize_;
 		const int32_t valsPerElement_;
 
 		uint32_t baseAlignment_;
@@ -654,11 +654,11 @@ namespace regen {
 		uint32_t unalignedSize_ = 0u;
 
 		uint32_t vertexStride_ = 0u;
+		// This is the size in bytes of one element in the vertex buffer.
+		// e.g. vertexSize(vec3f[2]) = 2 * 3 * sizeof(float)
+		uint32_t vertexSize_;
 		uint32_t offset_ = 0u;
 		uint32_t inputSize_ = 0u;
-		// This is the size in bytes of one element in the vertex buffer.
-		// e.g. elementSize(vec3f[2]) = 2 * 3 * sizeof(float)
-		uint32_t elementSize_;
 		uint32_t numArrayElements_;
 		uint32_t numVertices_ = 1u;
 		uint32_t numInstances_ = 1u;

--- a/regen/shader/shader-input.h
+++ b/regen/shader/shader-input.h
@@ -536,6 +536,13 @@ namespace regen {
 		void readServerData();
 
 		/**
+		 * Maps VRAM and copies over data to dstPtr.
+		 * If not server-side data is available, nothing is done.
+		 * @param dstPtr the destination pointer.
+		 */
+		void readServerData(byte *dstPtr);
+
+		/**
 		 * Write this attribute to the GL server.
 		 * @param rs The RenderState.
 		 */

--- a/regen/shapes/shape-processor.cpp
+++ b/regen/shapes/shape-processor.cpp
@@ -94,15 +94,15 @@ createTriangleMesh(SceneInputNode &input, const ref_ptr<Mesh> &mesh) {
 	}
 	btIndexedMesh btMesh;
 	btMesh.m_numVertices = static_cast<int>(pos->numVertices());
-	btMesh.m_vertexStride = static_cast<int>(pos->elementSize());
+	btMesh.m_vertexStride = static_cast<int>(pos->vertexSize());
 
 	switch (mesh->primitive()) {
 		case GL_TRIANGLES:
-			btMesh.m_triangleIndexStride = 3 * static_cast<int>(indices->elementSize());
+			btMesh.m_triangleIndexStride = 3 * static_cast<int>(indices->vertexSize());
 			btMesh.m_numTriangles = static_cast<int>(indices->numVertices()) / 3;
 			break;
 		case GL_TRIANGLE_STRIP:
-			btMesh.m_triangleIndexStride = 1 * static_cast<int>(indices->elementSize());
+			btMesh.m_triangleIndexStride = 1 * static_cast<int>(indices->vertexSize());
 			btMesh.m_numTriangles = static_cast<int>(indices->numVertices() - 2);
 			break;
 		default:


### PR DESCRIPTION
This pull request introduces functionality for generating machine learning training data from volume rendering computations. The PR includes a significant refactoring of shader input size semantics to better distinguish between element sizes and vertex sizes, adds new data export capabilities for staged buffers, and provides a complete example using the Bonsai volume dataset.

Key changes include:
- Refactored `ShaderInput` API: renamed `baseSize_` to `elementSize_` and the method `elementSize()` to `vertexSize()` to clarify semantic meaning
- Added data export functionality with JSON and binary serialization for `StagedBuffer` objects
- Introduced compute shader for neural network training data generation from volume ray casting
- Added support for loading binary data files directly into shader inputs
- Fixed critical bug in `BufferObject::readBufferSubData` checking wrong flag